### PR TITLE
feat: add idempotency key support to POST /emails/batch

### DIFF
--- a/src/batch/batch.spec.ts
+++ b/src/batch/batch.spec.ts
@@ -69,6 +69,93 @@ describe('Batch', () => {
 }
 `);
     });
+
+    it('does not send the Idempotency-Key header when idempotencyKey is not provided', async () => {
+      const response: CreateBatchSuccessResponse = {
+        data: [
+          {
+            id: 'not-idempotent-123',
+          },
+        ],
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+          Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+        },
+      });
+
+      const payload: CreateBatchOptions = [
+        {
+          from: 'admin@resend.com',
+          to: 'user@resend.com',
+          subject: 'Not Idempotent Test',
+          html: '<h1>Test</h1>',
+        },
+      ];
+
+      await resend.batch.create(payload);
+
+      // Inspect the last fetch call and body
+      const lastCall = fetchMock.mock.calls[0];
+      expect(lastCall).toBeDefined();
+
+      //@ts-ignore
+      const hasIdempotencyKey = lastCall[1]?.headers.has('Idempotency-Key');
+      expect(hasIdempotencyKey).toBeFalsy();
+
+      //@ts-ignore
+      const usedIdempotencyKey = lastCall[1]?.headers.get('Idempotency-Key');
+      expect(usedIdempotencyKey).toBeNull();
+    });
+
+    it('sends the Idempotency-Key header when idempotencyKey is provided', async () => {
+      const response: CreateBatchSuccessResponse = {
+        data: [
+          {
+            id: 'idempotent-123',
+          },
+        ],
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+          Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+        },
+      });
+
+      const payload: CreateBatchOptions = [
+        {
+          from: 'admin@resend.com',
+          to: 'user@resend.com',
+          subject: 'Idempotency Test',
+          html: '<h1>Test</h1>',
+        },
+      ];
+      const idempotencyKey = 'unique-key-123';
+
+      await resend.batch.create(payload, { idempotencyKey });
+
+      // Inspect the last fetch call and body
+      const lastCall = fetchMock.mock.calls[0];
+      expect(lastCall).toBeDefined();
+
+      // Check if headers contains Idempotency-Key
+      // In the mock, headers is an object with key-value pairs
+      expect(fetchMock.mock.calls[0][1]?.headers).toBeDefined();
+
+      //@ts-ignore
+      const hasIdempotencyKey = lastCall[1]?.headers.has('Idempotency-Key');
+      expect(hasIdempotencyKey).toBeTruthy();
+
+      //@ts-ignore
+      const usedIdempotencyKey = lastCall[1]?.headers.get('Idempotency-Key');
+      expect(usedIdempotencyKey).toBe(idempotencyKey);
+    });
   });
 
   describe('send', () => {
@@ -128,6 +215,93 @@ describe('Batch', () => {
   "error": null,
 }
 `);
+    });
+
+    it('does not send the Idempotency-Key header when idempotencyKey is not provided', async () => {
+      const response: CreateBatchSuccessResponse = {
+        data: [
+          {
+            id: 'not-idempotent-123',
+          },
+        ],
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+          Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+        },
+      });
+
+      const payload: CreateBatchOptions = [
+        {
+          from: 'admin@resend.com',
+          to: 'user@resend.com',
+          subject: 'Not Idempotent Test',
+          html: '<h1>Test</h1>',
+        },
+      ];
+
+      await resend.batch.send(payload);
+
+      // Inspect the last fetch call and body
+      const lastCall = fetchMock.mock.calls[0];
+      expect(lastCall).toBeDefined();
+
+      //@ts-ignore
+      const hasIdempotencyKey = lastCall[1]?.headers.has('Idempotency-Key');
+      expect(hasIdempotencyKey).toBeFalsy();
+
+      //@ts-ignore
+      const usedIdempotencyKey = lastCall[1]?.headers.get('Idempotency-Key');
+      expect(usedIdempotencyKey).toBeNull();
+    });
+
+    it('sends the Idempotency-Key header when idempotencyKey is provided', async () => {
+      const response: CreateBatchSuccessResponse = {
+        data: [
+          {
+            id: 'idempotent-123',
+          },
+        ],
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+          Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+        },
+      });
+
+      const payload: CreateBatchOptions = [
+        {
+          from: 'admin@resend.com',
+          to: 'user@resend.com',
+          subject: 'Idempotency Test',
+          html: '<h1>Test</h1>',
+        },
+      ];
+      const idempotencyKey = 'unique-key-123';
+
+      await resend.batch.send(payload, { idempotencyKey });
+
+      // Inspect the last fetch call and body
+      const lastCall = fetchMock.mock.calls[0];
+      expect(lastCall).toBeDefined();
+
+      // Check if headers contains Idempotency-Key
+      // In the mock, headers is an object with key-value pairs
+      expect(fetchMock.mock.calls[0][1]?.headers).toBeDefined();
+
+      //@ts-ignore
+      const hasIdempotencyKey = lastCall[1]?.headers.has('Idempotency-Key');
+      expect(hasIdempotencyKey).toBeTruthy();
+
+      //@ts-ignore
+      const usedIdempotencyKey = lastCall[1]?.headers.get('Idempotency-Key');
+      expect(usedIdempotencyKey).toBe(idempotencyKey);
     });
   });
 });

--- a/src/batch/interfaces/create-batch-options.interface.ts
+++ b/src/batch/interfaces/create-batch-options.interface.ts
@@ -1,10 +1,13 @@
 import type { PostOptions } from '../../common/interfaces';
+import type { IdempotentRequest } from '../../common/interfaces/idempotent-request.interface';
 import type { CreateEmailOptions } from '../../emails/interfaces/create-email-options.interface';
 import type { ErrorResponse } from '../../interfaces';
 
 export type CreateBatchOptions = CreateEmailOptions[];
 
-export interface CreateBatchRequestOptions extends PostOptions {}
+export interface CreateBatchRequestOptions
+  extends PostOptions,
+    IdempotentRequest {}
 
 export interface CreateBatchSuccessResponse {
   data: {


### PR DESCRIPTION
Similar to https://github.com/resend/resend-node/pull/489, adding support for idempotency keys on email batch sending.