### PR TITLE
feat: adds permissive mode for batch API

### DIFF
--- a/src/batch/batch.ts
+++ b/src/batch/batch.ts
@@ -52,6 +52,15 @@ export class Batch {
       options,
     );
 
+    // If the permissive header is not set, remove errors to maintain backward compatibility
+    if (data.data && options.headers?.['x-batch-validation'] !== 'permissive') {
+      const { errors, ...dataWithoutErrors } = data.data;
+      return {
+        ...data,
+        data: dataWithoutErrors,
+      };
+    }
+
     return data;
   }
 }

--- a/src/batch/interfaces/create-batch-options.interface.ts
+++ b/src/batch/interfaces/create-batch-options.interface.ts
@@ -14,6 +14,12 @@ export interface CreateBatchSuccessResponse {
     /** The ID of the newly created email. */
     id: string;
   }[];
+  errors?: { // Only present when header "x-batch-validation" is present.
+    // The index of the failed email in the batch
+    index: number;
+    // The error message for the failed email
+    message: string;
+  }[] | null;
 }
 
 export type CreateBatchResponse = Response<CreateBatchSuccessResponse>;

--- a/src/common/interfaces/post-option.interface.ts
+++ b/src/common/interfaces/post-option.interface.ts
@@ -1,3 +1,4 @@
 export interface PostOptions {
   query?: { [key: string]: unknown };
+  headers?: { [key: string]: string };
 }

--- a/src/test-utils/mock-fetch.ts
+++ b/src/test-utils/mock-fetch.ts
@@ -63,6 +63,20 @@ export function mockSuccessResponse<T>(
 }
 
 /**
+ * Mock successful response with a custom status code
+ */
+export function mockSuccessWithStatusCode<T>(
+  data: T,
+  status: number,
+  options: MockFetchOptions = {},
+): void {
+  mockFetchWithRateLimit(JSON.stringify(data), {
+    status,
+    ...options,
+  });
+}
+
+/**
  * Mock error response with rate limiting headers
  */
 export function mockErrorResponse(


### PR DESCRIPTION
This PR is related to this [feature](https://github.com/resend/resend-api/pull/2025).

Basically it should allow to call batch API with header `x-batch-validation`.
If the header value is `permissive`, it should expect to receive a field `errors` with `data`.
This should *NOT* cause a breaking change.

For that, if no header is provided, we guarantee that no field `errors` will be returned.