### PR TITLE
chore: lint

### DIFF
--- a/.github/scripts/check-pinned-dependencies.mjs
+++ b/.github/scripts/check-pinned-dependencies.mjs
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+
 const pkg = JSON.parse(await fs.promises.readFile('package.json', 'utf8'));
 const errors = [];
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fix linter error in .github/scripts/check-pinned-dependencies.mjs by adding a newline after the import to match our formatting rules. Keeps CI lint checks passing and aligns the script with our code style.

<!-- End of auto-generated description by cubic. -->

