### PR TITLE
chore: Update docs URL reference

### DIFF
--- a/src/contacts/interfaces/remove-contact.interface.ts
+++ b/src/contacts/interfaces/remove-contact.interface.ts
@@ -10,13 +10,13 @@ interface RemoveByOptions {
   /**
    * The contact id.
    *
-   * @link https://resend.com/api-reference/contacts/delete-contact#body-parameters
+   * @link https://resend.com/docs/api-reference/contacts/delete-contact#body-parameters
    */
   id?: string;
   /**
    * The contact email.
    *
-   * @link https://resend.com/api-reference/contacts/delete-contact#body-parameters
+   * @link https://resend.com/docs/api-reference/contacts/delete-contact#body-parameters
    */
   email?: string;
 }

--- a/src/emails/interfaces/create-email-options.interface.ts
+++ b/src/emails/interfaces/create-email-options.interface.ts
@@ -84,7 +84,7 @@ interface CreateEmailBaseOptions extends EmailRenderOptions {
 export type CreateEmailOptions = RequireAtLeastOne<EmailRenderOptions> &
   CreateEmailBaseOptions;
 
-export interface CreateEmailRequestOptions extends PostOptions { }
+export interface CreateEmailRequestOptions extends PostOptions {}
 
 export interface CreateEmailResponseSuccess {
   /** The ID of the newly created email. */

--- a/src/emails/interfaces/create-email-options.interface.ts
+++ b/src/emails/interfaces/create-email-options.interface.ts
@@ -7,19 +7,19 @@ interface EmailRenderOptions {
   /**
    * The React component used to write the message.
    *
-   * @link https://resend.com/api-reference/emails/send-email#body-parameters
+   * @link https://resend.com/docs/api-reference/emails/send-email#body-parameters
    */
   react?: React.ReactElement | React.ReactNode | null;
   /**
    * The HTML version of the message.
    *
-   * @link https://resend.com/api-reference/emails/send-email#body-parameters
+   * @link https://resend.com/docs/api-reference/emails/send-email#body-parameters
    */
   html?: string;
   /**
    * The plain text version of the message.
    *
-   * @link https://resend.com/api-reference/emails/send-email#body-parameters
+   * @link https://resend.com/docs/api-reference/emails/send-email#body-parameters
    */
   text?: string;
 }
@@ -84,7 +84,7 @@ interface CreateEmailBaseOptions extends EmailRenderOptions {
 export type CreateEmailOptions = RequireAtLeastOne<EmailRenderOptions> &
   CreateEmailBaseOptions;
 
-export interface CreateEmailRequestOptions extends PostOptions {}
+export interface CreateEmailRequestOptions extends PostOptions { }
 
 export interface CreateEmailResponseSuccess {
   /** The ID of the newly created email. */


### PR DESCRIPTION
Updating Docs API-Reference URL to include /docs before /api-reference.

### Old
- https://resend.com/api-reference/emails/send-email#body-parameters
- https://resend.com/api-reference/emails/send-email#body-parameters

### New 
- https://resend.com/docs/api-reference/contacts/delete-contact#body-parameters
- https://resend.com/docs/api-reference/emails/send-email#body-parameters