### PR TITLE
refactor: add chainable operations

### DIFF
--- a/src/templates/chainable-template-result.ts
+++ b/src/templates/chainable-template-result.ts
@@ -1,0 +1,39 @@
+import type { CreateTemplateResponse } from './interfaces/create-template-options.interface';
+import type { DuplicateTemplateResponse } from './interfaces/duplicate-template.interface';
+import type { PublishTemplateResponse } from './interfaces/publish-template.interface';
+
+export class ChainableTemplateResult<
+  T extends CreateTemplateResponse | DuplicateTemplateResponse,
+> implements PromiseLike<T>
+{
+  constructor(
+    private readonly promise: Promise<T>,
+    private readonly publishFn: (
+      id: string,
+    ) => Promise<PublishTemplateResponse>,
+  ) {}
+
+  // If user calls `then` or only awaits for the result of create() or duplicate(), the behavior should be
+  // exactly as if they called create() or duplicate() directly. This will act as a normal promise
+
+  // biome-ignore lint/suspicious/noThenProperty: This class intentionally implements PromiseLike
+  then<TResult1 = T, TResult2 = never>(
+    onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+  ): PromiseLike<TResult1 | TResult2> {
+    return this.promise.then(onfulfilled, onrejected);
+  }
+
+  async publish(): Promise<PublishTemplateResponse | null> {
+    const { data, error } = await this.promise;
+
+    if (error) {
+      return {
+        data: null,
+        error,
+      };
+    }
+    const publishResult = await this.publishFn(data.id);
+    return publishResult;
+  }
+}

--- a/src/templates/templates.spec.ts
+++ b/src/templates/templates.spec.ts
@@ -524,11 +524,11 @@ describe('publish', () => {
 
     await expect(resend.templates.publish(id)).resolves.toMatchInlineSnapshot(`
 {
-"data": {
-  "id": "5262504e-8ed7-4fac-bd16-0d4be94bc9f2",
-  "object": "template",
-},
-"error": null,
+  "data": {
+    "id": "5262504e-8ed7-4fac-bd16-0d4be94bc9f2",
+    "object": "template",
+  },
+  "error": null,
 }
 `);
   });
@@ -552,12 +552,125 @@ describe('publish', () => {
 
     await expect(resend.templates.publish(id)).resolves.toMatchInlineSnapshot(`
 {
-"data": null,
-"error": {
-  "message": "Template not found",
-  "name": "not_found",
-},
+  "data": null,
+  "error": {
+    "message": "Template not found",
+    "name": "not_found",
+  },
 }
 `);
+  });
+
+  describe('chaining with create', () => {
+    it('chains create().publish() successfully', async () => {
+      const createResponse = {
+        object: 'template',
+        id: 'fd61172c-cafc-40f5-b049-b45947779a29',
+      };
+
+      const publishResponse = {
+        object: 'template',
+        id: 'fd61172c-cafc-40f5-b049-b45947779a29',
+      };
+
+      // Mock create request
+      fetchMock.mockOnceIf(
+        (req) => req.url.includes('/templates') && !req.url.includes('publish'),
+        JSON.stringify(createResponse),
+        {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+            Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+          },
+        },
+      );
+
+      // Mock publish request
+      fetchMock.mockOnceIf(
+        (req) => req.url.includes('/templates') && req.url.includes('publish'),
+        JSON.stringify(publishResponse),
+        {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+            Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+          },
+        },
+      );
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      await expect(
+        resend.templates
+          .create({
+            name: 'Welcome Email',
+            html: '<h1>Welcome!</h1>',
+          })
+          .publish(),
+      ).resolves.toMatchInlineSnapshot(`
+{
+  "data": {
+    "id": "fd61172c-cafc-40f5-b049-b45947779a29",
+    "object": "template",
+  },
+  "error": null,
+}
+`);
+    });
+  });
+
+  describe('chaining with duplicate', () => {
+    it('chains duplicate().publish() successfully', async () => {
+      const duplicateResponse = {
+        object: 'template',
+        id: 'new-template-id-123',
+      };
+
+      const publishResponse = {
+        object: 'template',
+        id: 'new-template-id-123',
+      };
+
+      // Mock duplicate request
+      fetchMock.mockOnceIf(
+        (req) => req.url.includes('/duplicate'),
+        JSON.stringify(duplicateResponse),
+        {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+            Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+          },
+        },
+      );
+
+      // Mock publish request
+      fetchMock.mockOnceIf(
+        (req) => req.url.includes('/publish'),
+        JSON.stringify(publishResponse),
+        {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+            Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+          },
+        },
+      );
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      await expect(
+        resend.templates.duplicate('original-template-id').publish(),
+      ).resolves.toMatchInlineSnapshot(`
+{
+  "data": {
+    "id": "new-template-id-123",
+    "object": "template",
+  },
+  "error": null,
+}
+`);
+    });
   });
 });

