### PR TITLE
feat(interface): export missing email interfaces

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,5 +21,7 @@ export * from './domains/interfaces/list-domains.interface';
 export * from './domains/interfaces/remove-domain.interface';
 export * from './domains/interfaces/update-domain.interface';
 export * from './domains/interfaces/verify-domain.interface';
+export * from './emails/interfaces/cancel-email-options.interface';
 export * from './emails/interfaces/create-email-options.interface';
 export * from './emails/interfaces/get-email-options.interface';
+export * from './emails/interfaces/update-email-options.interface';


### PR DESCRIPTION
### Context

While working on a different package that leverages this client for some service interfaces, I've found that these two interfaces are missing, making extending this package a bit tricky (We would have to copy the interface into our code manually).

Since this package already exports most interfaces, I'm sending this pr for email export completeness.