### PR TITLE
feat: update types to allow type narrowing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules
 dist
-.yarn/*
-!.yarn/releases
+build

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "4.6.0",
+  "version": "4.7.0-canary.0",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/api-keys/interfaces/create-api-key-options.interface.ts
+++ b/src/api-keys/interfaces/create-api-key-options.interface.ts
@@ -14,7 +14,12 @@ export interface CreateApiKeyResponseSuccess {
   id: string;
 }
 
-export interface CreateApiKeyResponse {
-  data: CreateApiKeyResponseSuccess | null;
-  error: ErrorResponse | null;
-}
+export type CreateApiKeyResponse =
+  | {
+      data: CreateApiKeyResponseSuccess;
+      error: null;
+    }
+  | {
+      data: null;
+      error: ErrorResponse;
+    };

--- a/src/api-keys/interfaces/list-api-keys.interface.ts
+++ b/src/api-keys/interfaces/list-api-keys.interface.ts
@@ -6,7 +6,12 @@ export type ListApiKeysResponseSuccess = Pick<
   'name' | 'id' | 'created_at'
 >[];
 
-export interface ListApiKeysResponse {
-  data: ListApiKeysResponseSuccess | null;
-  error: ErrorResponse | null;
-}
+export type ListApiKeysResponse =
+  | {
+      data: ListApiKeysResponseSuccess;
+      error: null;
+    }
+  | {
+      data: null;
+      error: ErrorResponse;
+    };

--- a/src/api-keys/interfaces/remove-api-keys.interface.ts
+++ b/src/api-keys/interfaces/remove-api-keys.interface.ts
@@ -3,7 +3,12 @@ import type { ErrorResponse } from '../../interfaces';
 // biome-ignore lint/complexity/noBannedTypes: <explanation>
 export type RemoveApiKeyResponseSuccess = {};
 
-export interface RemoveApiKeyResponse {
-  data: RemoveApiKeyResponseSuccess | null;
-  error: ErrorResponse | null;
-}
+export type RemoveApiKeyResponse =
+  | {
+      data: RemoveApiKeyResponseSuccess;
+      error: null;
+    }
+  | {
+      data: null;
+      error: ErrorResponse;
+    };

--- a/src/audiences/interfaces/create-audience-options.interface.ts
+++ b/src/audiences/interfaces/create-audience-options.interface.ts
@@ -13,7 +13,12 @@ export interface CreateAudienceResponseSuccess
   object: 'audience';
 }
 
-export interface CreateAudienceResponse {
-  data: CreateAudienceResponseSuccess | null;
-  error: ErrorResponse | null;
-}
+export type CreateAudienceResponse =
+  | {
+      data: CreateAudienceResponseSuccess;
+      error: null;
+    }
+  | {
+      data: null;
+      error: ErrorResponse;
+    };

--- a/src/audiences/interfaces/get-audience.interface.ts
+++ b/src/audiences/interfaces/get-audience.interface.ts
@@ -6,7 +6,12 @@ export interface GetAudienceResponseSuccess
   object: 'audience';
 }
 
-export interface GetAudienceResponse {
-  data: GetAudienceResponseSuccess | null;
-  error: ErrorResponse | null;
-}
+export type GetAudienceResponse =
+  | {
+      data: GetAudienceResponseSuccess;
+      error: null;
+    }
+  | {
+      data: null;
+      error: ErrorResponse;
+    };

--- a/src/audiences/interfaces/list-audiences.interface.ts
+++ b/src/audiences/interfaces/list-audiences.interface.ts
@@ -6,7 +6,12 @@ export type ListAudiencesResponseSuccess = {
   data: Audience[];
 };
 
-export interface ListAudiencesResponse {
-  data: ListAudiencesResponseSuccess | null;
-  error: ErrorResponse | null;
-}
+export type ListAudiencesResponse =
+  | {
+      data: ListAudiencesResponseSuccess;
+      error: null;
+    }
+  | {
+      data: null;
+      error: ErrorResponse;
+    };

--- a/src/audiences/interfaces/remove-audience.interface.ts
+++ b/src/audiences/interfaces/remove-audience.interface.ts
@@ -6,7 +6,12 @@ export interface RemoveAudiencesResponseSuccess extends Pick<Audience, 'id'> {
   deleted: boolean;
 }
 
-export interface RemoveAudiencesResponse {
-  data: RemoveAudiencesResponseSuccess | null;
-  error: ErrorResponse | null;
-}
+export type RemoveAudiencesResponse =
+  | {
+      data: RemoveAudiencesResponseSuccess;
+      error: null;
+    }
+  | {
+      data: null;
+      error: ErrorResponse;
+    };

--- a/src/batch/interfaces/create-batch-options.interface.ts
+++ b/src/batch/interfaces/create-batch-options.interface.ts
@@ -16,7 +16,12 @@ export interface CreateBatchSuccessResponse {
   }[];
 }
 
-export interface CreateBatchResponse {
-  data: CreateBatchSuccessResponse | null;
-  error: ErrorResponse | null;
-}
+export type CreateBatchResponse =
+  | {
+      data: CreateBatchSuccessResponse;
+      error: null;
+    }
+  | {
+      data: null;
+      error: ErrorResponse;
+    };

--- a/src/broadcasts/interfaces/create-broadcast-options.interface.ts
+++ b/src/broadcasts/interfaces/create-broadcast-options.interface.ts
@@ -73,7 +73,12 @@ export interface CreateBroadcastResponseSuccess {
   id: string;
 }
 
-export interface CreateBroadcastResponse {
-  data: CreateBroadcastResponseSuccess | null;
-  error: ErrorResponse | null;
-}
+export type CreateBroadcastResponse =
+  | {
+      data: CreateBroadcastResponseSuccess;
+      error: null;
+    }
+  | {
+      data: null;
+      error: ErrorResponse;
+    };

--- a/src/broadcasts/interfaces/get-broadcast.interface.ts
+++ b/src/broadcasts/interfaces/get-broadcast.interface.ts
@@ -5,7 +5,12 @@ export interface GetBroadcastResponseSuccess extends Broadcast {
   object: 'broadcast';
 }
 
-export interface GetBroadcastResponse {
-  data: GetBroadcastResponseSuccess | null;
-  error: ErrorResponse | null;
-}
+export type GetBroadcastResponse =
+  | {
+      data: GetBroadcastResponseSuccess;
+      error: null;
+    }
+  | {
+      data: null;
+      error: ErrorResponse;
+    };

--- a/src/broadcasts/interfaces/list-broadcasts.interface.ts
+++ b/src/broadcasts/interfaces/list-broadcasts.interface.ts
@@ -15,7 +15,12 @@ export type ListBroadcastsResponseSuccess = {
   >[];
 };
 
-export interface ListBroadcastsResponse {
-  data: ListBroadcastsResponseSuccess | null;
-  error: ErrorResponse | null;
-}
+export type ListBroadcastsResponse =
+  | {
+      data: ListBroadcastsResponseSuccess;
+      error: null;
+    }
+  | {
+      data: null;
+      error: ErrorResponse;
+    };

--- a/src/broadcasts/interfaces/remove-broadcast.interface.ts
+++ b/src/broadcasts/interfaces/remove-broadcast.interface.ts
@@ -6,7 +6,12 @@ export interface RemoveBroadcastResponseSuccess extends Pick<Broadcast, 'id'> {
   deleted: boolean;
 }
 
-export interface RemoveBroadcastResponse {
-  data: RemoveBroadcastResponseSuccess | null;
-  error: ErrorResponse | null;
-}
+export type RemoveBroadcastResponse =
+  | {
+      data: RemoveBroadcastResponseSuccess;
+      error: null;
+    }
+  | {
+      data: null;
+      error: ErrorResponse;
+    };

--- a/src/broadcasts/interfaces/send-broadcast-options.interface.ts
+++ b/src/broadcasts/interfaces/send-broadcast-options.interface.ts
@@ -21,7 +21,12 @@ export interface SendBroadcastResponseSuccess {
   id: string;
 }
 
-export interface SendBroadcastResponse {
-  data: SendBroadcastResponseSuccess | null;
-  error: ErrorResponse | null;
-}
+export type SendBroadcastResponse =
+  | {
+      data: SendBroadcastResponseSuccess;
+      error: null;
+    }
+  | {
+      data: null;
+      error: ErrorResponse;
+    };

--- a/src/broadcasts/interfaces/update-broadcast.interface.ts
+++ b/src/broadcasts/interfaces/update-broadcast.interface.ts
@@ -15,7 +15,12 @@ export interface UpdateBroadcastOptions {
   previewText?: string;
 }
 
-export interface UpdateBroadcastResponse {
-  data: UpdateBroadcastResponseSuccess | null;
-  error: ErrorResponse | null;
-}
+export type UpdateBroadcastResponse =
+  | {
+      data: UpdateBroadcastResponseSuccess;
+      error: null;
+    }
+  | {
+      data: null;
+      error: ErrorResponse;
+    };

--- a/src/contacts/interfaces/create-contact-options.interface.ts
+++ b/src/contacts/interfaces/create-contact-options.interface.ts
@@ -16,7 +16,12 @@ export interface CreateContactResponseSuccess extends Pick<Contact, 'id'> {
   object: 'contact';
 }
 
-export interface CreateContactResponse {
-  data: CreateContactResponseSuccess | null;
-  error: ErrorResponse | null;
-}
+export type CreateContactResponse =
+  | {
+      data: CreateContactResponseSuccess;
+      error: null;
+    }
+  | {
+      data: null;
+      error: ErrorResponse;
+    };

--- a/src/contacts/interfaces/get-contact.interface.ts
+++ b/src/contacts/interfaces/get-contact.interface.ts
@@ -15,7 +15,12 @@ export interface GetContactResponseSuccess
   object: 'contact';
 }
 
-export interface GetContactResponse {
-  data: GetContactResponseSuccess | null;
-  error: ErrorResponse | null;
-}
+export type GetContactResponse =
+  | {
+      data: GetContactResponseSuccess;
+      error: null;
+    }
+  | {
+      data: null;
+      error: ErrorResponse;
+    };

--- a/src/contacts/interfaces/list-contacts.interface.ts
+++ b/src/contacts/interfaces/list-contacts.interface.ts
@@ -10,7 +10,12 @@ export interface ListContactsResponseSuccess {
   data: Contact[];
 }
 
-export interface ListContactsResponse {
-  data: ListContactsResponseSuccess | null;
-  error: ErrorResponse | null;
-}
+export type ListContactsResponse =
+  | {
+      data: ListContactsResponseSuccess;
+      error: null;
+    }
+  | {
+      data: null;
+      error: ErrorResponse;
+    };

--- a/src/contacts/interfaces/remove-contact.interface.ts
+++ b/src/contacts/interfaces/remove-contact.interface.ts
@@ -25,7 +25,12 @@ export interface RemoveContactOptions extends RemoveByOptions {
   audienceId: string;
 }
 
-export interface RemoveContactsResponse {
-  data: RemoveContactsResponseSuccess | null;
-  error: ErrorResponse | null;
-}
+export type RemoveContactsResponse =
+  | {
+      data: RemoveContactsResponseSuccess;
+      error: null;
+    }
+  | {
+      data: null;
+      error: ErrorResponse;
+    };

--- a/src/contacts/interfaces/update-contact.interface.ts
+++ b/src/contacts/interfaces/update-contact.interface.ts
@@ -17,7 +17,12 @@ export type UpdateContactResponseSuccess = Pick<Contact, 'id'> & {
   object: 'contact';
 };
 
-export interface UpdateContactResponse {
-  data: UpdateContactResponseSuccess | null;
-  error: ErrorResponse | null;
-}
+export type UpdateContactResponse =
+  | {
+      data: UpdateContactResponseSuccess;
+      error: null;
+    }
+  | {
+      data: null;
+      error: ErrorResponse;
+    };

--- a/src/domains/interfaces/create-domain-options.interface.ts
+++ b/src/domains/interfaces/create-domain-options.interface.ts
@@ -15,7 +15,12 @@ export interface CreateDomainResponseSuccess
   records: DomainRecords[];
 }
 
-export interface CreateDomainResponse {
-  data: CreateDomainResponseSuccess | null;
-  error: ErrorResponse | null;
-}
+export type CreateDomainResponse =
+  | {
+      data: CreateDomainResponseSuccess;
+      error: null;
+    }
+  | {
+      data: null;
+      error: ErrorResponse;
+    };

--- a/src/domains/interfaces/get-domain.interface.ts
+++ b/src/domains/interfaces/get-domain.interface.ts
@@ -7,7 +7,12 @@ export interface GetDomainResponseSuccess
   records: DomainRecords[];
 }
 
-export interface GetDomainResponse {
-  data: GetDomainResponseSuccess | null;
-  error: ErrorResponse | null;
-}
+export type GetDomainResponse =
+  | {
+      data: GetDomainResponseSuccess;
+      error: null;
+    }
+  | {
+      data: null;
+      error: ErrorResponse;
+    };

--- a/src/domains/interfaces/list-domains.interface.ts
+++ b/src/domains/interfaces/list-domains.interface.ts
@@ -3,7 +3,12 @@ import type { Domain } from './domain';
 
 export type ListDomainsResponseSuccess = { data: Domain[] };
 
-export interface ListDomainsResponse {
-  data: ListDomainsResponseSuccess | null;
-  error: ErrorResponse | null;
-}
+export type ListDomainsResponse =
+  | {
+      data: ListDomainsResponseSuccess;
+      error: null;
+    }
+  | {
+      data: null;
+      error: ErrorResponse;
+    };

--- a/src/domains/interfaces/remove-domain.interface.ts
+++ b/src/domains/interfaces/remove-domain.interface.ts
@@ -6,7 +6,12 @@ export type RemoveDomainsResponseSuccess = Pick<Domain, 'id'> & {
   deleted: boolean;
 };
 
-export interface RemoveDomainsResponse {
-  data: RemoveDomainsResponseSuccess | null;
-  error: ErrorResponse | null;
-}
+export type RemoveDomainsResponse =
+  | {
+      data: RemoveDomainsResponseSuccess;
+      error: null;
+    }
+  | {
+      data: null;
+      error: ErrorResponse;
+    };

--- a/src/domains/interfaces/update-domain.interface.ts
+++ b/src/domains/interfaces/update-domain.interface.ts
@@ -12,7 +12,12 @@ export type UpdateDomainsResponseSuccess = Pick<Domain, 'id'> & {
   object: 'domain';
 };
 
-export interface UpdateDomainsResponse {
-  data: UpdateDomainsResponseSuccess | null;
-  error: ErrorResponse | null;
-}
+export type UpdateDomainsResponse =
+  | {
+      data: UpdateDomainsResponseSuccess;
+      error: null;
+    }
+  | {
+      data: null;
+      error: ErrorResponse;
+    };

--- a/src/domains/interfaces/verify-domain.interface.ts
+++ b/src/domains/interfaces/verify-domain.interface.ts
@@ -5,7 +5,12 @@ export type VerifyDomainsResponseSuccess = Pick<Domain, 'id'> & {
   object: 'domain';
 };
 
-export interface VerifyDomainsResponse {
-  data: VerifyDomainsResponseSuccess | null;
-  error: ErrorResponse | null;
-}
+export type VerifyDomainsResponse =
+  | {
+      data: VerifyDomainsResponseSuccess;
+      error: null;
+    }
+  | {
+      data: null;
+      error: ErrorResponse;
+    };

--- a/src/emails/interfaces/cancel-email-options.interface.ts
+++ b/src/emails/interfaces/cancel-email-options.interface.ts
@@ -1,11 +1,16 @@
 import type { ErrorResponse } from '../../interfaces';
 
-export interface CancelEmailResponse {
-  data: CancelEmailResponseSuccess | null;
-  error: ErrorResponse | null;
-}
-
 export interface CancelEmailResponseSuccess {
   object: 'email';
   id: string;
 }
+
+export type CancelEmailResponse =
+  | {
+      data: CancelEmailResponseSuccess;
+      error: null;
+    }
+  | {
+      data: null;
+      error: ErrorResponse;
+    };

--- a/src/emails/interfaces/create-email-options.interface.ts
+++ b/src/emails/interfaces/create-email-options.interface.ts
@@ -101,10 +101,15 @@ export interface CreateEmailResponseSuccess {
   id: string;
 }
 
-export interface CreateEmailResponse {
-  data: CreateEmailResponseSuccess | null;
-  error: ErrorResponse | null;
-}
+export type CreateEmailResponse =
+  | {
+      data: CreateEmailResponseSuccess;
+      error: null;
+    }
+  | {
+      data: null;
+      error: ErrorResponse;
+    };
 
 export interface Attachment {
   /** Content of an attached file. */

