### PR TITLE
feat: add update template method

### DIFF
--- a/src/templates/interfaces/create-template-options.interface.ts
+++ b/src/templates/interfaces/create-template-options.interface.ts
@@ -8,11 +8,18 @@ type TemplateContentCreationOptions = RequireAtLeastOne<{
   react: React.ReactNode;
 }>;
 
+type TemplateVariableCreationOptions = Pick<
+  TemplateVariable,
+  'key' | 'type'
+> & {
+  fallback_value?: string | number | boolean | null;
+};
+
 type TemplateOptionalFieldsForCreation = Partial<
   Pick<Template, 'subject' | 'text' | 'alias' | 'from' | 'reply_to'>
 > & {
-  variables?: Pick<TemplateVariable, 'key' | 'fallback_value' | 'type'>[];
   reply_to?: string[] | string;
+  variables?: TemplateVariableCreationOptions[];
 };
 
 export type CreateTemplateOptions = Pick<Template, 'name'> &

--- a/src/templates/interfaces/template.ts
+++ b/src/templates/interfaces/template.ts
@@ -16,7 +16,7 @@ export interface Template {
 
 export interface TemplateVariable {
   key: string;
-  fallback_value: string | null;
+  fallback_value: string | number | boolean | null;
   type: 'string' | 'number' | 'boolean';
   created_at: string;
   updated_at: string;

--- a/src/templates/interfaces/update-template.interface.ts
+++ b/src/templates/interfaces/update-template.interface.ts
@@ -1,0 +1,30 @@
+import type { ErrorResponse } from '../../interfaces';
+import type { Template, TemplateVariable } from './template';
+
+type TemplateVariableUpdateOptions = Pick<TemplateVariable, 'key' | 'type'> & {
+  fallback_value?: string | number | boolean | null;
+};
+
+export interface UpdateTemplateOptions
+  extends Partial<
+    Pick<
+      Template,
+      'name' | 'subject' | 'html' | 'text' | 'from' | 'reply_to' | 'alias'
+    >
+  > {
+  variables?: TemplateVariableUpdateOptions[];
+}
+
+export interface UpdateTemplateResponseSuccess extends Pick<Template, 'id'> {
+  object: 'template';
+}
+
+export type UpdateTemplateResponse =
+  | {
+      data: UpdateTemplateResponseSuccess;
+      error: null;
+    }
+  | {
+      data: null;
+      error: ErrorResponse;
+    };

--- a/src/templates/templates.spec.ts
+++ b/src/templates/templates.spec.ts
@@ -6,6 +6,7 @@ import type {
   CreateTemplateResponseSuccess,
 } from './interfaces/create-template-options.interface';
 import type { GetTemplateResponseSuccess } from './interfaces/get-template.interface';
+import type { UpdateTemplateOptions } from './interfaces/update-template.interface';
 
 enableFetchMocks();
 
@@ -389,6 +390,124 @@ describe('Templates', () => {
 
       await expect(
         resend.templates.duplicate(id),
+      ).resolves.toMatchInlineSnapshot(`
+{
+  "data": null,
+  "error": {
+    "message": "Template not found",
+    "name": "not_found",
+  },
+}
+`);
+    });
+  });
+
+  describe('update', () => {
+    it('updates a template with minimal fields', async () => {
+      const id = '5262504e-8ed7-4fac-bd16-0d4be94bc9f2';
+      const payload: UpdateTemplateOptions = {
+        name: 'Updated Welcome Email',
+      };
+      const response = {
+        object: 'template',
+        id,
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+          Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      await expect(
+        resend.templates.update(id, payload),
+      ).resolves.toMatchInlineSnapshot(`
+{
+  "data": {
+    "id": "5262504e-8ed7-4fac-bd16-0d4be94bc9f2",
+    "object": "template",
+  },
+  "error": null,
+}
+`);
+    });
+
+    it('updates a template with all optional fields', async () => {
+      const id = 'fd61172c-cafc-40f5-b049-b45947779a29';
+      const payload: UpdateTemplateOptions = {
+        name: 'Updated Welcome Email',
+        subject: 'Updated Welcome to our platform',
+        html: '<h1>Updated Welcome to our platform, {{{name}}}!</h1><p>We are excited to have you join {{{company}}}.</p>',
+        text: 'Updated Welcome to our platform, {{{name}}}! We are excited to have you join {{{company}}}.',
+        variables: [
+          {
+            key: 'name',
+            fallback_value: 'User',
+            type: 'string',
+          },
+          {
+            key: 'company',
+            type: 'string',
+          },
+        ],
+        alias: 'updated-welcome-email',
+        from: 'updated@example.com',
+        reply_to: ['updated-support@example.com'],
+      };
+      const response = {
+        object: 'template',
+        id,
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+          Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      await expect(
+        resend.templates.update(id, payload),
+      ).resolves.toMatchInlineSnapshot(`
+{
+  "data": {
+    "id": "fd61172c-cafc-40f5-b049-b45947779a29",
+    "object": "template",
+  },
+  "error": null,
+}
+`);
+    });
+
+    it('throws error when template not found', async () => {
+      const id = '5262504e-8ed7-4fac-bd16-0d4be94bc9f2';
+      const payload: UpdateTemplateOptions = {
+        name: 'Updated Welcome Email',
+      };
+      const response: ErrorResponse = {
+        name: 'not_found',
+        message: 'Template not found',
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 404,
+        headers: {
+          'content-type': 'application/json',
+          Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      await expect(
+        resend.templates.update(id, payload),
       ).resolves.toMatchInlineSnapshot(`
 {
   "data": null,

--- a/src/templates/templates.ts
+++ b/src/templates/templates.ts
@@ -22,6 +22,11 @@ import type {
   RemoveTemplateResponse,
   RemoveTemplateResponseSuccess,
 } from './interfaces/remove-template.interface';
+import type {
+  UpdateTemplateOptions,
+  UpdateTemplateResponse,
+  UpdateTemplateResponseSuccess,
+} from './interfaces/update-template.interface';
 
 export class Templates {
   private renderAsync?: (component: React.ReactElement) => Promise<string>;
@@ -77,6 +82,17 @@ export class Templates {
   async duplicate(identifier: string): Promise<DuplicateTemplateResponse> {
     const data = await this.resend.post<DuplicateTemplateResponseSuccess>(
       `/templates/${identifier}/duplicate`,
+    );
+    return data;
+  }
+
+  async update(
+    identifier: string,
+    payload: UpdateTemplateOptions,
+  ): Promise<UpdateTemplateResponse> {
+    const data = await this.resend.patch<UpdateTemplateResponseSuccess>(
+      `/templates/${identifier}`,
+      payload,
     );
     return data;
   }


### PR DESCRIPTION
Besides the method addition itself, this PR also adds two minor changes:
- Fix the expected `fallback_value` type during Template creation
- Moves the `get` template testing block inside the `Templates` block
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add Templates.update() to patch existing templates and return the updated template id. Also fixes the variable fallback_value type and reorganizes tests under the Templates block.

- New Features
  - Added templates.update(id, payload) using PATCH /templates/:id.
  - Introduced UpdateTemplateOptions/Response types; supports name, subject, html, text, from, reply_to, alias, and variables (key, type, optional fallback_value).
  - Added tests for minimal update, full update, and not-found error.

<!-- End of auto-generated description by cubic. -->

