### PR TITLE
feat: Add get, remove and list broadcast endpoints

### DIFF
--- a/src/broadcasts/broadcasts.spec.ts
+++ b/src/broadcasts/broadcasts.spec.ts
@@ -5,6 +5,9 @@ import type {
   CreateBroadcastOptions,
   CreateBroadcastResponseSuccess,
 } from './interfaces/create-broadcast-options.interface';
+import type { GetBroadcastResponseSuccess } from './interfaces/get-broadcast.interface';
+import type { ListBroadcastsResponseSuccess } from './interfaces/list-broadcasts.interface';
+import type { RemoveBroadcastResponseSuccess } from './interfaces/remove-broadcast.interface';
 
 enableFetchMocks();
 
@@ -243,6 +246,189 @@ describe('Broadcasts', () => {
 {
   "data": {
     "id": "b01e0de9-7c27-4a53-bf38-2e3f98389a65",
+  },
+  "error": null,
+}
+`);
+    });
+  });
+
+  describe('list', () => {
+    it('lists broadcasts', async () => {
+      const response: ListBroadcastsResponseSuccess = {
+        object: 'list',
+        data: [
+          {
+            id: '49a3999c-0ce1-4ea6-ab68-afcd6dc2e794',
+            audience_id: '78261eea-8f8b-4381-83c6-79fa7120f1cf',
+            name: 'broadcast 1',
+            status: 'draft',
+            created_at: '2024-11-01T15:13:31.723Z',
+            scheduled_at: null,
+            sent_at: null,
+          },
+          {
+            id: '559ac32e-9ef5-46fb-82a1-b76b840c0f7b',
+            audience_id: '78261eea-8f8b-4381-83c6-79fa7120f1cf',
+            name: 'broadcast 2',
+            status: 'sent',
+            created_at: '2024-12-01T19:32:22.980Z',
+            scheduled_at: '2024-12-02T19:32:22.980Z',
+            sent_at: '2024-12-02T19:32:22.980Z',
+          },
+        ],
+      };
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+          Authorization: 'Bearer re_924b3rjh2387fbewf823',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      await expect(resend.broadcasts.list()).resolves.toMatchInlineSnapshot(`
+{
+  "data": {
+    "data": [
+      {
+        "audience_id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
+        "created_at": "2024-11-01T15:13:31.723Z",
+        "id": "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794",
+        "name": "broadcast 1",
+        "scheduled_at": null,
+        "sent_at": null,
+        "status": "draft",
+      },
+      {
+        "audience_id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
+        "created_at": "2024-12-01T19:32:22.980Z",
+        "id": "559ac32e-9ef5-46fb-82a1-b76b840c0f7b",
+        "name": "broadcast 2",
+        "scheduled_at": "2024-12-02T19:32:22.980Z",
+        "sent_at": "2024-12-02T19:32:22.980Z",
+        "status": "sent",
+      },
+    ],
+    "object": "list",
+  },
+  "error": null,
+}
+`);
+    });
+  });
+
+  describe('get', () => {
+    describe('when broadcast not found', () => {
+      it('returns error', async () => {
+        const response: ErrorResponse = {
+          name: 'not_found',
+          message: 'Broadcast not found',
+        };
+
+        fetchMock.mockOnce(JSON.stringify(response), {
+          status: 404,
+          headers: {
+            'content-type': 'application/json',
+            Authorization: 'Bearer re_924b3rjh2387fbewf823',
+          },
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+        const result = resend.broadcasts.get(
+          '559ac32e-9ef5-46fb-82a1-b76b840c0f7b',
+        );
+
+        await expect(result).resolves.toMatchInlineSnapshot(`
+{
+  "data": null,
+  "error": {
+    "message": "Broadcast not found",
+    "name": "not_found",
+  },
+}
+`);
+      });
+    });
+
+    it('get broadcast', async () => {
+      const response: GetBroadcastResponseSuccess = {
+        object: 'broadcast',
+        id: '559ac32e-9ef5-46fb-82a1-b76b840c0f7b',
+        name: 'Announcements',
+        audience_id: '78261eea-8f8b-4381-83c6-79fa7120f1cf',
+        from: 'Acme <onboarding@resend.dev>',
+        subject: 'hello world',
+        reply_to: null,
+        preview_text: 'Check out our latest announcements',
+        status: 'draft',
+        created_at: '2024-12-01T19:32:22.980Z',
+        scheduled_at: null,
+        sent_at: null,
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+          Authorization: 'Bearer re_924b3rjh2387fbewf823',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      await expect(
+        resend.broadcasts.get('559ac32e-9ef5-46fb-82a1-b76b840c0f7b'),
+      ).resolves.toMatchInlineSnapshot(`
+{
+  "data": {
+    "audience_id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
+    "created_at": "2024-12-01T19:32:22.980Z",
+    "from": "Acme <onboarding@resend.dev>",
+    "id": "559ac32e-9ef5-46fb-82a1-b76b840c0f7b",
+    "name": "Announcements",
+    "object": "broadcast",
+    "preview_text": "Check out our latest announcements",
+    "reply_to": null,
+    "scheduled_at": null,
+    "sent_at": null,
+    "status": "draft",
+    "subject": "hello world",
+  },
+  "error": null,
+}
+`);
+    });
+  });
+
+  describe('remove', () => {
+    it('removes a broadcast', async () => {
+      const id = 'b01e0de9-7c27-4a53-bf38-2e3f98389a65';
+      const response: RemoveBroadcastResponseSuccess = {
+        object: 'broadcast',
+        id,
+        deleted: true,
+      };
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+          Authorization: 'Bearer re_924b3rjh2387fbewf823',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      await expect(
+        resend.broadcasts.remove(id),
+      ).resolves.toMatchInlineSnapshot(`
+{
+  "data": {
+    "deleted": true,
+    "id": "b01e0de9-7c27-4a53-bf38-2e3f98389a65",
+    "object": "broadcast",
   },
   "error": null,
 }

--- a/src/broadcasts/broadcasts.ts
+++ b/src/broadcasts/broadcasts.ts
@@ -5,6 +5,18 @@ import type {
   CreateBroadcastRequestOptions,
 } from './interfaces/create-broadcast-options.interface';
 import type {
+  GetBroadcastResponse,
+  GetBroadcastResponseSuccess,
+} from './interfaces/get-broadcast.interface';
+import type {
+  ListBroadcastsResponse,
+  ListBroadcastsResponseSuccess,
+} from './interfaces/list-broadcasts.interface';
+import type {
+  RemoveBroadcastResponse,
+  RemoveBroadcastResponseSuccess,
+} from './interfaces/remove-broadcast.interface';
+import type {
   SendBroadcastOptions,
   SendBroadcastResponse,
   SendBroadcastResponseSuccess,
@@ -62,6 +74,26 @@ export class Broadcasts {
       { scheduled_at: payload?.scheduledAt },
     );
 
+    return data;
+  }
+
+  async list(): Promise<ListBroadcastsResponse> {
+    const data =
+      await this.resend.get<ListBroadcastsResponseSuccess>('/broadcasts');
+    return data;
+  }
+
+  async get(id: string): Promise<GetBroadcastResponse> {
+    const data = await this.resend.get<GetBroadcastResponseSuccess>(
+      `/broadcasts/${id}`,
+    );
+    return data;
+  }
+
+  async remove(id: string): Promise<RemoveBroadcastResponse> {
+    const data = await this.resend.delete<RemoveBroadcastResponseSuccess>(
+      `/broadcasts/${id}`,
+    );
     return data;
   }
 }

--- a/src/broadcasts/interfaces/broadcast.ts
+++ b/src/broadcasts/interfaces/broadcast.ts
@@ -1,0 +1,13 @@
+export interface Broadcast {
+  id: string;
+  name: string;
+  audience_id: string | null;
+  from: string | null;
+  subject: string | null;
+  reply_to: string[] | null;
+  preview_text: string | null;
+  status: 'draft' | 'sent' | 'queued';
+  created_at: string;
+  scheduled_at: string | null;
+  sent_at: string | null;
+}

--- a/src/broadcasts/interfaces/get-broadcast.interface.ts
+++ b/src/broadcasts/interfaces/get-broadcast.interface.ts
@@ -1,0 +1,11 @@
+import type { ErrorResponse } from '../../interfaces';
+import type { Broadcast } from './broadcast';
+
+export interface GetBroadcastResponseSuccess extends Broadcast {
+  object: 'broadcast';
+}
+
+export interface GetBroadcastResponse {
+  data: GetBroadcastResponseSuccess | null;
+  error: ErrorResponse | null;
+}

--- a/src/broadcasts/interfaces/list-broadcasts.interface.ts
+++ b/src/broadcasts/interfaces/list-broadcasts.interface.ts
@@ -1,0 +1,21 @@
+import type { ErrorResponse } from '../../interfaces';
+import type { Broadcast } from './broadcast';
+
+export type ListBroadcastsResponseSuccess = {
+  object: 'list';
+  data: Pick<
+    Broadcast,
+    | 'id'
+    | 'name'
+    | 'audience_id'
+    | 'status'
+    | 'created_at'
+    | 'scheduled_at'
+    | 'sent_at'
+  >[];
+};
+
+export interface ListBroadcastsResponse {
+  data: ListBroadcastsResponseSuccess | null;
+  error: ErrorResponse | null;
+}

--- a/src/broadcasts/interfaces/remove-broadcast.interface.ts
+++ b/src/broadcasts/interfaces/remove-broadcast.interface.ts
@@ -1,0 +1,12 @@
+import type { ErrorResponse } from '../../interfaces';
+import type { Broadcast } from './broadcast';
+
+export interface RemoveBroadcastResponseSuccess extends Pick<Broadcast, 'id'> {
+  object: 'broadcast';
+  deleted: boolean;
+}
+
+export interface RemoveBroadcastResponse {
+  data: RemoveBroadcastResponseSuccess | null;
+  error: ErrorResponse | null;
+}

--- a/src/emails/emails.spec.ts
+++ b/src/emails/emails.spec.ts
@@ -371,6 +371,7 @@ describe('Emails', () => {
           cc: null,
           reply_to: null,
           last_event: 'delivered',
+          scheduled_at: null,
         };
 
         fetchMock.mockOnce(JSON.stringify(response), {
@@ -395,6 +396,7 @@ describe('Emails', () => {
     "last_event": "delivered",
     "object": "email",
     "reply_to": null,
+    "scheduled_at": null,
     "subject": "Test email",
     "text": null,
     "to": [
@@ -420,6 +422,7 @@ describe('Emails', () => {
           cc: ['zeno@resend.com', 'bu@resend.com'],
           reply_to: null,
           last_event: 'delivered',
+          scheduled_at: null,
         };
 
         fetchMock.mockOnce(JSON.stringify(response), {
@@ -447,6 +450,7 @@ describe('Emails', () => {
     "last_event": "delivered",
     "object": "email",
     "reply_to": null,
+    "scheduled_at": null,
     "subject": "Test email",
     "text": null,
     "to": [


### PR DESCRIPTION
This PR adds the ability to `get`, `remove`, and `list` broadcasts using the SDK.