### PR TITLE
fix: correct email batch api call with reply_to

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "4.2.0",
+  "version": "4.1.1",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/batch/batch.ts
+++ b/src/batch/batch.ts
@@ -1,5 +1,5 @@
 import type * as React from 'react';
-import type { EmailAPIOptions } from '../common/interfaces/email-api-options.interface';
+import type { EmailApiOptions } from '../common/interfaces/email-api-options.interface';
 import { parseEmailToAPIOptions } from '../common/utils/parse-email-to-api-options';
 import type { Resend } from '../resend';
 import type {
@@ -24,7 +24,7 @@ export class Batch {
     payload: CreateBatchOptions,
     options: CreateBatchRequestOptions = {},
   ): Promise<CreateBatchResponse> {
-    const emails: EmailAPIOptions[] = [];
+    const emails: EmailApiOptions[] = [];
 
     for (const email of payload) {
       if (email.react) {

--- a/src/batch/batch.ts
+++ b/src/batch/batch.ts
@@ -1,4 +1,6 @@
 import type * as React from 'react';
+import type { EmailAPIOptions } from '../common/interfaces/email-api-options.interface';
+import { parseEmailToAPIOptions } from '../common/utils/parse-email-to-api-options';
 import type { Resend } from '../resend';
 import type {
   CreateBatchOptions,
@@ -22,6 +24,8 @@ export class Batch {
     payload: CreateBatchOptions,
     options: CreateBatchRequestOptions = {},
   ): Promise<CreateBatchResponse> {
+    const emails: EmailAPIOptions[] = [];
+
     for (const email of payload) {
       if (email.react) {
         if (!this.renderAsync) {
@@ -38,11 +42,13 @@ export class Batch {
         email.html = await this.renderAsync(email.react as React.ReactElement);
         email.react = undefined;
       }
+
+      emails.push(parseEmailToAPIOptions(email));
     }
 
     const data = await this.resend.post<CreateBatchSuccessResponse>(
       '/emails/batch',
-      payload,
+      emails,
       options,
     );
 

--- a/src/batch/batch.ts
+++ b/src/batch/batch.ts
@@ -1,6 +1,6 @@
 import type * as React from 'react';
 import type { EmailApiOptions } from '../common/interfaces/email-api-options.interface';
-import { parseEmailToAPIOptions } from '../common/utils/parse-email-to-api-options';
+import { parseEmailToApiOptions } from '../common/utils/parse-email-to-api-options';
 import type { Resend } from '../resend';
 import type {
   CreateBatchOptions,
@@ -43,7 +43,7 @@ export class Batch {
         email.react = undefined;
       }
 
-      emails.push(parseEmailToAPIOptions(email));
+      emails.push(parseEmailToApiOptions(email));
     }
 
     const data = await this.resend.post<CreateBatchSuccessResponse>(

--- a/src/common/interfaces/email-api-options.interface.ts
+++ b/src/common/interfaces/email-api-options.interface.ts
@@ -1,0 +1,18 @@
+import type { Attachment } from '../../emails/interfaces/create-email-options.interface';
+import type { Tag } from '../../interfaces';
+
+export interface EmailAPIOptions {
+  from: string;
+  to: string | string[];
+  subject: string;
+  region?: string;
+  headers?: Record<string, string>;
+  html?: string;
+  text?: string;
+  bcc?: string | string[];
+  cc?: string | string[];
+  reply_to?: string | string[];
+  scheduled_at?: string;
+  tags?: Tag[];
+  attachments?: Attachment[];
+}

--- a/src/common/interfaces/email-api-options.interface.ts
+++ b/src/common/interfaces/email-api-options.interface.ts
@@ -1,7 +1,7 @@
 import type { Attachment } from '../../emails/interfaces/create-email-options.interface';
 import type { Tag } from '../../interfaces';
 
-export interface EmailAPIOptions {
+export interface EmailApiOptions {
   from: string;
   to: string | string[];
   subject: string;

--- a/src/common/utils/parse-email-to-api-options.spec.ts
+++ b/src/common/utils/parse-email-to-api-options.spec.ts
@@ -1,0 +1,44 @@
+import type { CreateEmailOptions } from '../../emails/interfaces/create-email-options.interface';
+import { parseEmailToAPIOptions } from './parse-email-to-api-options';
+
+describe('parseEmailToAPIOptions', () => {
+  it('should handle minimal email with only required fields', () => {
+    const emailPayload: CreateEmailOptions = {
+      from: 'joao@resend.com',
+      to: 'bu@resend.com',
+      subject: 'Hey, there!',
+      html: '<h1>Hey, there!</h1>',
+    };
+
+    const apiOptions = parseEmailToAPIOptions(emailPayload);
+
+    expect(apiOptions).toEqual({
+      from: 'joao@resend.com',
+      to: 'bu@resend.com',
+      subject: 'Hey, there!',
+      html: '<h1>Hey, there!</h1>',
+    });
+  });
+
+  it('should properly parse camel case to snake case', () => {
+    const emailPayload: CreateEmailOptions = {
+      from: 'joao@resend.com',
+      to: 'bu@resend.com',
+      subject: 'Hey, there!',
+      html: '<h1>Hey, there!</h1>',
+      replyTo: 'zeno@resend.com',
+      scheduledAt: 'in 1 min',
+    };
+
+    const apiOptions = parseEmailToAPIOptions(emailPayload);
+
+    expect(apiOptions).toEqual({
+      from: 'joao@resend.com',
+      to: 'bu@resend.com',
+      subject: 'Hey, there!',
+      html: '<h1>Hey, there!</h1>',
+      reply_to: 'zeno@resend.com',
+      scheduled_at: 'in 1 min',
+    });
+  });
+});

--- a/src/common/utils/parse-email-to-api-options.spec.ts
+++ b/src/common/utils/parse-email-to-api-options.spec.ts
@@ -1,5 +1,5 @@
 import type { CreateEmailOptions } from '../../emails/interfaces/create-email-options.interface';
-import { parseEmailToAPIOptions } from './parse-email-to-api-options';
+import { parseEmailToApiOptions } from './parse-email-to-api-options';
 
 describe('parseEmailToAPIOptions', () => {
   it('should handle minimal email with only required fields', () => {
@@ -10,7 +10,7 @@ describe('parseEmailToAPIOptions', () => {
       html: '<h1>Hey, there!</h1>',
     };
 
-    const apiOptions = parseEmailToAPIOptions(emailPayload);
+    const apiOptions = parseEmailToApiOptions(emailPayload);
 
     expect(apiOptions).toEqual({
       from: 'joao@resend.com',
@@ -30,7 +30,7 @@ describe('parseEmailToAPIOptions', () => {
       scheduledAt: 'in 1 min',
     };
 
-    const apiOptions = parseEmailToAPIOptions(emailPayload);
+    const apiOptions = parseEmailToApiOptions(emailPayload);
 
     expect(apiOptions).toEqual({
       from: 'joao@resend.com',

--- a/src/common/utils/parse-email-to-api-options.spec.ts
+++ b/src/common/utils/parse-email-to-api-options.spec.ts
@@ -1,7 +1,7 @@
 import type { CreateEmailOptions } from '../../emails/interfaces/create-email-options.interface';
 import { parseEmailToApiOptions } from './parse-email-to-api-options';
 
-describe('parseEmailToAPIOptions', () => {
+describe('parseEmailToApiOptions', () => {
   it('should handle minimal email with only required fields', () => {
     const emailPayload: CreateEmailOptions = {
       from: 'joao@resend.com',

--- a/src/common/utils/parse-email-to-api-options.ts
+++ b/src/common/utils/parse-email-to-api-options.ts
@@ -1,9 +1,9 @@
 import type { CreateEmailOptions } from '../../emails/interfaces/create-email-options.interface';
-import type { EmailAPIOptions } from '../interfaces/email-api-options.interface';
+import type { EmailApiOptions } from '../interfaces/email-api-options.interface';
 
 export function parseEmailToAPIOptions(
   email: CreateEmailOptions,
-): EmailAPIOptions {
+): EmailApiOptions {
   return {
     attachments: email.attachments,
     bcc: email.bcc,

--- a/src/common/utils/parse-email-to-api-options.ts
+++ b/src/common/utils/parse-email-to-api-options.ts
@@ -1,0 +1,21 @@
+import type { CreateEmailOptions } from '../../emails/interfaces/create-email-options.interface';
+import type { EmailAPIOptions } from '../interfaces/email-api-options.interface';
+
+export function parseEmailToAPIOptions(
+  email: CreateEmailOptions,
+): EmailAPIOptions {
+  return {
+    attachments: email.attachments,
+    bcc: email.bcc,
+    cc: email.cc,
+    from: email.from,
+    headers: email.headers,
+    html: email.html,
+    reply_to: email.replyTo,
+    scheduled_at: email.scheduledAt,
+    subject: email.subject,
+    tags: email.tags,
+    text: email.text,
+    to: email.to,
+  };
+}

--- a/src/common/utils/parse-email-to-api-options.ts
+++ b/src/common/utils/parse-email-to-api-options.ts
@@ -1,7 +1,7 @@
 import type { CreateEmailOptions } from '../../emails/interfaces/create-email-options.interface';
 import type { EmailApiOptions } from '../interfaces/email-api-options.interface';
 
-export function parseEmailToAPIOptions(
+export function parseEmailToApiOptions(
   email: CreateEmailOptions,
 ): EmailApiOptions {
   return {

--- a/src/emails/emails.ts
+++ b/src/emails/emails.ts
@@ -1,4 +1,5 @@
 import type * as React from 'react';
+import { parseEmailToAPIOptions } from '../common/utils/parse-email-to-api-options';
 import type { Resend } from '../resend';
 import type {
   CancelEmailResponse,
@@ -54,20 +55,7 @@ export class Emails {
 
     const data = await this.resend.post<CreateEmailResponseSuccess>(
       '/emails',
-      {
-        attachments: payload.attachments,
-        bcc: payload.bcc,
-        cc: payload.cc,
-        from: payload.from,
-        headers: payload.headers,
-        html: payload.html,
-        reply_to: payload.replyTo,
-        scheduled_at: payload.scheduledAt,
-        subject: payload.subject,
-        tags: payload.tags,
-        text: payload.text,
-        to: payload.to,
-      },
+      parseEmailToAPIOptions(payload),
       options,
     );
 

--- a/src/emails/emails.ts
+++ b/src/emails/emails.ts
@@ -1,5 +1,5 @@
 import type * as React from 'react';
-import { parseEmailToAPIOptions } from '../common/utils/parse-email-to-api-options';
+import { parseEmailToApiOptions } from '../common/utils/parse-email-to-api-options';
 import type { Resend } from '../resend';
 import type {
   CancelEmailResponse,
@@ -55,7 +55,7 @@ export class Emails {
 
     const data = await this.resend.post<CreateEmailResponseSuccess>(
       '/emails',
-      parseEmailToAPIOptions(payload),
+      parseEmailToApiOptions(payload),
       options,
     );
 

--- a/src/emails/interfaces/create-email-options.interface.ts
+++ b/src/emails/interfaces/create-email-options.interface.ts
@@ -103,7 +103,7 @@ export interface CreateEmailResponse {
   error: ErrorResponse | null;
 }
 
-interface Attachment {
+export interface Attachment {
   /** Content of an attached file. */
   content?: string | Buffer;
   /** Name of attached file. */


### PR DESCRIPTION
Closes #421 

## Using this implementation ↓
![74614](https://github.com/user-attachments/assets/2def9d6e-93b2-412f-a0c9-03b458070880)

## We were getting this behavior when replying an email ↓

![CleanShot 2025-01-22 at 22 00 10@2x](https://github.com/user-attachments/assets/faa33721-4a81-4c08-893f-0c84410ef5fc)

But it should reply to `delivered@resend.dev` instead.

## After fixing it, this is what we get ↓

![CleanShot 2025-01-22 at 22 01 14@2x](https://github.com/user-attachments/assets/65497ded-82f9-4cbc-9789-76bda0f3f7ce)

Correctly mapping the Node.js SDK's fields to Resend's API so we do not forget any option in the payload.

