### PR TITLE
chore: temporarily remove docker container credentials

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: buildjet-4vcpu-ubuntu-2204
     container:
       image: node:20
-      credentials:
-        username: ${{ vars.DOCKER_HUB_USERNAME || '' }}
-        password: ${{ secrets.DOCKER_HUB_API_KEY || '' }}
+      # credentials:
+      #   username: ${{ vars.DOCKER_HUB_USERNAME || '' }}
+      #   password: ${{ secrets.DOCKER_HUB_API_KEY || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pin-dependencies-check.yml
+++ b/.github/workflows/pin-dependencies-check.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: buildjet-4vcpu-ubuntu-2204
     container:
       image: node:20
-      credentials:
-        username: ${{ vars.DOCKER_HUB_USERNAME || '' }}
-        password: ${{ secrets.DOCKER_HUB_API_KEY || '' }}
+      # credentials:
+      #   username: ${{ vars.DOCKER_HUB_USERNAME || '' }}
+      #   password: ${{ secrets.DOCKER_HUB_API_KEY || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: buildjet-4vcpu-ubuntu-2204
     container:
       image: node:20
-      credentials:
-        username: ${{ vars.DOCKER_HUB_USERNAME || '' }}
-        password: ${{ secrets.DOCKER_HUB_API_KEY || '' }}
+      # credentials:
+      #   username: ${{ vars.DOCKER_HUB_USERNAME || '' }}
+      #   password: ${{ secrets.DOCKER_HUB_API_KEY || '' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: buildjet-4vcpu-ubuntu-2204
     container:
       image: node:23
-      credentials:
-        username: ${{ vars.DOCKER_HUB_USERNAME || '' }}
-        password: ${{ secrets.DOCKER_HUB_API_KEY || '' }}
+      # credentials:
+      #   username: ${{ vars.DOCKER_HUB_USERNAME || '' }}
+      #   password: ${{ secrets.DOCKER_HUB_API_KEY || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This pull request removes the `credentials` field in all of our workflows. We
originally included this so that we could avoid getting rate limited by Docker
Hub's API, because they rate limit our anonymous requests. 

But, it seems like the workflow files become invalid YML when running without
the secret and var for our Docker Hub, specifically on contributor forks. This
means that we basically aren't able to run our CI on pull requests from the
community. 

I've tried to solve this by conditionally including the credentials, but the
syntax that GitHub provides us is simply not enough for this. The single thing
that works is having multiple workflows that check for having the secret and
var to run with/without the credentials, but that gets really messy when
running. 

So, after trying a myriad of solutions, it seemed simpler for me to just remove
these temporarily so that we can review things from the community while we
don't get this into a better shape. 

Here's one pull requests that we can't merge without bypassing the merging rules: #540 