### PR TITLE
refactor: remove deprecated usage of render async

### DIFF
--- a/src/batch/batch.ts
+++ b/src/batch/batch.ts
@@ -10,7 +10,7 @@ import type {
 } from './interfaces/create-batch-options.interface';
 
 export class Batch {
-  private renderAsync?: (component: React.ReactElement) => Promise<string>;
+  private render?: (component: React.ReactElement) => Promise<string>;
   constructor(private readonly resend: Resend) {}
 
   async send(
@@ -28,10 +28,10 @@ export class Batch {
 
     for (const email of payload) {
       if (email.react) {
-        if (!this.renderAsync) {
+        if (!this.render) {
           try {
-            const { renderAsync } = await import('@react-email/render');
-            this.renderAsync = renderAsync;
+            const { render } = await import('@react-email/render');
+            this.render = render;
           } catch (error) {
             throw new Error(
               'Failed to render React component. Make sure to install `@react-email/render`',
@@ -39,7 +39,7 @@ export class Batch {
           }
         }
 
-        email.html = await this.renderAsync(email.react as React.ReactElement);
+        email.html = await this.render(email.react as React.ReactElement);
         email.react = undefined;
       }
 

--- a/src/broadcasts/broadcasts.ts
+++ b/src/broadcasts/broadcasts.ts
@@ -28,7 +28,7 @@ import type {
 } from './interfaces/update-broadcast.interface';
 
 export class Broadcasts {
-  private renderAsync?: (component: React.ReactElement) => Promise<string>;
+  private render?: (component: React.ReactElement) => Promise<string>;
   constructor(private readonly resend: Resend) {}
 
   async create(
@@ -36,10 +36,10 @@ export class Broadcasts {
     options: CreateBroadcastRequestOptions = {},
   ): Promise<SendBroadcastResponse> {
     if (payload.react) {
-      if (!this.renderAsync) {
+      if (!this.render) {
         try {
-          const { renderAsync } = await import('@react-email/render');
-          this.renderAsync = renderAsync;
+          const { render } = await import('@react-email/render');
+          this.render = render;
         } catch (error) {
           throw new Error(
             'Failed to render React component. Make sure to install `@react-email/render`',
@@ -47,7 +47,7 @@ export class Broadcasts {
         }
       }
 
-      payload.html = await this.renderAsync(
+      payload.html = await this.render(
         payload.react as React.ReactElement,
       );
     }

--- a/src/emails/emails.ts
+++ b/src/emails/emails.ts
@@ -22,7 +22,7 @@ import type {
 } from './interfaces/update-email-options.interface';
 
 export class Emails {
-  private renderAsync?: (component: React.ReactElement) => Promise<string>;
+  private render?: (component: React.ReactElement) => Promise<string>;
   constructor(private readonly resend: Resend) {}
 
   async send(
@@ -37,10 +37,10 @@ export class Emails {
     options: CreateEmailRequestOptions = {},
   ): Promise<CreateEmailResponse> {
     if (payload.react) {
-      if (!this.renderAsync) {
+      if (!this.render) {
         try {
-          const { renderAsync } = await import('@react-email/render');
-          this.renderAsync = renderAsync;
+          const { render } = await import('@react-email/render');
+          this.render = render;
         } catch (error) {
           throw new Error(
             'Failed to render React component. Make sure to install `@react-email/render`',
@@ -48,7 +48,7 @@ export class Emails {
         }
       }
 
-      payload.html = await this.renderAsync(
+      payload.html = await this.render(
         payload.react as React.ReactElement,
       );
     }


### PR DESCRIPTION
This refactor removes the usage of the deprecated `renderAsync` function from `@react-email/render`, replacing it with the updated and recommended `render function`. While both methods provide the same core functionality, `render` offers a clearer and more consistent naming.

This change maintains the existing behavior while improving code clarity and future compatibility, reducing technical debt, and ensuring alignment with the latest library standards.