### PR TITLE
feat: add support for retrieval of contact by email

### DIFF
--- a/src/contacts/contacts.spec.ts
+++ b/src/contacts/contacts.spec.ts
@@ -194,7 +194,7 @@ describe('Contacts', () => {
       });
     });
 
-    it('get contact', async () => {
+    it('get contact by id', async () => {
       const response: GetContactResponseSuccess = {
         object: 'contact',
         id: 'fd61172c-cafc-40f5-b049-b45947779a29',
@@ -216,6 +216,48 @@ describe('Contacts', () => {
       const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
       const options: GetContactOptions = {
         id: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223',
+        audienceId: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87222',
+      };
+      await expect(
+        resend.contacts.get(options),
+      ).resolves.toMatchInlineSnapshot(`
+{
+  "data": {
+    "created_at": "2024-01-16T18:12:26.514Z",
+    "email": "team@resend.com",
+    "first_name": "",
+    "id": "fd61172c-cafc-40f5-b049-b45947779a29",
+    "last_name": "",
+    "object": "contact",
+    "unsubscribed": false,
+  },
+  "error": null,
+}
+`);
+    });
+
+    it('get contact by email', async () => {
+      const response: GetContactResponseSuccess = {
+        object: 'contact',
+        id: 'fd61172c-cafc-40f5-b049-b45947779a29',
+        email: 'team@resend.com',
+        first_name: '',
+        last_name: '',
+        created_at: '2024-01-16T18:12:26.514Z',
+        unsubscribed: false,
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+          Authorization: 'Bearer re_924b3rjh2387fbewf823',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      const options: GetContactOptions = {
+        email: 'team@resend.com',
         audienceId: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87222',
       };
       await expect(

--- a/src/contacts/contacts.ts
+++ b/src/contacts/contacts.ts
@@ -54,8 +54,18 @@ export class Contacts {
   }
 
   async get(options: GetContactOptions): Promise<GetContactResponse> {
+    if (!options.id && !options.email) {
+      return {
+        data: null,
+        error: {
+          message: 'Missing `id` or `email` field.',
+          name: 'missing_required_field',
+        },
+      };
+    }
+
     const data = await this.resend.get<GetContactResponseSuccess>(
-      `/audiences/${options.audienceId}/contacts/${options.id}`,
+      `/audiences/${options.audienceId}/contacts/${options?.email ? options?.email : options?.id}`,
     );
     return data;
   }

--- a/src/contacts/interfaces/get-contact.interface.ts
+++ b/src/contacts/interfaces/get-contact.interface.ts
@@ -3,7 +3,8 @@ import type { Contact } from './contact';
 
 export interface GetContactOptions {
   audienceId: string;
-  id: string;
+  id?: string;
+  email?: string;
 }
 
 export interface GetContactResponseSuccess


### PR DESCRIPTION
### Description

This PR adds support for retrieval of contacts by their email. We already had this for the [update method](https://arc.net/l/quote/mgcatgks) and the [delete](https://arc.net/l/quote/vnuqlvak). Only `get` was solely done with the ID option