### PR TITLE
fix: Content type case

### DIFF
--- a/src/emails/interfaces/create-email-options.interface.ts
+++ b/src/emails/interfaces/create-email-options.interface.ts
@@ -111,7 +111,7 @@ interface Attachment {
   /** Path where the attachment file is hosted */
   path?: string;
   /** Optional content type for the attachment, if not set will be derived from the filename property */
-  content_type?: string;
+  contentType?: string;
 }
 
 export type Tag = {


### PR DESCRIPTION
Rename `content_type` to `contentType`