### PR TITLE
feat: discussion/issue templates

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/help.yml
+++ b/.github/DISCUSSION_TEMPLATE/help.yml
@@ -1,0 +1,20 @@
+body:
+  - type: textarea
+    attributes:
+      label: Summary
+      description: What do you need help with?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional information
+      description: Any code snippets, error messages, or dependency details that may be related?
+      render: js
+    validations:
+      required: false
+  - type: input
+    attributes:
+      label: Example
+      description: A link to a minimal reproduction is helpful for collaborative debugging!
+    validations:
+      required: false

--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -1,0 +1,23 @@
+body:
+  - type: textarea
+    attributes:
+      label: Goals
+      description: Short list of what the feature request aims to address?
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Background
+      description: Discuss prior art, why do you think this feature is needed? Are there current alternatives?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Proposal
+      description: How should this feature be implemented? Are you interested in contributing?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/1.bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report.yml
@@ -1,0 +1,39 @@
+name: Bug Report
+description: Create a bug report for the Node SDK
+labels: ["Type: Bug"]
+body:
+  - type: textarea
+    attributes:
+      label: Describe the Bug
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Link to the code that reproduces this issue
+      description: |
+        A link to a GitHub repository minimal reproduction. A minimal reproduction code is really helpful to understand the issue.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: To Reproduce
+      description: Steps to reproduce the behavior, please provide a clear description of how to reproduce the issue, based on the linked minimal reproduction. Screenshots can be provided in the issue body below. If using code blocks, make sure that [syntax highlighting is correct](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#syntax-highlighting) and double check that the rendered preview is not broken.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: A clear and concise description of what you expected to happen.
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: Before posting the issue go through the steps you've written down to make sure the steps provided are detailed and clear.
+  - type: markdown
+    attributes:
+      value: Contributors should be able to follow the steps provided in order to reproduce the bug.
+  - type: input
+    attributes:
+      label: What's your node version? (if relevant)
+      description: "Please specify the exact version."

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ask a question
+    url: https://github.com/resend/react-email/discussions
+    about: Ask questions and discuss with other community members
+  - name: Feature request
+    url: https://github.com/resend/react-email/discussions/new?category=ideas
+    about: Feature requests should be opened as discussions

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Ask a question
-    url: https://github.com/resend/react-email/discussions
+    url: https://github.com/resend/resend-node/discussions
     about: Ask questions and discuss with other community members
   - name: Feature request
-    url: https://github.com/resend/react-email/discussions/new?category=ideas
+    url: https://github.com/resend/resend-node/discussions/new?category=ideas
     about: Feature requests should be opened as discussions


### PR DESCRIPTION
Adds in the same issue and discussion templates as we already have for [React Email](https://github.com/resend/react-email/tree/canary/.github)

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add GitHub issue and discussion templates to standardize bug reports and guide questions/feature requests to Discussions. Mirrors the React Email templates for consistency.

- **New Features**
  - Discussion templates: Help and Ideas with structured prompts.
  - Issue template: Bug Report with required fields and Node version.
  - Config: Disable blank issues; add contact links to Discussions.

<!-- End of auto-generated description by cubic. -->

