### PR TITLE
fix: Verify domain response

### DIFF
--- a/src/domains/domains.spec.ts
+++ b/src/domains/domains.spec.ts
@@ -10,6 +10,7 @@ import {
 import { ListDomainsResponseSuccess } from './interfaces/list-domains.interface';
 import { RemoveDomainsResponseSuccess } from './interfaces/remove-domain.interface';
 import { UpdateDomainsResponseSuccess } from './interfaces/update-domain.interface';
+import { VerifyDomainsResponseSuccess } from './interfaces/verify-domain.interface';
 
 enableFetchMocks();
 
@@ -536,7 +537,12 @@ describe('Domains', () => {
 
   describe('verify', () => {
     it('verifies a domain', async () => {
-      fetchMock.mockOnce(JSON.stringify({}), {
+      const id = '5262504e-8ed7-4fac-bd16-0d4be94bc9f2';
+      const response: VerifyDomainsResponseSuccess = {
+        object: 'domain',
+        id,
+      };
+      fetchMock.mockOnce(JSON.stringify(response), {
         status: 200,
         headers: {
           'content-type': 'application/json',
@@ -546,11 +552,12 @@ describe('Domains', () => {
 
       const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
 
-      await expect(
-        resend.domains.verify('5262504e-8ed7-4fac-bd16-0d4be94bc9f2'),
-      ).resolves.toMatchInlineSnapshot(`
+      await expect(resend.domains.verify(id)).resolves.toMatchInlineSnapshot(`
 {
-  "data": {},
+  "data": {
+    "id": "5262504e-8ed7-4fac-bd16-0d4be94bc9f2",
+    "object": "domain",
+  },
   "error": null,
 }
 `);

--- a/src/domains/interfaces/verify-domain.interface.ts
+++ b/src/domains/interfaces/verify-domain.interface.ts
@@ -1,7 +1,9 @@
 import { ErrorResponse } from '../../interfaces';
 import { Domain } from './domain';
 
-export type VerifyDomainsResponseSuccess = Domain[];
+export type VerifyDomainsResponseSuccess = Pick<Domain, 'id'> & {
+  object: 'domain';
+};
 
 export interface VerifyDomainsResponse {
   data: VerifyDomainsResponseSuccess | null;


### PR DESCRIPTION
Changing `VerifyDomainsResponseSuccess` to have only `object` and `id` properties like Resend docs

![Screenshot 2024-05-31 at 10 15 35 AM](https://github.com/resend/resend-node/assets/42066025/6abadaee-5cd2-42fe-849f-af55c69a5a93)

https://resend.com/docs/api-reference/domains/verify-domain