### PR TITLE
feat: add list method

### DIFF
--- a/src/common/interfaces/list-option.interface.ts
+++ b/src/common/interfaces/list-option.interface.ts
@@ -2,3 +2,13 @@ export interface List<T> {
   readonly object: 'list';
   data: T[];
 }
+
+export interface PaginatedList<T> extends List<T> {
+  has_more: boolean;
+}
+
+export interface PaginationOptions {
+  before?: string | null;
+  after?: string | null;
+  limit?: number | null;
+}

--- a/src/common/utils/get-pagination-query-properties.spec.ts
+++ b/src/common/utils/get-pagination-query-properties.spec.ts
@@ -1,0 +1,38 @@
+import { getPaginationQueryProperties } from './get-pagination-query-properties';
+
+describe('getPaginationQueryProperties', () => {
+  it('returns empty string when no options provided', () => {
+    expect(getPaginationQueryProperties()).toBe('');
+    expect(getPaginationQueryProperties({})).toBe('');
+  });
+
+  it('builds query string with single parameter', () => {
+    expect(getPaginationQueryProperties({ before: 'cursor1' })).toBe(
+      '?before=cursor1',
+    );
+    expect(getPaginationQueryProperties({ after: 'cursor2' })).toBe(
+      '?after=cursor2',
+    );
+    expect(getPaginationQueryProperties({ limit: 10 })).toBe('?limit=10');
+  });
+
+  it('builds query string with multiple parameters', () => {
+    const result = getPaginationQueryProperties({
+      before: 'cursor1',
+      after: 'cursor2',
+      limit: 25,
+    });
+
+    expect(result).toBe('?before=cursor1&after=cursor2&limit=25');
+  });
+
+  it('ignores undefined/null values', () => {
+    expect(
+      getPaginationQueryProperties({
+        before: undefined,
+        after: 'cursor2',
+        limit: null,
+      }),
+    ).toBe('?after=cursor2');
+  });
+});

--- a/src/common/utils/get-pagination-query-properties.ts
+++ b/src/common/utils/get-pagination-query-properties.ts
@@ -1,0 +1,13 @@
+import type { PaginationOptions } from '../interfaces';
+
+export function getPaginationQueryProperties(
+  options: PaginationOptions = {},
+): string {
+  const query = new URLSearchParams();
+
+  if (options.before) query.set('before', options.before);
+  if (options.after) query.set('after', options.after);
+  if (options.limit) query.set('limit', options.limit.toString());
+
+  return query.size > 0 ? `?${query.toString()}` : '';
+}

--- a/src/templates/interfaces/list-templates.interface.ts
+++ b/src/templates/interfaces/list-templates.interface.ts
@@ -1,0 +1,28 @@
+import type { PaginatedList } from '../../common/interfaces';
+import type { ErrorResponse } from '../../interfaces';
+import type { Template } from './template';
+
+interface TemplateListItem
+  extends Pick<
+    Template,
+    | 'id'
+    | 'name'
+    | 'created_at'
+    | 'updated_at'
+    | 'status'
+    | 'published_at'
+    | 'alias'
+  > {}
+
+export interface ListTemplatesResponseSuccess
+  extends PaginatedList<TemplateListItem> {}
+
+export type ListTemplatesResponse =
+  | {
+      data: ListTemplatesResponseSuccess;
+      error: null;
+    }
+  | {
+      data: null;
+      error: ErrorResponse;
+    };

