### PR TITLE
fix!: make @react-email/render an optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,13 @@
     "url": "https://github.com/resendlabs/resend-node/issues"
   },
   "homepage": "https://github.com/resendlabs/resend-node#readme",
-  "dependencies": {
+  "peerDependencies": {
     "@react-email/render": "1.1.2"
+  },
+  "peerDependenciesMeta": {
+    "@react-email/render": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",


### PR DESCRIPTION
## Summary

Several Resend users have been complaining about unexpectedly seeing `@react-email/render` and `react` in their builds. After analysis, it was found that this was happening because `@react-email/render` was listed as a dependency of resend-node.

To fix this, I decided to make `@react-email/render` an optional peer dependency. This way, it won’t be automatically installed when `resend-node` is installed.

No functionality should be affected, as `@react-email/render` is dynamically imported throughout the codebase. However, this is a breaking change for users who use the react parameter to send emails with resend-node, as they will now need to install `@react-email/render` themselves.

## Additional information

I'm opening this PR to start the discussion around the topic and get approval from the maintainers to move forward with that effort, as further changes will have to be made to the docs, mentioning that now users who want to send emails using React will have to install `@react-email/render` themselves.

Additionally, I believe that, in an ideal world, `resend-node` should not depend directly on `@react-email/render`. Instead, it should rely on an abstraction, such as a function passed into the Resend constructor, that handles the conversion. This would decouple `resend-node` from any specific rendering implementation. Alternatively, the package could be simplified to only accept `html` or `text`, allowing users to decide how they want to convert React components into email content using any library they prefer. This approach would make `resend-node` more flexible and extensible.

However, implementing such a change would require a significant architectural refactor, so it’s not suitable as a quick fix.

## Potentially related open issues

[Resend should not have a React Dependency](https://github.com/resend/resend-node/issues/525)
[Resend require react to be used](https://github.com/resend/resend-node/issues/503)
[React declaration not found in Fastify (Node.js) app](https://github.com/resend/resend-node/issues/406)
[Why Resend need React to work in Express??](https://github.com/resend/resend-node/issues/353)
[Resend SDK design](https://github.com/resend/resend-node/issues/309)
[Remove dependency on react package to make it more lightweight](https://github.com/resend/resend-node/issues/243)

Happy to hear your thoughts and feedback :) 