--- a/src/templates/templates.ts
+++ b/src/templates/templates.ts
@@ -1,4 +1,5 @@
 import type { Resend } from '../resend';
+import { ChainableTemplateResult } from './chainable-template-result';
 import type {
   CreateTemplateOptions,
   CreateTemplateResponse,
@@ -25,7 +26,17 @@ export class Templates {
   private renderAsync?: (component: React.ReactElement) => Promise<string>;
   constructor(private readonly resend: Resend) {}
 
-  async create(
+  create(
+    payload: CreateTemplateOptions,
+  ): ChainableTemplateResult<CreateTemplateResponse> {
+    const createPromise = this.performCreate(payload);
+    return new ChainableTemplateResult(createPromise, this.publish.bind(this));
+  }
+  // This creation process is being done separately from the public create so that
+  // the user can chain the publish operation after the create operation. Otherwise, due
+  // to the async nature of the renderAsync, the return type would be
+  // Promise<ChainableTemplateResult<CreateTemplateResponse>> which wouldn't be chainable.
+  private async performCreate(
     payload: CreateTemplateOptions,
   ): Promise<CreateTemplateResponse> {
     if (payload.react) {
@@ -45,11 +56,10 @@ export class Templates {
       );
     }
 
-    const data = await this.resend.post<CreateTemplateResponseSuccess>(
+    return this.resend.post<CreateTemplateResponseSuccess>(
       '/templates',
       payload,
     );
-    return data;
   }
 
   async remove(identifier: string): Promise<RemoveTemplateResponse> {
@@ -66,11 +76,16 @@ export class Templates {
     return data;
   }
 
-  async duplicate(identifier: string): Promise<DuplicateTemplateResponse> {
-    const data = await this.resend.post<DuplicateTemplateResponseSuccess>(
+  duplicate(
+    identifier: string,
+  ): ChainableTemplateResult<DuplicateTemplateResponse> {
+    const promiseDuplicate = this.resend.post<DuplicateTemplateResponseSuccess>(
       `/templates/${identifier}/duplicate`,
     );
-    return data;
+    return new ChainableTemplateResult(
+      promiseDuplicate,
+      this.publish.bind(this),
+    );
   }
 
   async publish(identifier: string): Promise<PublishTemplateResponse> {


### PR DESCRIPTION
## Description

In order to achieve something like was [described here](https://github.com/resend/resend-node/pull/574#pullrequestreview-3137421322):

> In order to make the experience of using our SDK smoother, what do you think of implementing additional methods for `create`, `update`, and `duplicate`? I was thinking of something like this:

> ### Create
> ```ts
> await resend.templates.create(/** ... */).publish()
> ```
> 
> ### Update
> ```ts
> await resend.templates.update(/** ... */).publish()
> ```
> 
> ### Duplicate
> ```ts
> await resend.templates.duplicate(/** ... */).publish()
> ```
> 
> Instead of having to call the SDK twice for these operations, like:
> ```ts
> await resend.templates.create(/** ... */);
> await resend.templates.publish(/** ... */);
> ```
> 
> What do you think?

A new class `ChainableTemplateResult` was introduced. It uses PromiseLike to support the native Promise behavior while also enhancing the behavior of the Promise by adding the `publish` method to it.
The method `publish` can now be chained after the `create` and `duplicate` methods are executed. 
(Although the chaining is possible is not required, users that only use `create()` or `duplicate()` won't be affected)    