### PR TITLE
fix: Rename `fistName` to `firstName` typo

### DIFF
--- a/src/contacts/contacts.spec.ts
+++ b/src/contacts/contacts.spec.ts
@@ -239,7 +239,7 @@ describe('Contacts', () => {
       const payload: UpdateContactOptions = {
         id: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223',
         audienceId: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87222',
-        fistName: 'Bu',
+        firstName: 'Bu',
       };
       const response = {
         id: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223',

--- a/src/contacts/contacts.ts
+++ b/src/contacts/contacts.ts
@@ -65,7 +65,7 @@ export class Contacts {
       `/audiences/${payload.audienceId}/contacts/${payload.id}`,
       {
         unsubscribed: payload.unsubscribed,
-        first_name: payload.fistName,
+        first_name: payload.firstName,
         last_name: payload.lastName,
       },
     );

--- a/src/contacts/interfaces/update-contact.interface.ts
+++ b/src/contacts/interfaces/update-contact.interface.ts
@@ -5,7 +5,7 @@ export interface UpdateContactOptions {
   id: string;
   audienceId: string;
   unsubscribed?: boolean;
-  fistName?: string;
+  firstName?: string;
   lastName?: string;
 }
 


### PR DESCRIPTION
This fixes the naming of the first name property in the update contact command to correctly reflect the documentation:

> **`firstName`** `string`
> The first name of the contact.