--- a/src/templates/templates.spec.ts
+++ b/src/templates/templates.spec.ts
@@ -635,14 +635,12 @@ describe('Templates', () => {
 `);
 
       // Verify the request was made with correct query parameters
-      expect(fetchMock).toHaveBeenCalledWith(
-        expect.stringMatching(
-          /^https?:\/\/[^\/]+\/templates\?before=cursor123&limit=10$/,
-        ),
-        expect.objectContaining({
-          method: 'GET',
-        }),
-      );
+      const [url] = fetchMock.mock.calls[0];
+      const parsedUrl = new URL(url as string);
+
+      expect(parsedUrl.pathname).toBe('/templates');
+      expect(parsedUrl.searchParams.get('before')).toBe('cursor123');
+      expect(parsedUrl.searchParams.get('limit')).toBe('10');
     });
 
     it('handles all pagination options', async () => {
@@ -669,14 +667,13 @@ describe('Templates', () => {
       });
 
       // Verify all pagination parameters are included
-      expect(fetchMock).toHaveBeenCalledWith(
-        expect.stringMatching(
-          /^https?:\/\/[^\/]+\/templates\?before=cursor1&after=cursor2&limit=25$/,
-        ),
-        expect.objectContaining({
-          method: 'GET',
-        }),
-      );
+      const [url] = fetchMock.mock.calls[0];
+      const parsedUrl = new URL(url as string);
+
+      expect(parsedUrl.pathname).toBe('/templates');
+      expect(parsedUrl.searchParams.get('before')).toBe('cursor1');
+      expect(parsedUrl.searchParams.get('after')).toBe('cursor2');
+      expect(parsedUrl.searchParams.get('limit')).toBe('25');
     });
   });
 });

--- a/src/templates/templates.spec.ts
+++ b/src/templates/templates.spec.ts
@@ -14,6 +14,8 @@ jest.mock('@react-email/render', () => ({
   renderAsync: mockRenderAsync,
 }));
 
+const TEST_API_KEY = 're_test_api_key';
+
 describe('Templates', () => {
   afterEach(() => {
     jest.resetAllMocks();
@@ -35,11 +37,11 @@ describe('Templates', () => {
         status: 200,
         headers: {
           'content-type': 'application/json',
-          Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+          Authorization: `Bearer ${TEST_API_KEY}`,
         },
       });
 
-      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      const resend = new Resend(TEST_API_KEY);
       await expect(
         resend.templates.create(payload),
       ).resolves.toMatchInlineSnapshot(`
@@ -84,11 +86,11 @@ describe('Templates', () => {
         status: 200,
         headers: {
           'content-type': 'application/json',
-          Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+          Authorization: `Bearer ${TEST_API_KEY}`,
         },
       });
 
-      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      const resend = new Resend(TEST_API_KEY);
       await expect(
         resend.templates.create(payload),
       ).resolves.toMatchInlineSnapshot(`
@@ -124,11 +126,11 @@ describe('Templates', () => {
         status: 422,
         headers: {
           'content-type': 'application/json',
-          Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+          Authorization: `Bearer ${TEST_API_KEY}`,
         },
       });
 
-      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      const resend = new Resend(TEST_API_KEY);
 
       const result = resend.templates.create(payload);
 
@@ -165,11 +167,11 @@ describe('Templates', () => {
         status: 200,
         headers: {
           'content-type': 'application/json',
-          Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+          Authorization: `Bearer ${TEST_API_KEY}`,
         },
       });
 
-      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      const resend = new Resend(TEST_API_KEY);
       await expect(
         resend.templates.create(payload),
       ).resolves.toMatchInlineSnapshot(`
@@ -231,11 +233,11 @@ describe('Templates', () => {
         status: 200,
         headers: {
           'content-type': 'application/json',
-          Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+          Authorization: `Bearer ${TEST_API_KEY}`,
         },
       });
 
-      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      const resend = new Resend(TEST_API_KEY);
       await expect(
         resend.templates.create(payload),
       ).resolves.toMatchInlineSnapshot(`
@@ -269,7 +271,7 @@ describe('Templates', () => {
         react: mockReactComponent,
       };
 
-      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      const resend = new Resend(TEST_API_KEY);
 
       await expect(resend.templates.create(payload)).rejects.toThrow(
         'Failed to render React component. Make sure to install `@react-email/render`',
@@ -290,11 +292,11 @@ describe('Templates', () => {
         status: 200,
         headers: {
           'content-type': 'application/json',
-          Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+          Authorization: `Bearer ${TEST_API_KEY}`,
         },
       });
 
-      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      const resend = new Resend(TEST_API_KEY);
 
       await expect(resend.templates.remove(id)).resolves.toMatchInlineSnapshot(`
 {
@@ -319,11 +321,11 @@ describe('Templates', () => {
         status: 404,
         headers: {
           'content-type': 'application/json',
-          Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+          Authorization: `Bearer ${TEST_API_KEY}`,
         },
       });
 
-      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      const resend = new Resend(TEST_API_KEY);
 
       await expect(resend.templates.remove(id)).resolves.toMatchInlineSnapshot(`
 {
@@ -349,11 +351,11 @@ describe('Templates', () => {
         status: 200,
         headers: {
           'content-type': 'application/json',
-          Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+          Authorization: `Bearer ${TEST_API_KEY}`,
         },
       });
 
-      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      const resend = new Resend(TEST_API_KEY);
 
       await expect(
         resend.templates.duplicate(id),
@@ -379,11 +381,11 @@ describe('Templates', () => {
         status: 404,
         headers: {
           'content-type': 'application/json',
-          Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+          Authorization: `Bearer ${TEST_API_KEY}`,
         },
       });
 
-      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      const resend = new Resend(TEST_API_KEY);
 
       await expect(
         resend.templates.duplicate(id),
@@ -398,108 +400,108 @@ describe('Templates', () => {
 `);
     });
   });
-});
 