--- a/src/emails/interfaces/get-email-options.interface.ts
+++ b/src/emails/interfaces/get-email-options.interface.ts
@@ -27,7 +27,12 @@ export interface GetEmailResponseSuccess {
   object: 'email';
 }
 
-export interface GetEmailResponse {
-  data: GetEmailResponseSuccess | null;
-  error: ErrorResponse | null;
-}
+export type GetEmailResponse =
+  | {
+      data: GetEmailResponseSuccess;
+      error: null;
+    }
+  | {
+      data: null;
+      error: ErrorResponse;
+    };

--- a/src/emails/interfaces/update-email-options.interface.ts
+++ b/src/emails/interfaces/update-email-options.interface.ts
@@ -10,7 +10,12 @@ export interface UpdateEmailResponseSuccess {
   object: 'email';
 }
 
-export interface UpdateEmailResponse {
-  data: UpdateEmailResponseSuccess | null;
-  error: ErrorResponse | null;
-}
+export type UpdateEmailResponse =
+  | {
+      data: UpdateEmailResponseSuccess;
+      error: null;
+    }
+  | {
+      data: null;
+      error: ErrorResponse;
+    };

--- a/src/resend.ts
+++ b/src/resend.ts
@@ -56,7 +56,7 @@ export class Resend {
   async fetchRequest<T>(
     path: string,
     options = {},
-  ): Promise<{ data: T | null; error: ErrorResponse | null }> {
+  ): Promise<{ data: T; error: null } | { data: null; error: ErrorResponse }> {
     try {
       const response = await fetch(`${baseUrl}${path}`, options);
 


### PR DESCRIPTION
closes #356

previously we had the response schemas defining both `data` and `error` to be either the value or _null_. but as correctly pointed in the issue, we always have _either/or_

by updating the type definitions to something like:
```
// from this:
type Response = { data: MyData | null; error: MyError | null }

// to this:
type Response = { data: MyData; error: null } | { data: null; error: MyError }
```

we can leverage TypeScript type narrowing in the code and have better types 🎉 

**note the null in here:**
![CleanShot 2025-06-13 at 16 42 14@2x](https://github.com/user-attachments/assets/98e32f6e-4860-48d6-98a3-bbe4da6e6c57)


**much better:**
![CleanShot 2025-06-13 at 16 51 10@2x](https://github.com/user-attachments/assets/7b79631f-724a-4344-aea2-4a16228ad86b)

