### PR TITLE
fix: Delete domain response

### DIFF
--- a/src/domains/domains.spec.ts
+++ b/src/domains/domains.spec.ts
@@ -561,7 +561,9 @@ describe('Domains', () => {
     it('removes a domain', async () => {
       const id = '5262504e-8ed7-4fac-bd16-0d4be94bc9f2';
       const response: RemoveDomainsResponseSuccess = {
+        object: 'domain',
         id,
+        deleted: true,
       };
       fetchMock.mockOnce(JSON.stringify(response), {
         status: 200,
@@ -576,7 +578,9 @@ describe('Domains', () => {
       await expect(resend.domains.remove(id)).resolves.toMatchInlineSnapshot(`
 {
   "data": {
+    "deleted": true,
     "id": "5262504e-8ed7-4fac-bd16-0d4be94bc9f2",
+    "object": "domain",
   },
   "error": null,
 }

--- a/src/domains/interfaces/remove-domain.interface.ts
+++ b/src/domains/interfaces/remove-domain.interface.ts
@@ -1,7 +1,10 @@
 import { ErrorResponse } from '../../interfaces';
 import { Domain } from './domain';
 
-export type RemoveDomainsResponseSuccess = Pick<Domain, 'id'>;
+export type RemoveDomainsResponseSuccess = Pick<Domain, 'id'> & {
+  object: 'domain',
+  deleted: boolean;
+};
 
 export interface RemoveDomainsResponse {
   data: RemoveDomainsResponseSuccess | null;

--- a/src/domains/interfaces/remove-domain.interface.ts
+++ b/src/domains/interfaces/remove-domain.interface.ts
@@ -2,7 +2,7 @@ import { ErrorResponse } from '../../interfaces';
 import { Domain } from './domain';
 
 export type RemoveDomainsResponseSuccess = Pick<Domain, 'id'> & {
-  object: 'domain',
+  object: 'domain';
   deleted: boolean;
 };
 


### PR DESCRIPTION
Including missing properties `object` and `deleted` to `RemoveDomainsResponseSuccess`

![Screenshot 2024-05-31 at 10 07 10 AM](https://github.com/resend/resend-node/assets/42066025/31325010-a2d6-46ff-b7ea-6726e6ccf5f9)

https://resend.com/docs/api-reference/domains/delete-domain