### PR TITLE
chore: use `render` as a `devDependency`

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "homepage": "https://github.com/resendlabs/resend-node#readme",
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
-    "@react-email/render": "1.1.0",
+    "@react-email/render": "1.1.2",
     "@types/jest": "29.5.14",
     "@types/node": "18.19.86",
     "@types/react": "19.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "5.0.0-canary.0",
+  "version": "5.0.0-canary.1",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "homepage": "https://github.com/resendlabs/resend-node#readme",
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
-    "@react-email/render": "^1.1.0",
+    "@react-email/render": "1.1.0",
     "@types/jest": "29.5.14",
     "@types/node": "18.19.86",
     "@types/react": "19.1.2",

--- a/package.json
+++ b/package.json
@@ -41,8 +41,6 @@
     "url": "https://github.com/resendlabs/resend-node/issues"
   },
   "homepage": "https://github.com/resendlabs/resend-node#readme",
-  "peerDependencies": {
-  },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "@react-email/render": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -42,15 +42,10 @@
   },
   "homepage": "https://github.com/resendlabs/resend-node#readme",
   "peerDependencies": {
-    "@react-email/render": "^1.1.0"
-  },
-  "peerDependenciesMeta": {
-    "@react-email/render": {
-      "optional": true
-    }
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
+    "@react-email/render": "^1.1.0",
     "@types/jest": "29.5.14",
     "@types/node": "18.19.86",
     "@types/react": "19.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: 1.9.4
         version: 1.9.4
       '@react-email/render':
-        specifier: 1.1.0
-        version: 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 1.1.2
+        version: 1.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/jest':
         specifier: 29.5.14
         version: 29.5.14
@@ -519,8 +519,8 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@react-email/render@1.1.0':
-    resolution: {integrity: sha512-X4CsHvXi5X7kTn5NgXNGg8Y5U1VtVJmlpNLlTc2E8RVHKFS3bpr+o/ZXhEPN4yRkdY+ZYN5eqVTV922Hujqsxw==}
+  '@react-email/render@1.1.2':
+    resolution: {integrity: sha512-RnRehYN3v9gVlNMehHPHhyp2RQo7+pSkHDtXPvg3s0GbzM9SQMW4Qrf8GRNvtpLC4gsI+Wt0VatNRUFqjvevbw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
@@ -2386,7 +2386,7 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@react-email/render@1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-email/render@1.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       html-to-text: 9.0.5
       prettier: 3.5.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: 1.9.4
         version: 1.9.4
       '@react-email/render':
-        specifier: ^1.1.0
-        version: 1.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 1.1.0
+        version: 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/jest':
         specifier: 29.5.14
         version: 29.5.14
@@ -519,8 +519,8 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@react-email/render@1.1.2':
-    resolution: {integrity: sha512-RnRehYN3v9gVlNMehHPHhyp2RQo7+pSkHDtXPvg3s0GbzM9SQMW4Qrf8GRNvtpLC4gsI+Wt0VatNRUFqjvevbw==}
+  '@react-email/render@1.1.0':
+    resolution: {integrity: sha512-X4CsHvXi5X7kTn5NgXNGg8Y5U1VtVJmlpNLlTc2E8RVHKFS3bpr+o/ZXhEPN4yRkdY+ZYN5eqVTV922Hujqsxw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
@@ -2386,7 +2386,7 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@react-email/render@1.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@react-email/render@1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       html-to-text: 9.0.5
       prettier: 3.5.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,14 +7,13 @@ settings:
 importers:
 
   .:
-    dependencies:
-      '@react-email/render':
-        specifier: ^1.1.0
-        version: 1.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@biomejs/biome':
         specifier: 1.9.4
         version: 1.9.4
+      '@react-email/render':
+        specifier: ^1.1.0
+        version: 1.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/jest':
         specifier: 29.5.14
         version: 29.5.14


### PR DESCRIPTION
Continuing on the work of #527.

After testing out the `5.0.0-canary.0` on an existing project I noticed that the approach of using peer dependencies made it so that if the user already had installed the previous version, consequently having `@react-email/render` in their lockfile, and then updated, it would keep `@react-email/render` in the lockfile for pnpm, npm and bun. This would not happen for new installs, though.

If we were to keep it as a peer dependency, we'd need to tell users to either remove things from their lockfile manually, or recreate their lockfile (which they should probably not do).

This pull requests changes it so that we use `devDependencies` instead, this avoids that problem and will reduce the installed dependencies after upgrading.

I tested this with a package prefixed with my name, you can compare installing `gabriel-resend-node@4.7.0`, and then installing `gabriel-resend-node@5.0.0-canary.0` and notice that the lockfile does not include `@react-email/render` after the version change. Here's what you will find with pnpm:


| 4.7.0 | 5.0.0-canary.0 |
|--------|--------|
| <img width="3680" height="2940" alt="image" src="https://github.com/user-attachments/assets/2181d046-b701-409e-943b-7de019157249" /> | <img width="3680" height="3032" alt="image" src="https://github.com/user-attachments/assets/b2b28ba1-7c3b-428b-a567-85a61969c6d7" /> |
| <img width="3680" height="2940" alt="image" src="https://github.com/user-attachments/assets/19e89ffa-930d-4284-a999-cf360b4caa8f" /> | <img width="3680" height="2580" alt="image" src="https://github.com/user-attachments/assets/e2de192a-d861-437a-a538-a3b9c8f88189" /> |
