### PR TITLE
fix: Update contact response

### DIFF
--- a/src/contacts/contacts.spec.ts
+++ b/src/contacts/contacts.spec.ts
@@ -243,6 +243,7 @@ describe('Contacts', () => {
       };
       const response = {
         id: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223',
+        object: 'contact',
       };
       fetchMock.mockOnce(JSON.stringify(response), {
         status: 200,
@@ -259,6 +260,7 @@ describe('Contacts', () => {
 {
   "data": {
     "id": "3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223",
+    "object": "contact",
   },
   "error": null,
 }

--- a/src/contacts/interfaces/update-contact.interface.ts
+++ b/src/contacts/interfaces/update-contact.interface.ts
@@ -9,7 +9,9 @@ export interface UpdateContactOptions {
   lastName?: string;
 }
 
-export type UpdateContactResponseSuccess = Pick<Contact, 'id'>;
+export type UpdateContactResponseSuccess = Pick<Contact, 'id'> & {
+  object: 'contact';
+};
 
 export interface UpdateContactResponse {
   data: UpdateContactResponseSuccess | null;


### PR DESCRIPTION
Updating the `UpdateContactResponseSuccess` interface to include the `object` property that was missing.

![Screenshot 2024-05-30 at 4 24 40 PM](https://github.com/resend/resend-node/assets/42066025/0894610f-a076-4501-98db-5886997e4106)
