### PR TITLE
feat: improve update contact's subscriptions method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "4.7.0-preview-topics.0",
+  "version": "4.7.0-preview-topics.1",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/contacts/topics/contact-topics.spec.ts
+++ b/src/contacts/topics/contact-topics.spec.ts
@@ -18,7 +18,12 @@ describe('ContactTopics', () => {
     it('updates contact topics with opt_in', async () => {
       const payload: UpdateContactTopicsOptions = {
         email: 'carolina+2@resend.com',
-        opt_in: ['c7e1e488-ae2c-4255-a40c-a4db3af7ed0b'],
+        topics: [
+          {
+            id: 'c7e1e488-ae2c-4255-a40c-a4db3af7ed0b',
+            subscription: 'opt_in',
+          },
+        ],
       };
       const response: UpdateContactTopicsResponseSuccess = {
         id: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223',
@@ -48,7 +53,12 @@ describe('ContactTopics', () => {
     it('updates contact topics with opt_out', async () => {
       const payload: UpdateContactTopicsOptions = {
         email: 'carolina+2@resend.com',
-        opt_out: ['c7e1e488-ae2c-4255-a40c-a4db3af7ed0b'],
+        topics: [
+          {
+            id: 'c7e1e488-ae2c-4255-a40c-a4db3af7ed0b',
+            subscription: 'opt_out',
+          },
+        ],
       };
       const response: UpdateContactTopicsResponseSuccess = {
         id: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223',
@@ -78,8 +88,16 @@ describe('ContactTopics', () => {
     it('updates contact topics with both opt_in and opt_out', async () => {
       const payload: UpdateContactTopicsOptions = {
         email: 'carolina+2@resend.com',
-        opt_in: ['c7e1e488-ae2c-4255-a40c-a4db3af7ed0b'],
-        opt_out: ['another-topic-id'],
+        topics: [
+          {
+            id: 'c7e1e488-ae2c-4255-a40c-a4db3af7ed0b',
+            subscription: 'opt_in',
+          },
+          {
+            id: 'another-topic-id',
+            subscription: 'opt_out',
+          },
+        ],
       };
       const response: UpdateContactTopicsResponseSuccess = {
         id: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223',
@@ -108,7 +126,12 @@ describe('ContactTopics', () => {
 
     it('returns error when missing both id and email', async () => {
       const payload = {
-        opt_in: ['c7e1e488-ae2c-4255-a40c-a4db3af7ed0b'],
+        topics: [
+          {
+            id: 'c7e1e488-ae2c-4255-a40c-a4db3af7ed0b',
+            subscription: 'opt_in',
+          },
+        ],
       };
       const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
 
@@ -130,7 +153,12 @@ describe('ContactTopics', () => {
     it('updates contact topics using ID', async () => {
       const payload: UpdateContactTopicsOptions = {
         id: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223',
-        opt_in: ['c7e1e488-ae2c-4255-a40c-a4db3af7ed0b'],
+        topics: [
+          {
+            id: 'c7e1e488-ae2c-4255-a40c-a4db3af7ed0b',
+            subscription: 'opt_in',
+          },
+        ],
       };
       const response: UpdateContactTopicsResponseSuccess = {
         id: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223',

--- a/src/contacts/topics/contact-topics.ts
+++ b/src/contacts/topics/contact-topics.ts
@@ -29,10 +29,7 @@ export class ContactTopics {
     const identifier = payload.email ? payload.email : payload.id;
     const data = await this.resend.patch<UpdateContactTopicsResponseSuccess>(
       `/contacts/${identifier}/topics`,
-      {
-        opt_in: payload.opt_in,
-        opt_out: payload.opt_out,
-      },
+      payload.topics,
     );
 
     return data;

--- a/src/contacts/topics/interfaces/update-contact-topics.interface.ts
+++ b/src/contacts/topics/interfaces/update-contact-topics.interface.ts
@@ -8,8 +8,7 @@ interface UpdateContactTopicsBaseOptions {
 
 export interface UpdateContactTopicsOptions
   extends UpdateContactTopicsBaseOptions {
-  opt_in?: string | string[];
-  opt_out?: string | string[];
+  topics: { id: string; subscription: 'opt_in' | 'opt_out' }[];
 }
 
 export interface UpdateContactTopicsRequestOptions extends PatchOptions {}


### PR DESCRIPTION
## Description
Given the feedback given in [this Slack thread](https://resend.slack.com/archives/C08QC31VD17/p1752772795490149), the update contact's topics request body will be changed in favor of a cleaner approach. This approach is also closer to the response we give when the user fetches the contact's subscriptions

**Before**

```typescript
await resend.contacts.topics.update({
    id?: string,
    email?: string,
    opt_out?: string | string[],
    opt_in?: string | string[],
});
```

**After**

```typescript
await resend.contacts.topics.update({
  id?: string,
  email?: string,
  topics: [{ id: string, subscription: "opt_in" | "opt_out" }],
});

```