### PR TITLE
feat: add create template method

### DIFF
--- a/src/resend.ts
+++ b/src/resend.ts
@@ -10,6 +10,7 @@ import { Contacts } from './contacts/contacts';
 import { Domains } from './domains/domains';
 import { Emails } from './emails/emails';
 import type { ErrorResponse } from './interfaces';
+import { Templates } from './templates/templates';
 
 const defaultBaseUrl = 'https://api.resend.com';
 const defaultUserAgent = `resend-node:${version}`;
@@ -32,6 +33,7 @@ export class Resend {
   readonly contacts = new Contacts(this);
   readonly domains = new Domains(this);
   readonly emails = new Emails(this);
+  readonly templates = new Templates(this);
 
   constructor(readonly key?: string) {
     if (!key) {

--- a/src/templates/interfaces/create-template-options.interface.ts
+++ b/src/templates/interfaces/create-template-options.interface.ts
@@ -1,0 +1,27 @@
+import type { PostOptions } from '../../common/interfaces';
+import type { ErrorResponse } from '../../interfaces';
+import type { Template, TemplateVariable } from './template';
+
+export interface CreateTemplateOptions
+  extends Pick<
+    Template,
+    'name' | 'subject' | 'html' | 'text' | 'alias' | 'from' | 'reply_to'
+  > {
+  variables?: Pick<TemplateVariable, 'key' | 'fallback_value' | 'type'>[];
+}
+
+export interface CreateTemplateRequestOptions extends PostOptions {}
+
+export interface CreateTemplateResponseSuccess extends Pick<Template, 'id'> {
+  object: 'template';
+}
+
+export type CreateTemplateResponse =
+  | {
+      data: CreateTemplateResponseSuccess;
+      error: null;
+    }
+  | {
+      data: null;
+      error: ErrorResponse;
+    };

--- a/src/templates/interfaces/create-template-options.interface.ts
+++ b/src/templates/interfaces/create-template-options.interface.ts
@@ -1,14 +1,20 @@
 import type { PostOptions } from '../../common/interfaces';
+import type { RequireAtLeastOne } from '../../common/interfaces/require-at-least-one';
 import type { ErrorResponse } from '../../interfaces';
 import type { Template, TemplateVariable } from './template';
 
-export interface CreateTemplateOptions
-  extends Pick<
-    Template,
-    'name' | 'subject' | 'html' | 'text' | 'alias' | 'from' | 'reply_to'
-  > {
-  variables?: Pick<TemplateVariable, 'key' | 'fallback_value' | 'type'>[];
-}
+type TemplateContentCreationOptions = RequireAtLeastOne<{
+  html: string;
+  react: React.ReactNode;
+}>;
+
+export type CreateTemplateOptions = Pick<
+  Template,
+  'name' | 'subject' | 'text' | 'alias' | 'from' | 'reply_to'
+> &
+  TemplateContentCreationOptions & {
+    variables?: Pick<TemplateVariable, 'key' | 'fallback_value' | 'type'>[];
+  };
 
 export interface CreateTemplateRequestOptions extends PostOptions {}
 

--- a/src/templates/interfaces/template.ts
+++ b/src/templates/interfaces/template.ts
@@ -1,0 +1,23 @@
+export interface Template {
+  id: string;
+  name: string;
+  subject?: string;
+  html: string;
+  text?: string;
+  status: 'draft' | 'published' | 'deleted';
+  variables?: TemplateVariable[];
+  alias?: string;
+  from?: string;
+  reply_to?: string | string[];
+  published_at?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface TemplateVariable {
+  key: string;
+  fallback_value?: string;
+  type: 'string' | 'number' | 'boolean';
+  created_at: string;
+  updated_at: string;
+}

--- a/src/templates/templates.spec.ts
+++ b/src/templates/templates.spec.ts
@@ -42,22 +42,22 @@ describe('Templates', () => {
       await expect(
         resend.templates.create(payload),
       ).resolves.toMatchInlineSnapshot(`
-{
-  "data": {
-    "id": "3deaccfb-f47f-440a-8875-ea14b1716b43",
-    "object": "template",
-  },
-  "error": null,
-}
-`);
+    {
+      "data": {
+        "id": "3deaccfb-f47f-440a-8875-ea14b1716b43",
+        "object": "template",
+      },
+      "error": null,
+    }
+    `);
     });
 
     it('creates a template with all optional fields', async () => {
       const payload: CreateTemplateOptions = {
         name: 'Welcome Email',
         subject: 'Welcome to our platform',
-        html: '<h1>Welcome to our platform!</h1>',
-        text: 'Welcome to our platform!',
+        html: '<h1>Welcome to our platform, {{{name}}}!</h1><p>We are excited to have you join {{{company}}}.</p>',
+        text: 'Welcome to our platform, {{{name}}}! We are excited to have you join {{{company}}}.',
         variables: [
           {
             key: 'name',
@@ -91,21 +91,34 @@ describe('Templates', () => {
       await expect(
         resend.templates.create(payload),
       ).resolves.toMatchInlineSnapshot(`
-{
-  "data": {
-    "id": "fd61172c-cafc-40f5-b049-b45947779a29",
-    "object": "template",
-  },
-  "error": null,
-}
-`);
+    {
+      "data": {
+        "id": "fd61172c-cafc-40f5-b049-b45947779a29",
+        "object": "template",
+      },
+      "error": null,
+    }
+    `);
     });
 
     it('creates a template with some optional fields', async () => {
       const payload: CreateTemplateOptions = {
         name: 'Password Reset',
         subject: 'Reset your password',
-        html: '<h1>Reset your password</h1><p>Click the link below to reset your password.</p>',
+        html: '<h1>Reset your password, {{{username}}}</h1><p>Click the link below to reset your password: {{{reset_link}}}</p>',
+        text: 'Reset your password, {{{username}}}. Click here to reset: {{{reset_link}}}',
+        variables: [
+          {
+            key: 'username',
+            fallback_value: 'there',
+            type: 'string',
+          },
+          {
+            key: 'reset_link',
+            fallback_value: 'https://example.com/reset',
+            type: 'string',
+          },
+        ],
         alias: 'password-reset',
         from: 'security@example.com',
       };
@@ -126,14 +139,14 @@ describe('Templates', () => {
       await expect(
         resend.templates.create(payload),
       ).resolves.toMatchInlineSnapshot(`
-{
-  "data": {
-    "id": "ac7503ac-e027-4aea-94b3-b0acd46f65f9",
-    "object": "template",
-  },
-  "error": null,
-}
-`);
+    {
+      "data": {
+        "id": "ac7503ac-e027-4aea-94b3-b0acd46f65f9",
+        "object": "template",
+      },
+      "error": null,
+    }
+    `);
     });
 
     it('throws error when missing required name field', async () => {
@@ -159,14 +172,14 @@ describe('Templates', () => {
       const result = resend.templates.create(payload);
 
       await expect(result).resolves.toMatchInlineSnapshot(`
-{
-  "data": null,
-  "error": {
-    "message": "Missing \`name\` field",
-    "name": "missing_required_field",
-  },
-}
-`);
+    {
+      "data": null,
+      "error": {
+        "message": "Missing \`name\` field",
+        "name": "missing_required_field",
+      },
+    }
+    `);
     });
 
     it('throws error when missing required html field', async () => {
@@ -192,14 +205,14 @@ describe('Templates', () => {
       const result = resend.templates.create(payload);
 
       await expect(result).resolves.toMatchInlineSnapshot(`
-{
-  "data": null,
-  "error": {
-    "message": "Missing \`html\` field",
-    "name": "missing_required_field",
-  },
-}
-`);
+    {
+      "data": null,
+      "error": {
+        "message": "Missing \`html\` field",
+        "name": "missing_required_field",
+      },
+    }
+    `);
     });
 
     it('throws error when invalid email format in from field', async () => {
@@ -226,14 +239,14 @@ describe('Templates', () => {
       const result = resend.templates.create(payload);
 
       await expect(result).resolves.toMatchInlineSnapshot(`
-{
-  "data": null,
-  "error": {
-    "message": "Invalid email format in \`from\` field.",
-    "name": "invalid_parameter",
-  },
-}
-`);
+    {
+      "data": null,
+      "error": {
+        "message": "Invalid email format in \`from\` field.",
+        "name": "invalid_parameter",
+      },
+    }
+    `);
     });
 
     it('throws error when invalid email format in reply_to field', async () => {
@@ -260,14 +273,14 @@ describe('Templates', () => {
       const result = resend.templates.create(payload);
 
       await expect(result).resolves.toMatchInlineSnapshot(`
-{
-  "data": null,
-  "error": {
-    "message": "Invalid email format in \`reply_to\` field.",
-    "name": "invalid_parameter",
-  },
-}
-`);
+    {
+      "data": null,
+      "error": {
+        "message": "Invalid email format in \`reply_to\` field.",
+        "name": "invalid_parameter",
+      },
+    }
+    `);
     });
 
     it('throws error when invalid variable type', async () => {
@@ -301,14 +314,14 @@ describe('Templates', () => {
       const result = resend.templates.create(payload);
 
       await expect(result).resolves.toMatchInlineSnapshot(`
-{
-  "data": null,
-  "error": {
-    "message": "Invalid variable type. Must be one of: string, number, boolean.",
-    "name": "invalid_parameter",
-  },
-}
-`);
+    {
+      "data": null,
+      "error": {
+        "message": "Invalid variable type. Must be one of: string, number, boolean.",
+        "name": "invalid_parameter",
+      },
+    }
+    `);
     });
 
     it('throws error when variable key contains invalid characters', async () => {
@@ -342,14 +355,14 @@ describe('Templates', () => {
       const result = resend.templates.create(payload);
 
       await expect(result).resolves.toMatchInlineSnapshot(`
-{
-  "data": null,
-  "error": {
-    "message": "The \`variables, key\` field must only contain alphanumeric characters and underscores.",
-    "name": "validation_error",
-  },
-}
-`);
+    {
+      "data": null,
+      "error": {
+        "message": "The \`variables, key\` field must only contain alphanumeric characters and underscores.",
+        "name": "validation_error",
+      },
+    }
+    `);
     });
 
     it('throws error when variable is used in template but not defined', async () => {
@@ -383,14 +396,14 @@ describe('Templates', () => {
       const result = resend.templates.create(payload);
 
       await expect(result).resolves.toMatchInlineSnapshot(`
-{
-  "data": null,
-  "error": {
-    "message": "Variable 'user_email' is used in the template but not defined in the variables list",
-    "name": "validation_error",
-  },
-}
-`);
+    {
+      "data": null,
+      "error": {
+        "message": "Variable 'user_email' is used in the template but not defined in the variables list",
+        "name": "validation_error",
+      },
+    }
+    `);
     });
 
     it('throws error when name exceeds max length', async () => {
@@ -416,14 +429,14 @@ describe('Templates', () => {
       const result = resend.templates.create(payload);
 
       await expect(result).resolves.toMatchInlineSnapshot(`
-{
-  "data": null,
-  "error": {
-    "message": "The \`name\` field must not exceed 50 characters.",
-    "name": "validation_error",
-  },
-}
-`);
+    {
+      "data": null,
+      "error": {
+        "message": "The \`name\` field must not exceed 50 characters.",
+        "name": "validation_error",
+      },
+    }
+    `);
     });
 
     it('throws error when alias exceeds max length', async () => {
@@ -450,14 +463,14 @@ describe('Templates', () => {
       const result = resend.templates.create(payload);
 
       await expect(result).resolves.toMatchInlineSnapshot(`
-{
-  "data": null,
-  "error": {
-    "message": "The \`alias\` field must not exceed 50 characters.",
-    "name": "validation_error",
-  },
-}
-`);
+    {
+      "data": null,
+      "error": {
+        "message": "The \`alias\` field must not exceed 50 characters.",
+        "name": "validation_error",
+      },
+    }
+    `);
     });
 
     it('throws error when too many variables are provided', async () => {
@@ -489,14 +502,14 @@ describe('Templates', () => {
       const result = resend.templates.create(payload);
 
       await expect(result).resolves.toMatchInlineSnapshot(`
-{
-  "data": null,
-  "error": {
-    "message": "The \`variables\` field must not exceed 20 items.",
-    "name": "validation_error",
-  },
-}
-`);
+    {
+      "data": null,
+      "error": {
+        "message": "The \`variables\` field must not exceed 20 items.",
+        "name": "validation_error",
+      },
+    }
+    `);
     });
 
     it('throws error when too many reply_to addresses are provided', async () => {
@@ -523,6 +536,15 @@ describe('Templates', () => {
       const result = resend.templates.create(payload);
 
       await expect(result).resolves.toMatchInlineSnapshot(`
+    {
+      "data": null,
+      "error": {
+        "message": "The \`reply_to\` field must not exceed 50 items.",
+        "name": "validation_error",
+      },
+    }
+    `);
+    });
 
     it('creates template with reply_to as array', async () => {
       const payload: CreateTemplateOptions = {

--- a/src/templates/templates.spec.ts
+++ b/src/templates/templates.spec.ts
@@ -1,0 +1,561 @@
+import { enableFetchMocks } from 'jest-fetch-mock';
+import type { ErrorResponse } from '../interfaces';
+import { Resend } from '../resend';
+import type {
+  CreateTemplateOptions,
+  CreateTemplateResponseSuccess,
+} from './interfaces/create-template-options.interface';
+
+enableFetchMocks();
+
+describe('Templates', () => {
+  afterEach(() => fetchMock.resetMocks());
+
+  describe('create', () => {
+    it('creates a template with minimal required fields', async () => {
+      const payload: CreateTemplateOptions = {
+        name: 'Welcome Email',
+        html: '<h1>Welcome to our platform!</h1>',
+      };
+      const response: CreateTemplateResponseSuccess = {
+        object: 'template',
+        id: '3deaccfb-f47f-440a-8875-ea14b1716b43',
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+          Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      await expect(
+        resend.templates.create(payload),
+      ).resolves.toMatchInlineSnapshot(`
+{
+  "data": {
+    "id": "3deaccfb-f47f-440a-8875-ea14b1716b43",
+    "object": "template",
+  },
+  "error": null,
+}
+`);
+    });
+
+    it('creates a template with all optional fields', async () => {
+      const payload: CreateTemplateOptions = {
+        name: 'Welcome Email',
+        subject: 'Welcome to our platform',
+        html: '<h1>Welcome to our platform!</h1>',
+        text: 'Welcome to our platform!',
+        variables: [
+          {
+            key: 'name',
+            fallback_value: 'User',
+            type: 'string',
+          },
+          {
+            key: 'company',
+            fallback_value: 'Company',
+            type: 'string',
+          },
+        ],
+        alias: 'welcome-email',
+        from: 'noreply@example.com',
+        reply_to: ['support@example.com', 'help@example.com'],
+      };
+      const response: CreateTemplateResponseSuccess = {
+        object: 'template',
+        id: 'fd61172c-cafc-40f5-b049-b45947779a29',
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+          Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      await expect(
+        resend.templates.create(payload),
+      ).resolves.toMatchInlineSnapshot(`
+{
+  "data": {
+    "id": "fd61172c-cafc-40f5-b049-b45947779a29",
+    "object": "template",
+  },
+  "error": null,
+}
+`);
+    });
+
+    it('creates a template with some optional fields', async () => {
+      const payload: CreateTemplateOptions = {
+        name: 'Password Reset',
+        subject: 'Reset your password',
+        html: '<h1>Reset your password</h1><p>Click the link below to reset your password.</p>',
+        alias: 'password-reset',
+        from: 'security@example.com',
+      };
+      const response: CreateTemplateResponseSuccess = {
+        object: 'template',
+        id: 'ac7503ac-e027-4aea-94b3-b0acd46f65f9',
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+          Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      await expect(
+        resend.templates.create(payload),
+      ).resolves.toMatchInlineSnapshot(`
+{
+  "data": {
+    "id": "ac7503ac-e027-4aea-94b3-b0acd46f65f9",
+    "object": "template",
+  },
+  "error": null,
+}
+`);
+    });
+
+    it('throws error when missing required name field', async () => {
+      const payload: CreateTemplateOptions = {
+        name: '',
+        html: '<h1>Welcome!</h1>',
+      };
+      const response: ErrorResponse = {
+        name: 'missing_required_field',
+        message: 'Missing `name` field',
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 422,
+        headers: {
+          'content-type': 'application/json',
+          Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      const result = resend.templates.create(payload);
+
+      await expect(result).resolves.toMatchInlineSnapshot(`
+{
+  "data": null,
+  "error": {
+    "message": "Missing \`name\` field",
+    "name": "missing_required_field",
+  },
+}
+`);
+    });
+
+    it('throws error when missing required html field', async () => {
+      const payload: CreateTemplateOptions = {
+        name: 'Welcome Email',
+        html: '',
+      };
+      const response: ErrorResponse = {
+        name: 'missing_required_field',
+        message: 'Missing `html` field',
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 422,
+        headers: {
+          'content-type': 'application/json',
+          Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      const result = resend.templates.create(payload);
+
+      await expect(result).resolves.toMatchInlineSnapshot(`
+{
+  "data": null,
+  "error": {
+    "message": "Missing \`html\` field",
+    "name": "missing_required_field",
+  },
+}
+`);
+    });
+
+    it('throws error when invalid email format in from field', async () => {
+      const payload: CreateTemplateOptions = {
+        name: 'Welcome Email',
+        html: '<h1>Welcome!</h1>',
+        from: 'invalid-email',
+      };
+      const response: ErrorResponse = {
+        name: 'invalid_parameter',
+        message: 'Invalid email format in `from` field.',
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 422,
+        headers: {
+          'content-type': 'application/json',
+          Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      const result = resend.templates.create(payload);
+
+      await expect(result).resolves.toMatchInlineSnapshot(`
+{
+  "data": null,
+  "error": {
+    "message": "Invalid email format in \`from\` field.",
+    "name": "invalid_parameter",
+  },
+}
+`);
+    });
+
+    it('throws error when invalid email format in reply_to field', async () => {
+      const payload: CreateTemplateOptions = {
+        name: 'Welcome Email',
+        html: '<h1>Welcome!</h1>',
+        reply_to: ['valid@example.com', 'invalid-email'],
+      };
+      const response: ErrorResponse = {
+        name: 'invalid_parameter',
+        message: 'Invalid email format in `reply_to` field.',
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 422,
+        headers: {
+          'content-type': 'application/json',
+          Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      const result = resend.templates.create(payload);
+
+      await expect(result).resolves.toMatchInlineSnapshot(`
+{
+  "data": null,
+  "error": {
+    "message": "Invalid email format in \`reply_to\` field.",
+    "name": "invalid_parameter",
+  },
+}
+`);
+    });
+
+    it('throws error when invalid variable type', async () => {
+      const payload: CreateTemplateOptions = {
+        name: 'Welcome Email',
+        html: '<h1>Welcome!</h1>',
+        variables: [
+          {
+            key: 'count',
+            fallback_value: '0',
+            type: 'invalid_type' as 'string' | 'number' | 'boolean',
+          },
+        ],
+      };
+      const response: ErrorResponse = {
+        name: 'invalid_parameter',
+        message:
+          'Invalid variable type. Must be one of: string, number, boolean.',
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 422,
+        headers: {
+          'content-type': 'application/json',
+          Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      const result = resend.templates.create(payload);
+
+      await expect(result).resolves.toMatchInlineSnapshot(`
+{
+  "data": null,
+  "error": {
+    "message": "Invalid variable type. Must be one of: string, number, boolean.",
+    "name": "invalid_parameter",
+  },
+}
+`);
+    });
+
+    it('throws error when variable key contains invalid characters', async () => {
+      const payload: CreateTemplateOptions = {
+        name: 'Welcome Email',
+        html: '<h1>Welcome!</h1>',
+        variables: [
+          {
+            key: 'user-name', // Contains hyphen which is invalid
+            type: 'string',
+            fallback_value: 'Guest',
+          },
+        ],
+      };
+      const response: ErrorResponse = {
+        name: 'validation_error',
+        message:
+          'The `variables, key` field must only contain alphanumeric characters and underscores.',
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 422,
+        headers: {
+          'content-type': 'application/json',
+          Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      const result = resend.templates.create(payload);
+
+      await expect(result).resolves.toMatchInlineSnapshot(`
+{
+  "data": null,
+  "error": {
+    "message": "The \`variables, key\` field must only contain alphanumeric characters and underscores.",
+    "name": "validation_error",
+  },
+}
+`);
+    });
+
+    it('throws error when variable is used in template but not defined', async () => {
+      const payload: CreateTemplateOptions = {
+        name: 'Welcome Email',
+        html: '<h1>Welcome {{{user_email}}}!</h1>', // Uses undefined variable
+        variables: [
+          {
+            key: 'user_name',
+            type: 'string',
+            fallback_value: 'Guest',
+          },
+        ],
+      };
+      const response: ErrorResponse = {
+        name: 'validation_error',
+        message:
+          "Variable 'user_email' is used in the template but not defined in the variables list",
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 422,
+        headers: {
+          'content-type': 'application/json',
+          Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      const result = resend.templates.create(payload);
+
+      await expect(result).resolves.toMatchInlineSnapshot(`
+{
+  "data": null,
+  "error": {
+    "message": "Variable 'user_email' is used in the template but not defined in the variables list",
+    "name": "validation_error",
+  },
+}
+`);
+    });
+
+    it('throws error when name exceeds max length', async () => {
+      const payload: CreateTemplateOptions = {
+        name: 'A'.repeat(51), // Exceeds maxLength: 50
+        html: '<h1>Welcome!</h1>',
+      };
+      const response: ErrorResponse = {
+        name: 'validation_error',
+        message: 'The `name` field must not exceed 50 characters.',
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 422,
+        headers: {
+          'content-type': 'application/json',
+          Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      const result = resend.templates.create(payload);
+
+      await expect(result).resolves.toMatchInlineSnapshot(`
+{
+  "data": null,
+  "error": {
+    "message": "The \`name\` field must not exceed 50 characters.",
+    "name": "validation_error",
+  },
+}
+`);
+    });
+
+    it('throws error when alias exceeds max length', async () => {
+      const payload: CreateTemplateOptions = {
+        name: 'Welcome Email',
+        html: '<h1>Welcome!</h1>',
+        alias: 'A'.repeat(51), // Exceeds maxLength: 50
+      };
+      const response: ErrorResponse = {
+        name: 'validation_error',
+        message: 'The `alias` field must not exceed 50 characters.',
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 422,
+        headers: {
+          'content-type': 'application/json',
+          Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      const result = resend.templates.create(payload);
+
+      await expect(result).resolves.toMatchInlineSnapshot(`
+{
+  "data": null,
+  "error": {
+    "message": "The \`alias\` field must not exceed 50 characters.",
+    "name": "validation_error",
+  },
+}
+`);
+    });
+
+    it('throws error when too many variables are provided', async () => {
+      const payload: CreateTemplateOptions = {
+        name: 'Welcome Email',
+        html: '<h1>Welcome!</h1>',
+        variables: Array.from({ length: 21 }, (_, i) => ({
+          // Exceeds maxItems: 20
+          key: `var_${i}`,
+          type: 'string' as const,
+          fallback_value: 'default',
+        })),
+      };
+      const response: ErrorResponse = {
+        name: 'validation_error',
+        message: 'The `variables` field must not exceed 20 items.',
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 422,
+        headers: {
+          'content-type': 'application/json',
+          Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      const result = resend.templates.create(payload);
+
+      await expect(result).resolves.toMatchInlineSnapshot(`
+{
+  "data": null,
+  "error": {
+    "message": "The \`variables\` field must not exceed 20 items.",
+    "name": "validation_error",
+  },
+}
+`);
+    });
+
+    it('throws error when too many reply_to addresses are provided', async () => {
+      const payload: CreateTemplateOptions = {
+        name: 'Welcome Email',
+        html: '<h1>Welcome!</h1>',
+        reply_to: Array.from({ length: 51 }, (_, i) => `email${i}@example.com`), // Exceeds maxItems: 50
+      };
+      const response: ErrorResponse = {
+        name: 'validation_error',
+        message: 'The `reply_to` field must not exceed 50 items.',
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 422,
+        headers: {
+          'content-type': 'application/json',
+          Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      const result = resend.templates.create(payload);
+
+      await expect(result).resolves.toMatchInlineSnapshot(`
+{
+  "data": null,
+  "error": {
+    "message": "The \`reply_to\` field must not exceed 50 items.",
+    "name": "validation_error",
+  },
+}
+`);
+    });
+
+    it('creates template with reply_to as array', async () => {
+      const payload: CreateTemplateOptions = {
+        name: 'Welcome Email',
+        html: '<h1>Welcome!</h1>',
+        reply_to: ['support@example.com', 'noreply@example.com'],
+      };
+      const response: CreateTemplateResponseSuccess = {
+        object: 'template',
+        id: 'fd61172c-cafc-40f5-b049-b45947779a29',
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+          Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      await expect(
+        resend.templates.create(payload),
+      ).resolves.toMatchInlineSnapshot(`
+{
+  "data": {
+    "id": "fd61172c-cafc-40f5-b049-b45947779a29",
+    "object": "template",
+  },
+  "error": null,
+}
+`);
+    });
+  });
+});

--- a/src/templates/templates.ts
+++ b/src/templates/templates.ts
@@ -1,0 +1,20 @@
+import type { Resend } from '../resend';
+import type {
+  CreateTemplateOptions,
+  CreateTemplateResponse,
+  CreateTemplateResponseSuccess,
+} from './interfaces/create-template-options.interface';
+
+export class Templates {
+  constructor(private readonly resend: Resend) {}
+
+  async create(
+    payload: CreateTemplateOptions,
+  ): Promise<CreateTemplateResponse> {
+    const data = await this.resend.post<CreateTemplateResponseSuccess>(
+      '/templates',
+      payload,
+    );
+    return data;
+  }
+}

--- a/src/templates/templates.ts
+++ b/src/templates/templates.ts
@@ -6,11 +6,29 @@ import type {
 } from './interfaces/create-template-options.interface';
 
 export class Templates {
+  private renderAsync?: (component: React.ReactElement) => Promise<string>;
   constructor(private readonly resend: Resend) {}
 
   async create(
     payload: CreateTemplateOptions,
   ): Promise<CreateTemplateResponse> {
+    if (payload.react) {
+      if (!this.renderAsync) {
+        try {
+          const { renderAsync } = await import('@react-email/render');
+          this.renderAsync = renderAsync;
+        } catch (error) {
+          throw new Error(
+            'Failed to render React component. Make sure to install `@react-email/render`',
+          );
+        }
+      }
+
+      payload.html = await this.renderAsync(
+        payload.react as React.ReactElement,
+      );
+    }
+
     const data = await this.resend.post<CreateTemplateResponseSuccess>(
       '/templates',
       payload,


### PR DESCRIPTION
## Description
This PR implements the method for template creation. 
Worth mentioning that: besides HTML, it also supports React, as mentioned in the RFC

To support our current template syntax, and avoid users from ending up with a broken React code, the new.email approach to interpolations will be used ([this approach was suggested here](https://resend.slack.com/archives/C094Q028PK3/p1753889275450259?thread_ts=1753883774.546519&cid=C094Q028PK3))

Which means the code (for someone that will use React) will look something like the following:

Template code
```jsx
<Heading className="text-[24px] font-bold text-gray-900 mb-[16px]">
   Welcome to Your New Beginning, {props.employeeName}
</Heading>
```

SDK call in a node environment
```js
        const template = await resend.templates.create({
            name: "Welcome to Lumon",
            subject: "Welcome to Lumon Industries - Your journey begins now",
            react: React.createElement(LumonWelcomeEmail, {
                employeeName: "{{{employeeName}}}",
            }),
            variables: [
                { key: "employeeName", type: "string", fallback_value: "Mark S." },
            ]
        })
```



