### PR TITLE
feat: add custom return path support for domains creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "4.3.0",
+  "version": "4.4.0-canary-0",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "4.4.0-canary-0",
+  "version": "4.3.0",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/common/interfaces/domain-api-options.interface.ts
+++ b/src/common/interfaces/domain-api-options.interface.ts
@@ -1,0 +1,5 @@
+export interface DomainApiOptions {
+  name: string;
+  region?: string;
+  custom_return_path?: string;
+}

--- a/src/common/utils/parse-domain-to-api-options.spec.ts
+++ b/src/common/utils/parse-domain-to-api-options.spec.ts
@@ -29,4 +29,4 @@ describe('parseDomainToApiOptions', () => {
       custom_return_path: 'bounce@example.com',
     });
   });
-}); 
+});

--- a/src/common/utils/parse-domain-to-api-options.spec.ts
+++ b/src/common/utils/parse-domain-to-api-options.spec.ts
@@ -1,0 +1,32 @@
+import type { CreateDomainOptions } from '../../domains/interfaces/create-domain-options.interface';
+import { parseDomainToApiOptions } from './parse-domain-to-api-options';
+
+describe('parseDomainToApiOptions', () => {
+  it('should handle minimal domain with only required fields', () => {
+    const domainPayload: CreateDomainOptions = {
+      name: 'example.com',
+    };
+
+    const apiOptions = parseDomainToApiOptions(domainPayload);
+
+    expect(apiOptions).toEqual({
+      name: 'example.com',
+    });
+  });
+
+  it('should properly parse camel case to snake case', () => {
+    const domainPayload: CreateDomainOptions = {
+      name: 'example.com',
+      region: 'us-east-1',
+      customReturnPath: 'bounce@example.com',
+    };
+
+    const apiOptions = parseDomainToApiOptions(domainPayload);
+
+    expect(apiOptions).toEqual({
+      name: 'example.com',
+      region: 'us-east-1',
+      custom_return_path: 'bounce@example.com',
+    });
+  });
+}); 

--- a/src/common/utils/parse-domain-to-api-options.ts
+++ b/src/common/utils/parse-domain-to-api-options.ts
@@ -9,4 +9,4 @@ export function parseDomainToApiOptions(
     region: domain.region,
     custom_return_path: domain.customReturnPath,
   };
-}   
+}

--- a/src/common/utils/parse-domain-to-api-options.ts
+++ b/src/common/utils/parse-domain-to-api-options.ts
@@ -1,0 +1,12 @@
+import type { CreateDomainOptions } from '../../domains/interfaces/create-domain-options.interface';
+import type { DomainApiOptions } from '../interfaces/domain-api-options.interface';
+
+export function parseDomainToApiOptions(
+  domain: CreateDomainOptions,
+): DomainApiOptions {
+  return {
+    name: domain.name,
+    region: domain.region,
+    custom_return_path: domain.customReturnPath,
+  };
+}   

--- a/src/domains/domains.spec.ts
+++ b/src/domains/domains.spec.ts
@@ -358,7 +358,7 @@ describe('Domains', () => {
           ],
           region: 'us-east-1',
         };
-        
+
         fetchMock.mockOnce(JSON.stringify(response), {
           status: 200,
           headers: {
@@ -366,7 +366,7 @@ describe('Domains', () => {
             Authorization: 'Bearer re_924b3rjh2387fbewf823',
           },
         });
-        
+
         const payload: CreateDomainOptions = {
           name: 'resend.com',
           customReturnPath: 'custom',
@@ -414,7 +414,7 @@ describe('Domains', () => {
   "error": null,
 }
 `);
-      }); 
+      });
     });
   });
 

--- a/src/domains/domains.spec.ts
+++ b/src/domains/domains.spec.ts
@@ -321,6 +321,101 @@ describe('Domains', () => {
 `);
       });
     });