-describe('get', () => {
-  describe('when template not found', () => {
-    it('returns error', async () => {
-      const response: ErrorResponse = {
-        name: 'not_found',
-        message: 'Template not found',
+  describe('get', () => {
+    describe('when template not found', () => {
+      it('returns error', async () => {
+        const response: ErrorResponse = {
+          name: 'not_found',
+          message: 'Template not found',
+        };
+
+        fetchMock.mockOnce(JSON.stringify(response), {
+          status: 404,
+          headers: {
+            'content-type': 'application/json',
+            Authorization: `Bearer ${TEST_API_KEY}`,
+          },
+        });
+
+        const resend = new Resend(TEST_API_KEY);
+
+        await expect(
+          resend.templates.get('non-existent-id'),
+        ).resolves.toMatchInlineSnapshot(`
+  {
+    "data": null,
+    "error": {
+      "message": "Template not found",
+      "name": "not_found",
+    },
+  }
+  `);
+      });
+    });
+
+    it('get template', async () => {
+      const response: GetTemplateResponseSuccess = {
+        object: 'template',
+        id: 'fd61172c-cafc-40f5-b049-b45947779a29',
+        name: 'Welcome Email',
+        created_at: '2025-08-19 19:28:27.947052+00',
+        updated_at: '2025-08-19 19:28:27.947052+00',
+        html: '<h1>Welcome!</h1>',
+        text: 'Welcome!',
+        subject: 'Welcome to our platform',
+        status: 'published',
+        alias: 'welcome-email',
+        from: 'noreply@example.com',
+        reply_to: ['support@example.com'],
+        published_at: '2025-08-19 19:28:27.947052+00',
+        variables: [
+          {
+            key: 'name',
+            type: 'string',
+            fallback_value: 'User',
+            created_at: '2025-08-19 19:28:27.947052+00',
+            updated_at: '2025-08-19 19:28:27.947052+00',
+          },
+        ],
       };
 
       fetchMock.mockOnce(JSON.stringify(response), {
-        status: 404,
+        status: 200,
         headers: {
           'content-type': 'application/json',
-          Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+          Authorization: `Bearer ${TEST_API_KEY}`,
         },
       });
 
-      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      const resend = new Resend(TEST_API_KEY);
 
       await expect(
-        resend.templates.get('non-existent-id'),
+        resend.templates.get('fd61172c-cafc-40f5-b049-b45947779a29'),
       ).resolves.toMatchInlineSnapshot(`
-{
-  "data": null,
-  "error": {
-    "message": "Template not found",
-    "name": "not_found",
-  },
-}
-`);
-    });
-  });
-
-  it('get template', async () => {
-    const response: GetTemplateResponseSuccess = {
-      object: 'template',
-      id: 'fd61172c-cafc-40f5-b049-b45947779a29',
-      name: 'Welcome Email',
-      created_at: '2025-08-19 19:28:27.947052+00',
-      updated_at: '2025-08-19 19:28:27.947052+00',
-      html: '<h1>Welcome!</h1>',
-      text: 'Welcome!',
-      subject: 'Welcome to our platform',
-      status: 'published',
-      alias: 'welcome-email',
-      from: 'noreply@example.com',
-      reply_to: ['support@example.com'],
-      published_at: '2025-08-19 19:28:27.947052+00',
-      variables: [
+  {
+    "data": {
+      "alias": "welcome-email",
+      "created_at": "2025-08-19 19:28:27.947052+00",
+      "from": "noreply@example.com",
+      "html": "<h1>Welcome!</h1>",
+      "id": "fd61172c-cafc-40f5-b049-b45947779a29",
+      "name": "Welcome Email",
+      "object": "template",
+      "published_at": "2025-08-19 19:28:27.947052+00",
+      "reply_to": [
+        "support@example.com",
+      ],
+      "status": "published",
+      "subject": "Welcome to our platform",
+      "text": "Welcome!",
+      "updated_at": "2025-08-19 19:28:27.947052+00",
+      "variables": [
         {
-          key: 'name',
-          type: 'string',
-          fallback_value: 'User',
-          created_at: '2025-08-19 19:28:27.947052+00',
-          updated_at: '2025-08-19 19:28:27.947052+00',
+          "created_at": "2025-08-19 19:28:27.947052+00",
+          "fallback_value": "User",
+          "key": "name",
+          "type": "string",
+          "updated_at": "2025-08-19 19:28:27.947052+00",
         },
       ],
-    };
-
-    fetchMock.mockOnce(JSON.stringify(response), {
-      status: 200,
-      headers: {
-        'content-type': 'application/json',
-        Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
-      },
+    },
+    "error": null,
+  }
+  `);
     });
-
-    const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
-
-    await expect(
-      resend.templates.get('fd61172c-cafc-40f5-b049-b45947779a29'),
-    ).resolves.toMatchInlineSnapshot(`
-{
-  "data": {
-    "alias": "welcome-email",
-    "created_at": "2025-08-19 19:28:27.947052+00",
-    "from": "noreply@example.com",
-    "html": "<h1>Welcome!</h1>",
-    "id": "fd61172c-cafc-40f5-b049-b45947779a29",
-    "name": "Welcome Email",
-    "object": "template",
-    "published_at": "2025-08-19 19:28:27.947052+00",
-    "reply_to": [
-      "support@example.com",
-    ],
-    "status": "published",
-    "subject": "Welcome to our platform",
-    "text": "Welcome!",
-    "updated_at": "2025-08-19 19:28:27.947052+00",
-    "variables": [
-      {
-        "created_at": "2025-08-19 19:28:27.947052+00",
-        "fallback_value": "User",
-        "key": "name",
-        "type": "string",
-        "updated_at": "2025-08-19 19:28:27.947052+00",
-      },
-    ],
-  },
-  "error": null,
-}
-`);
   });
 });

--- a/src/templates/templates.spec.ts
+++ b/src/templates/templates.spec.ts
@@ -504,4 +504,179 @@ describe('Templates', () => {
   `);
     });
   });
+
+  describe('list', () => {
+    it('lists templates without pagination options', async () => {
+      const response = {
+        object: 'list',
+        has_more: false,
+        data: [
+          {
+            id: 'fd61172c-cafc-40f5-b049-b45947779a29',
+            name: 'Welcome Email',
+            created_at: '2023-04-07T23:13:52.669661+00:00',
+            updated_at: '2023-04-07T23:13:52.669661+00:00',
+            status: 'published',
+            alias: 'welcome-email',
+            published_at: '2023-04-07T23:13:52.669661+00:00',
+          },
+          {
+            id: 'b6d24b8e-af0b-4c3c-be0c-359bbd97381e',
+            name: 'Newsletter Template',
+            created_at: '2023-04-06T20:10:30.417116+00:00',
+            updated_at: '2023-04-06T20:10:30.417116+00:00',
+            status: 'draft',
+            alias: 'newsletter',
+            published_at: null,
+          },
+        ],
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+          Authorization: `Bearer ${TEST_API_KEY}`,
+        },
+      });
+
+      const resend = new Resend(TEST_API_KEY);
+
+      await expect(resend.templates.list()).resolves.toMatchInlineSnapshot(`
+{
+  "data": {
+    "data": [
+      {
+        "alias": "welcome-email",
+        "created_at": "2023-04-07T23:13:52.669661+00:00",
+        "id": "fd61172c-cafc-40f5-b049-b45947779a29",
+        "name": "Welcome Email",
+        "published_at": "2023-04-07T23:13:52.669661+00:00",
+        "status": "published",
+        "updated_at": "2023-04-07T23:13:52.669661+00:00",
+      },
+      {
+        "alias": "newsletter",
+        "created_at": "2023-04-06T20:10:30.417116+00:00",
+        "id": "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
+        "name": "Newsletter Template",
+        "published_at": null,
+        "status": "draft",
+        "updated_at": "2023-04-06T20:10:30.417116+00:00",
+      },
+    ],
+    "has_more": false,
+    "object": "list",
+  },
+  "error": null,
+}
+`);
+
+      // Verify the request was made without query parameters
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringMatching(/^https?:\/\/[^\/]+\/templates$/),
+        expect.objectContaining({
+          method: 'GET',
+        }),
+      );
+    });
+
+    it('lists templates with pagination options', async () => {
+      const response = {
+        object: 'list',
+        has_more: true,
+        data: [
+          {
+            id: 'fd61172c-cafc-40f5-b049-b45947779a29',
+            name: 'Welcome Email',
+            created_at: '2023-04-07T23:13:52.669661+00:00',
+            updated_at: '2023-04-07T23:13:52.669661+00:00',
+            status: 'published',
+            alias: 'welcome-email',
+            published_at: '2023-04-07T23:13:52.669661+00:00',
+          },
+        ],
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+          Authorization: `Bearer ${TEST_API_KEY}`,
+        },
+      });
+
+      const resend = new Resend(TEST_API_KEY);
+
+      await expect(
+        resend.templates.list({
+          before: 'cursor123',
+          limit: 10,
+        }),
+      ).resolves.toMatchInlineSnapshot(`
+{
+  "data": {
+    "data": [
+      {
+        "alias": "welcome-email",
+        "created_at": "2023-04-07T23:13:52.669661+00:00",
+        "id": "fd61172c-cafc-40f5-b049-b45947779a29",
+        "name": "Welcome Email",
+        "published_at": "2023-04-07T23:13:52.669661+00:00",
+        "status": "published",
+        "updated_at": "2023-04-07T23:13:52.669661+00:00",
+      },
+    ],
+    "has_more": true,
+    "object": "list",
+  },
+  "error": null,
+}
+`);
+
+      // Verify the request was made with correct query parameters
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /^https?:\/\/[^\/]+\/templates\?before=cursor123&limit=10$/,
+        ),
+        expect.objectContaining({
+          method: 'GET',
+        }),
+      );
+    });
+
+    it('handles all pagination options', async () => {
+      const response = {
+        object: 'list',
+        has_more: false,
+        data: [],
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+          Authorization: `Bearer ${TEST_API_KEY}`,
+        },
+      });
+
+      const resend = new Resend(TEST_API_KEY);
+
+      await resend.templates.list({
+        before: 'cursor1',
+        after: 'cursor2',
+        limit: 25,
+      });
+
+      // Verify all pagination parameters are included
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /^https?:\/\/[^\/]+\/templates\?before=cursor1&after=cursor2&limit=25$/,
+        ),
+        expect.objectContaining({
+          method: 'GET',
+        }),
+      );
+    });
+  });
 });

