### PR TITLE
chore: bump to 6.1.0-canary.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.1.0-canary.0",
+  "version": "6.1.0-canary.1",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
Bumping due to #510

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Bump package version to 6.1.0-canary.1 to release the changes from #510 on the canary channel.

<!-- End of auto-generated description by cubic. -->

