### PR TITLE
fix: preview releases workflow

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -27,13 +27,14 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Run Build
         run: pnpm build
-      - name: Find changed packages
-        id: changed_packages
+      - name: Find changed files
+        id: changed_files
+        if: github.event_name == 'pull_request'
         uses: tj-actions/changed-files@2036da178f85576f1940fedb74bb93a36cd89ab7
         with:
           files: src/**
           dir_names: true
           dir_names_max_depth: 2
       - name: Publish changed packages to pkg.pr.new
-        if: steps.changed_packages.outputs.all_changed_and_modified_files != ''
+        if: github.event_name == 'push' || steps.changed_files.outputs.all_changed_and_modified_files != ''
         run: pnpm dlx pkg-pr-new publish


### PR DESCRIPTION
This pull requests changes the preview release workflow so that the changed-files step only runs on `pull_request` events and not on push ones, which [it doesn't support](https://github.com/resend/resend-node/actions/runs/17158782422/job/48682398565).

It also changes the actual preview release step so that it always runs on `push` events.