+
+    describe('with customReturnPath', () => {
+      it('creates a domain with customReturnPath', async () => {
+        const response: CreateDomainResponseSuccess = {
+          id: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87222',
+          name: 'resend.com',
+          created_at: '2023-04-07T22:48:33.420498+00:00',
+          status: 'not_started',
+          records: [
+            {
+              record: 'SPF',
+              name: 'custom',
+              type: 'MX',
+              ttl: 'Auto',
+              status: 'not_started',
+              value: 'feedback-smtp.us-east-1.com',
+              priority: 10,
+            },
+            {
+              record: 'SPF',
+              name: 'custom',
+              value: '"v=spf1 include:com ~all"',
+              type: 'TXT',
+              ttl: 'Auto',
+              status: 'not_started',
+            },
+            {
+              record: 'DKIM',
+              name: 'resend._domainkey',
+              value: 'nu22pfdfqaxdybogtw3ebaokmalv5mxg.dkim.com.',
+              type: 'CNAME',
+              status: 'not_started',
+              ttl: 'Auto',
+            },
+          ],
+          region: 'us-east-1',
+        };
+        
+        fetchMock.mockOnce(JSON.stringify(response), {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+            Authorization: 'Bearer re_924b3rjh2387fbewf823',
+          },
+        });
+        
+        const payload: CreateDomainOptions = {
+          name: 'resend.com',
+          customReturnPath: 'custom',
+        };
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+        await expect(
+          resend.domains.create(payload),
+        ).resolves.toMatchInlineSnapshot(`
+{
+  "data": {
+    "created_at": "2023-04-07T22:48:33.420498+00:00",
+    "id": "3d4a472d-bc6d-4dd2-aa9d-d3d50ce87222",
+    "name": "resend.com",
+    "records": [
+      {
+        "name": "custom",
+        "priority": 10,
+        "record": "SPF",
+        "status": "not_started",
+        "ttl": "Auto",
+        "type": "MX",
+        "value": "feedback-smtp.us-east-1.com",
+      },
+      {
+        "name": "custom",
+        "record": "SPF",
+        "status": "not_started",
+        "ttl": "Auto",
+        "type": "TXT",
+        "value": ""v=spf1 include:com ~all"",
+      },
+      {
+        "name": "resend._domainkey",
+        "record": "DKIM",
+        "status": "not_started",
+        "ttl": "Auto",
+        "type": "CNAME",
+        "value": "nu22pfdfqaxdybogtw3ebaokmalv5mxg.dkim.com.",
+      },
+    ],
+    "region": "us-east-1",
+    "status": "not_started",
+  },
+  "error": null,
+}
+`);
+      }); 
+    });
   });
 
   describe('list', () => {

--- a/src/domains/domains.ts
+++ b/src/domains/domains.ts
@@ -1,3 +1,4 @@
+import { parseDomainToApiOptions } from '../common/utils/parse-domain-to-api-options';
 import type { Resend } from '../resend';
 import type {
   CreateDomainOptions,
@@ -36,7 +37,7 @@ export class Domains {
   ): Promise<CreateDomainResponse> {
     const data = await this.resend.post<CreateDomainResponseSuccess>(
       '/domains',
-      payload,
+      parseDomainToApiOptions(payload),
       options,
     );
     return data;

--- a/src/domains/interfaces/create-domain-options.interface.ts
+++ b/src/domains/interfaces/create-domain-options.interface.ts
@@ -5,6 +5,7 @@ import type { Domain, DomainRecords, DomainRegion } from './domain';
 export interface CreateDomainOptions {
   name: string;
   region?: DomainRegion;
+  customReturnPath?: string;
 }
 
 export interface CreateDomainRequestOptions extends PostOptions {}


### PR DESCRIPTION
This PR adds support for sending a `customReturnPath` field to domains creation (`resend.domains.create`). It allows users to customize their SPF record host names.

The field is supposed to be optional and correctly parsed to snake case to match our API.