### PR TITLE
feat: export new Response type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,5 +21,8 @@ export * from './domains/interfaces/update-domain.interface';
 export * from './domains/interfaces/verify-domain.interface';
 export * from './emails/interfaces/create-email-options.interface';
 export * from './emails/interfaces/get-email-options.interface';
-export { ErrorResponse } from './interfaces';
+export {
+  ErrorResponse,
+  Response,
+} from './interfaces';
 export { Resend } from './resend';


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Expose the Response type from the package entrypoint so consumers can import it directly alongside ErrorResponse. This improves DX and lets apps type responses without deep imports.

<!-- End of auto-generated description by cubic. -->

