### PR TITLE
release: bump version from 4.1.2-canary.0 to 4.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "4.1.2-canary.0",
+  "version": "4.1.2",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
We can confirm the fix is properly working by following [these instructions](https://github.com/joaopcm/resend-node-4.1.2-canary.0-demo).