### PR TITLE
fix: wrong syntax in rendering template note

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -119,7 +119,7 @@ console.log(`Email ${data.id} with a React template has been sent`);
 ```
 
 > [!NOTE]
-> If your endpoint is a JS/TS file, render the template (i.e., pass `EmailTemplate({firstName="John", product="MyApp"})` instead of the component).
+> If your endpoint is a JS/TS file, render the template (i.e., pass `EmailTemplate({ firstName: "John", product: "MyApp" })` instead of the component).
 
 ## License
 


### PR DESCRIPTION
    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Corrects the README note example for rendering a template in JS/TS endpoints. Replaces `EmailTemplate({firstName="John", product="MyApp"})` with `EmailTemplate({ firstName: "John", product: "MyApp" })` to use valid object syntax.

<!-- End of auto-generated description by cubic. -->