--- a/src/templates/templates.ts
+++ b/src/templates/templates.ts
@@ -1,3 +1,5 @@
+import type { PaginationOptions } from '../common/interfaces';
+import { getPaginationQueryProperties } from '../common/utils/get-pagination-query-properties';
 import type { Resend } from '../resend';
 import type {
   CreateTemplateOptions,
@@ -12,6 +14,10 @@ import type {
   GetTemplateResponse,
   GetTemplateResponseSuccess,
 } from './interfaces/get-template.interface';
+import type {
+  ListTemplatesResponse,
+  ListTemplatesResponseSuccess,
+} from './interfaces/list-templates.interface';
 import type {
   RemoveTemplateResponse,
   RemoveTemplateResponseSuccess,
@@ -60,6 +66,12 @@ export class Templates {
       `/templates/${identifier}`,
     );
     return data;
+  }
+
+  async list(options: PaginationOptions = {}): Promise<ListTemplatesResponse> {
+    return this.resend.get<ListTemplatesResponseSuccess>(
+      `/templates${getPaginationQueryProperties(options)}`,
+    );
   }
 
   async duplicate(identifier: string): Promise<DuplicateTemplateResponse> {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds Templates.list() to fetch templates with cursor-based pagination. Introduces shared pagination types and a query builder util to build query params.

- New Features
  - Added Templates.list(options?: PaginationOptions) using getPaginationQueryProperties; returns PaginatedList of templates with before/after/limit support.
  - Introduced PaginatedList, PaginationOptions, and ListTemplatesResponse types.

- Refactors
  - Consolidated tests under Templates block, standardized a TEST_API_KEY, and added unit tests for pagination util and list/get behavior (including query param assertions).

<!-- End of auto-generated description by cubic. -->

