### PR TITLE
feat: add contact topics endpoints to node sdk

### DIFF
--- a/src/contacts/contacts.ts
+++ b/src/contacts/contacts.ts
@@ -25,9 +25,14 @@ import type {
   UpdateContactResponse,
   UpdateContactResponseSuccess,
 } from './interfaces/update-contact.interface';
+import { ContactTopics } from './topics/contact-topics';
 
 export class Contacts {
-  constructor(private readonly resend: Resend) {}
+  readonly topics: ContactTopics;
+
+  constructor(private readonly resend: Resend) {
+    this.topics = new ContactTopics(this.resend);
+  }
 
   async create(
     payload: CreateContactOptions,

--- a/src/contacts/topics/contact-topics.spec.ts
+++ b/src/contacts/topics/contact-topics.spec.ts
@@ -1,0 +1,271 @@
+import { enableFetchMocks } from 'jest-fetch-mock';
+import { Resend } from '../../resend';
+import type {
+  GetContactTopicsOptions,
+  GetContactTopicsResponseSuccess,
+} from './interfaces/get-contact-topics.interface';
+import type {
+  UpdateContactTopicsOptions,
+  UpdateContactTopicsResponseSuccess,
+} from './interfaces/update-contact-topics.interface';
+
+enableFetchMocks();
+
+describe('ContactTopics', () => {
+  afterEach(() => fetchMock.resetMocks());
+
+  describe('update', () => {
+    it('updates contact topics with opt_in', async () => {
+      const payload: UpdateContactTopicsOptions = {
+        email: 'carolina+2@resend.com',
+        opt_in: ['c7e1e488-ae2c-4255-a40c-a4db3af7ed0b'],
+      };
+      const response: UpdateContactTopicsResponseSuccess = {
+        id: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223',
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+          Authorization: 'Bearer re_924b3rjh2387fbewf823',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      await expect(
+        resend.contacts.topics.update(payload),
+      ).resolves.toMatchInlineSnapshot(`
+{
+  "data": {
+    "id": "3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223",
+  },
+  "error": null,
+}
+`);
+    });
+
+    it('updates contact topics with opt_out', async () => {
+      const payload: UpdateContactTopicsOptions = {
+        email: 'carolina+2@resend.com',
+        opt_out: ['c7e1e488-ae2c-4255-a40c-a4db3af7ed0b'],
+      };
+      const response: UpdateContactTopicsResponseSuccess = {
+        id: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223',
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+          Authorization: 'Bearer re_924b3rjh2387fbewf823',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      await expect(
+        resend.contacts.topics.update(payload),
+      ).resolves.toMatchInlineSnapshot(`
+{
+  "data": {
+    "id": "3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223",
+  },
+  "error": null,
+}
+`);
+    });
+
+    it('updates contact topics with both opt_in and opt_out', async () => {
+      const payload: UpdateContactTopicsOptions = {
+        email: 'carolina+2@resend.com',
+        opt_in: ['c7e1e488-ae2c-4255-a40c-a4db3af7ed0b'],
+        opt_out: ['another-topic-id'],
+      };
+      const response: UpdateContactTopicsResponseSuccess = {
+        id: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223',
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+          Authorization: 'Bearer re_924b3rjh2387fbewf823',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      await expect(
+        resend.contacts.topics.update(payload),
+      ).resolves.toMatchInlineSnapshot(`
+{
+  "data": {
+    "id": "3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223",
+  },
+  "error": null,
+}
+`);
+    });
+
+    it('returns error when missing both id and email', async () => {
+      const payload = {
+        opt_in: ['c7e1e488-ae2c-4255-a40c-a4db3af7ed0b'],
+      };
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      const result = resend.contacts.topics.update(
+        payload as UpdateContactTopicsOptions,
+      );
+
+      await expect(result).resolves.toMatchInlineSnapshot(`
+{
+  "data": null,
+  "error": {
+    "message": "Missing \`id\` or \`email\` field.",
+    "name": "missing_required_field",
+  },
+}
+`);
+    });
+
+    it('updates contact topics using ID', async () => {
+      const payload: UpdateContactTopicsOptions = {
+        id: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223',
+        opt_in: ['c7e1e488-ae2c-4255-a40c-a4db3af7ed0b'],
+      };
+      const response: UpdateContactTopicsResponseSuccess = {
+        id: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223',
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+          Authorization: 'Bearer re_924b3rjh2387fbewf823',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      await expect(
+        resend.contacts.topics.update(payload),
+      ).resolves.toMatchInlineSnapshot(`
+{
+  "data": {
+    "id": "3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223",
+  },
+  "error": null,
+}
+`);
+    });
+  });
+
+  describe('get', () => {
+    it('gets contact topics by email', async () => {
+      const options: GetContactTopicsOptions = {
+        email: 'carolina@resend.com',
+      };
+      const response: GetContactTopicsResponseSuccess = {
+        email: 'carolina@resend.com',
+        topics: [
+          {
+            id: 'c7e1e488-ae2c-4255-a40c-a4db3af7ed0b',
+            subscription: 'opt_in',
+          },
+          {
+            id: 'another-topic-id',
+            subscription: 'opt_out',
+          },
+        ],
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+          Authorization: 'Bearer re_924b3rjh2387fbewf823',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      await expect(
+        resend.contacts.topics.get(options),
+      ).resolves.toMatchInlineSnapshot(`
+{
+  "data": {
+    "email": "carolina@resend.com",
+    "topics": [
+      {
+        "id": "c7e1e488-ae2c-4255-a40c-a4db3af7ed0b",
+        "subscription": "opt_in",
+      },
+      {
+        "id": "another-topic-id",
+        "subscription": "opt_out",
+      },
+    ],
+  },
+  "error": null,
+}
+`);
+    });
+
+    it('gets contact topics by ID', async () => {
+      const options: GetContactTopicsOptions = {
+        id: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223',
+      };
+      const response: GetContactTopicsResponseSuccess = {
+        email: 'carolina@resend.com',
+        topics: [
+          {
+            id: 'c7e1e488-ae2c-4255-a40c-a4db3af7ed0b',
+            subscription: 'opt_in',
+          },
+        ],
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+          Authorization: 'Bearer re_924b3rjh2387fbewf823',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      await expect(
+        resend.contacts.topics.get(options),
+      ).resolves.toMatchInlineSnapshot(`
+{
+  "data": {
+    "email": "carolina@resend.com",
+    "topics": [
+      {
+        "id": "c7e1e488-ae2c-4255-a40c-a4db3af7ed0b",
+        "subscription": "opt_in",
+      },
+    ],
+  },
+  "error": null,
+}
+`);
+    });
+
+    it('returns error when missing both id and email', async () => {
+      const options = {};
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      const result = resend.contacts.topics.get(
+        options as GetContactTopicsOptions,
+      );
+
+      await expect(result).resolves.toMatchInlineSnapshot(`
+{
+  "data": null,
+  "error": {
+    "message": "Missing \`id\` or \`email\` field.",
+    "name": "missing_required_field",
+  },
+}
+`);
+    });
+  });
+});

--- a/src/contacts/topics/contact-topics.ts
+++ b/src/contacts/topics/contact-topics.ts
@@ -1,0 +1,61 @@
+import type { Resend } from '../../resend';
+import type {
+  GetContactTopicsOptions,
+  GetContactTopicsResponse,
+  GetContactTopicsResponseSuccess,
+} from './interfaces/get-contact-topics.interface';
+import type {
+  UpdateContactTopicsOptions,
+  UpdateContactTopicsResponse,
+  UpdateContactTopicsResponseSuccess,
+} from './interfaces/update-contact-topics.interface';
+
+export class ContactTopics {
+  constructor(private readonly resend: Resend) {}
+
+  async update(
+    payload: UpdateContactTopicsOptions,
+  ): Promise<UpdateContactTopicsResponse> {
+    if (!payload.id && !payload.email) {
+      return {
+        data: null,
+        error: {
+          message: 'Missing `id` or `email` field.',
+          name: 'missing_required_field',
+        },
+      };
+    }
+
+    const identifier = payload.email ? payload.email : payload.id;
+    const data = await this.resend.patch<UpdateContactTopicsResponseSuccess>(
+      `/contacts/${identifier}/topics`,
+      {
+        opt_in: payload.opt_in,
+        opt_out: payload.opt_out,
+      },
+    );
+
+    return data;
+  }
+
+  async get(
+    options: GetContactTopicsOptions,
+  ): Promise<GetContactTopicsResponse> {
+    if (!options.id && !options.email) {
+      return {
+        data: null,
+        error: {
+          message: 'Missing `id` or `email` field.',
+          name: 'missing_required_field',
+        },
+      };
+    }
+
+    const identifier = options.email ? options.email : options.id;
+    const data = await this.resend.get<GetContactTopicsResponseSuccess>(
+      `/contacts/${identifier}/topics`,
+    );
+
+    return data;
+  }
+}

--- a/src/contacts/topics/interfaces/get-contact-topics.interface.ts
+++ b/src/contacts/topics/interfaces/get-contact-topics.interface.ts
@@ -1,0 +1,26 @@
+import type { GetOptions } from '../../../common/interfaces';
+import type { ErrorResponse } from '../../../interfaces';
+
+interface GetContactTopicsBaseOptions {
+  id?: string;
+  email?: string;
+}
+
+export interface GetContactTopicsOptions extends GetContactTopicsBaseOptions {}
+
+export interface GetContactTopicsRequestOptions extends GetOptions {}
+
+export interface ContactTopic {
+  id: string;
+  subscription: 'opt_in' | 'opt_out';
+}
+
+export interface GetContactTopicsResponseSuccess {
+  email: string;
+  topics: ContactTopic[];
+}
+
+export interface GetContactTopicsResponse {
+  data: GetContactTopicsResponseSuccess | null;
+  error: ErrorResponse | null;
+}

--- a/src/contacts/topics/interfaces/update-contact-topics.interface.ts
+++ b/src/contacts/topics/interfaces/update-contact-topics.interface.ts
@@ -1,0 +1,24 @@
+import type { PatchOptions } from '../../../common/interfaces/patch-option.interface';
+import type { ErrorResponse } from '../../../interfaces';
+
+interface UpdateContactTopicsBaseOptions {
+  id?: string;
+  email?: string;
+}
+
+export interface UpdateContactTopicsOptions
+  extends UpdateContactTopicsBaseOptions {
+  opt_in?: string[];
+  opt_out?: string[];
+}
+
+export interface UpdateContactTopicsRequestOptions extends PatchOptions {}
+
+export interface UpdateContactTopicsResponseSuccess {
+  id: string;
+}
+
+export interface UpdateContactTopicsResponse {
+  data: UpdateContactTopicsResponseSuccess | null;
+  error: ErrorResponse | null;
+}

--- a/src/contacts/topics/interfaces/update-contact-topics.interface.ts
+++ b/src/contacts/topics/interfaces/update-contact-topics.interface.ts
@@ -8,8 +8,8 @@ interface UpdateContactTopicsBaseOptions {
 
 export interface UpdateContactTopicsOptions
   extends UpdateContactTopicsBaseOptions {
-  opt_in?: string[];
-  opt_out?: string[];
+  opt_in?: string | string[];
+  opt_out?: string | string[];
 }
 
 export interface UpdateContactTopicsRequestOptions extends PatchOptions {}


### PR DESCRIPTION
## Description 
This PR adds Contacts/Topics operations (`contacts.topics.patch` and `contacts.topics.get`) support to the SDK just as [described here](https://www.notion.so/resend/Unsubscribe-Topics-API-SDK-1ecc40d6c4ef80f29ee1c6b5c4038ccb)