### PR TITLE
feat: specific option to pass in the header, and type-safe definition based on the option

### DIFF
--- a/src/batch/batch.spec.ts
+++ b/src/batch/batch.spec.ts
@@ -1,3 +1,4 @@
+/** biome-ignore-all lint/style/noNonNullAssertion: <explanation> */
 import { Resend } from '../resend';
 import {
   mockSuccessResponse,
@@ -35,18 +36,20 @@ describe('Batch', () => {
           html: '<h1>Hi there</h1>',
         },
       ];
-      const response: CreateBatchSuccessResponse = {
-        data: [
-          { id: 'aabeeefc-bd13-474a-a440-0ee139b3a4cc' },
-          { id: 'aebe1c6e-30ad-4257-993b-519f5affa626' },
-          { id: 'b2bc2598-f98b-4da4-86c9-7b32881ef394' },
-        ],
-      };
-      mockSuccessResponse(response, {
-        headers: {
-          Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+      mockSuccessResponse(
+        {
+          data: [
+            { id: 'aabeeefc-bd13-474a-a440-0ee139b3a4cc' },
+            { id: 'aebe1c6e-30ad-4257-993b-519f5affa626' },
+            { id: 'b2bc2598-f98b-4da4-86c9-7b32881ef394' },
+          ],
         },
-      });
+        {
+          headers: {
+            Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+          },
+        },
+      );
 
       const data = await resend.batch.create(payload);
       expect(data).toMatchInlineSnapshot(`
@@ -75,19 +78,20 @@ describe('Batch', () => {
     });
 
     it('does not send the Idempotency-Key header when idempotencyKey is not provided', async () => {
-      const response: CreateBatchSuccessResponse = {
-        data: [
-          {
-            id: 'not-idempotent-123',
-          },
-        ],
-      };
-
-      mockSuccessResponse(response, {
-        headers: {
-          Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+      mockSuccessResponse(
+        {
+          data: [
+            {
+              id: 'not-idempotent-123',
+            },
+          ],
         },
-      });
+        {
+          headers: {
+            Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+          },
+        },
+      );
 
       const payload: CreateBatchOptions = [
         {
@@ -114,19 +118,20 @@ describe('Batch', () => {
     });
 
     it('sends the Idempotency-Key header when idempotencyKey is provided', async () => {
-      const response: CreateBatchSuccessResponse = {
-        data: [
-          {
-            id: 'idempotent-123',
-          },
-        ],
-      };
-
-      mockSuccessResponse(response, {
-        headers: {
-          Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+      mockSuccessResponse(
+        {
+          data: [
+            {
+              id: 'idempotent-123',
+            },
+          ],
         },
-      });
+        {
+          headers: {
+            Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+          },
+        },
+      );
 
       const payload: CreateBatchOptions = [
         {
@@ -303,22 +308,24 @@ describe('Batch', () => {
       expect(usedIdempotencyKey).toBe(idempotencyKey);
     });
 
-    it('handles batch response with errors field when permissive header is set', async () => {
-      const response: CreateBatchSuccessResponse = {
-        data: [],
-        errors: [{ index: 2, message: 'Invalid email address' }],
-      };
-
-      mockSuccessWithStatusCode(response, 202, {
-        headers: {
-          Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+    it('handles batch response with errors field when permissive option is set', async () => {
+      mockSuccessWithStatusCode(
+        {
+          data: [],
+          errors: [{ index: 2, message: 'Invalid email address' }],
         },
-      });
+        202,
+        {
+          headers: {
+            Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+          },
+        },
+      );
 
       const payload: CreateBatchOptions = [];
 
       const result = await resend.batch.create(payload, {
-        headers: { 'x-batch-validation': 'permissive' },
+        batchValidation: 'permissive',
       });
 
       // Verify the header was passed correctly
@@ -336,20 +343,20 @@ describe('Batch', () => {
     });
 
     it('removes errors field when permissive header is not set (backward compatibility)', async () => {
-      const apiResponse: CreateBatchSuccessResponse = {
-        data: [
-          { id: 'success-email-1' },
-          { id: 'success-email-2' },
-          { id: 'success-email-3' },
-        ],
-        errors: null,
-      };
-
-      mockSuccessResponse(apiResponse, {
-        headers: {
-          Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+      mockSuccessResponse(
+        {
+          data: [
+            { id: 'success-email-1' },
+            { id: 'success-email-2' },
+            { id: 'success-email-3' },
+          ],
         },
-      });
+        {
+          headers: {
+            Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+          },
+        },
+      );
 
       const payload: CreateBatchOptions = [
         {
@@ -372,10 +379,10 @@ describe('Batch', () => {
         },
       ];
 
-      const result = await resend.batch.create(payload);
+      const response = await resend.batch.create(payload);
       // Should not have errors field for backward compatibility
-      expect(result.data?.errors).toBeUndefined();
-      expect(result.data?.data).toEqual([
+      expect(response.data!).not.toHaveProperty('errors');
+      expect(response.data!.data).toEqual([
         { id: 'success-email-1' },
         { id: 'success-email-2' },
         { id: 'success-email-3' },

--- a/src/batch/batch.spec.ts
+++ b/src/batch/batch.spec.ts
@@ -1,13 +1,9 @@
-/** biome-ignore-all lint/style/noNonNullAssertion: <explanation> */
 import { Resend } from '../resend';
 import {
   mockSuccessResponse,
   mockSuccessWithStatusCode,
 } from '../test-utils/mock-fetch';
-import type {
-  CreateBatchOptions,
-  CreateBatchSuccessResponse,
-} from './interfaces/create-batch-options.interface';
+import type { CreateBatchOptions } from './interfaces/create-batch-options.interface';
 
 const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
 
@@ -185,19 +181,21 @@ describe('Batch', () => {
           html: '<h1>Hi there</h1>',
         },
       ];
-      const response: CreateBatchSuccessResponse = {
-        data: [
-          { id: 'aabeeefc-bd13-474a-a440-0ee139b3a4cc' },
-          { id: 'aebe1c6e-30ad-4257-993b-519f5affa626' },
-          { id: 'b2bc2598-f98b-4da4-86c9-7b32881ef394' },
-        ],
-      };
 
-      mockSuccessResponse(response, {
-        headers: {
-          Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+      mockSuccessResponse(
+        {
+          data: [
+            { id: 'aabeeefc-bd13-474a-a440-0ee139b3a4cc' },
+            { id: 'aebe1c6e-30ad-4257-993b-519f5affa626' },
+            { id: 'b2bc2598-f98b-4da4-86c9-7b32881ef394' },
+          ],
         },
-      });
+        {
+          headers: {
+            Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+          },
+        },
+      );
 
       const data = await resend.batch.send(payload);
       expect(data).toMatchInlineSnapshot(`
@@ -226,19 +224,20 @@ describe('Batch', () => {
     });
 
     it('does not send the Idempotency-Key header when idempotencyKey is not provided', async () => {
-      const response: CreateBatchSuccessResponse = {
-        data: [
-          {
-            id: 'not-idempotent-123',
-          },
-        ],
-      };
-
-      mockSuccessResponse(response, {
-        headers: {
-          Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+      mockSuccessResponse(
+        {
+          data: [
+            {
+              id: 'not-idempotent-123',
+            },
+          ],
         },
-      });
+        {
+          headers: {
+            Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+          },
+        },
+      );
 
       const payload: CreateBatchOptions = [
         {
@@ -265,19 +264,20 @@ describe('Batch', () => {
     });
 
     it('sends the Idempotency-Key header when idempotencyKey is provided', async () => {
-      const response: CreateBatchSuccessResponse = {
-        data: [
-          {
-            id: 'idempotent-123',
-          },
-        ],
-      };
-
-      mockSuccessResponse(response, {
-        headers: {
-          Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+      mockSuccessResponse(
+        {
+          data: [
+            {
+              id: 'idempotent-123',
+            },
+          ],
         },
-      });
+        {
+          headers: {
+            Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+          },
+        },
+      );
 
       const payload: CreateBatchOptions = [
         {
@@ -294,18 +294,15 @@ describe('Batch', () => {
       // Inspect the last fetch call and body
       const lastCall = fetchMock.mock.calls[0];
       expect(lastCall).toBeDefined();
+      console.log(lastCall[1].headers);
 
       // Check if headers contains Idempotency-Key
       // In the mock, headers is an object with key-value pairs
       expect(fetchMock.mock.calls[0][1]?.headers).toBeDefined();
 
-      //@ts-expect-error
-      const hasIdempotencyKey = lastCall[1]?.headers.has('Idempotency-Key');
-      expect(hasIdempotencyKey).toBeTruthy();
+      expect(lastCall[1]?.headers).toHaveProperty('Idempotency-Key');
 
-      //@ts-expect-error
-      const usedIdempotencyKey = lastCall[1]?.headers.get('Idempotency-Key');
-      expect(usedIdempotencyKey).toBe(idempotencyKey);
+      expect(lastCall[1]?.headers['Idempotency-Key']).toBe(idempotencyKey);
     });
 
     it('handles batch response with errors field when permissive option is set', async () => {
@@ -381,8 +378,8 @@ describe('Batch', () => {
 
       const response = await resend.batch.create(payload);
       // Should not have errors field for backward compatibility
-      expect(response.data!).not.toHaveProperty('errors');
-      expect(response.data!.data).toEqual([
+      expect(response.data).not.toHaveProperty('errors');
+      expect(response.data?.data).toEqual([
         { id: 'success-email-1' },
         { id: 'success-email-2' },
         { id: 'success-email-3' },

--- a/src/batch/batch.spec.ts
+++ b/src/batch/batch.spec.ts
@@ -104,13 +104,11 @@ describe('Batch', () => {
       const lastCall = fetchMock.mock.calls[0];
       expect(lastCall).toBeDefined();
 
-      //@ts-expect-error
-      const hasIdempotencyKey = lastCall[1]?.headers.has('Idempotency-Key');
-      expect(hasIdempotencyKey).toBeFalsy();
+      const request = lastCall[1];
+      expect(request).toBeDefined();
 
-      //@ts-expect-error
-      const usedIdempotencyKey = lastCall[1]?.headers.get('Idempotency-Key');
-      expect(usedIdempotencyKey).toBeNull();
+      const headers = new Headers(request?.headers);
+      expect(headers.has('Idempotency-Key')).toBeFalsy();
     });
 
     it('sends the Idempotency-Key header when idempotencyKey is provided', async () => {
@@ -253,14 +251,10 @@ describe('Batch', () => {
       // Inspect the last fetch call and body
       const lastCall = fetchMock.mock.calls[0];
       expect(lastCall).toBeDefined();
-
-      //@ts-expect-error
-      const hasIdempotencyKey = lastCall[1]?.headers.has('Idempotency-Key');
-      expect(hasIdempotencyKey).toBeFalsy();
-
-      //@ts-expect-error
-      const usedIdempotencyKey = lastCall[1]?.headers.get('Idempotency-Key');
-      expect(usedIdempotencyKey).toBeNull();
+      const request = lastCall[1];
+      expect(request).toBeDefined();
+      const headers = new Headers(request?.headers);
+      expect(headers.has('Idempotency-Key')).toBe(false);
     });
 
     it('sends the Idempotency-Key header when idempotencyKey is provided', async () => {
@@ -294,15 +288,9 @@ describe('Batch', () => {
       // Inspect the last fetch call and body
       const lastCall = fetchMock.mock.calls[0];
       expect(lastCall).toBeDefined();
-      console.log(lastCall[1].headers);
-
-      // Check if headers contains Idempotency-Key
-      // In the mock, headers is an object with key-value pairs
-      expect(fetchMock.mock.calls[0][1]?.headers).toBeDefined();
-
-      expect(lastCall[1]?.headers).toHaveProperty('Idempotency-Key');
-
-      expect(lastCall[1]?.headers['Idempotency-Key']).toBe(idempotencyKey);
+      const headers = new Headers(lastCall[1]?.headers);
+      expect(headers.has('Idempotency-Key')).toBeTruthy();
+      expect(headers.get('Idempotency-Key')).toBe(idempotencyKey);
     });
 
     it('handles batch response with errors field when permissive option is set', async () => {
@@ -328,9 +316,10 @@ describe('Batch', () => {
       // Verify the header was passed correctly
       const lastCall = fetchMock.mock.calls[0];
       expect(lastCall).toBeDefined();
-      expect(lastCall[1]?.headers).toBeDefined();
-      //@ts-expect-error: checking custom header in mock
-      expect(lastCall[1]?.headers['x-batch-validation']).toBe('permissive');
+      const request = lastCall[1];
+      expect(request).toBeDefined();
+      const headers = new Headers(request?.headers);
+      expect(headers.get('x-batch-validation')).toBe('permissive');
 
       expect(result.data).toEqual({
         data: [],

--- a/src/batch/batch.ts
+++ b/src/batch/batch.ts
@@ -14,7 +14,7 @@ export class Batch {
 
   async send<Options extends CreateBatchRequestOptions>(
     payload: CreateBatchOptions,
-    options: CreateBatchRequestOptions = {},
+    options: Options = {} as unknown as Options,
   ): Promise<CreateBatchResponse<Options>> {
     return this.create(payload, options);
   }

--- a/src/batch/batch.ts
+++ b/src/batch/batch.ts
@@ -14,14 +14,14 @@ export class Batch {
 
   async send<Options extends CreateBatchRequestOptions>(
     payload: CreateBatchOptions,
-    options: Options = {} as unknown as Options,
+    options?: Options,
   ): Promise<CreateBatchResponse<Options>> {
     return this.create(payload, options);
   }
 
   async create<Options extends CreateBatchRequestOptions>(
     payload: CreateBatchOptions,
-    options: Options = {} as unknown as Options,
+    options?: Options,
   ): Promise<CreateBatchResponse<Options>> {
     const emails: EmailApiOptions[] = [];
 
@@ -51,8 +51,8 @@ export class Batch {
       {
         ...options,
         headers: {
-          'x-batch-validation': options.batchValidation ?? 'strict',
-          ...options.headers,
+          'x-batch-validation': options?.batchValidation ?? 'strict',
+          ...options?.headers,
         },
       },
     );

--- a/src/batch/batch.ts
+++ b/src/batch/batch.ts
@@ -1,4 +1,3 @@
-import type * as React from 'react';
 import type { EmailApiOptions } from '../common/interfaces/email-api-options.interface';
 import { parseEmailToApiOptions } from '../common/utils/parse-email-to-api-options';
 import type { Resend } from '../resend';
@@ -13,17 +12,17 @@ export class Batch {
   private renderAsync?: (component: React.ReactElement) => Promise<string>;
   constructor(private readonly resend: Resend) {}
 
-  async send(
+  async send<Options extends CreateBatchRequestOptions>(
     payload: CreateBatchOptions,
     options: CreateBatchRequestOptions = {},
-  ): Promise<CreateBatchResponse> {
+  ): Promise<CreateBatchResponse<Options>> {
     return this.create(payload, options);
   }
 
-  async create(
+  async create<Options extends CreateBatchRequestOptions>(
     payload: CreateBatchOptions,
-    options: CreateBatchRequestOptions = {},
-  ): Promise<CreateBatchResponse> {
+    options: Options = {} as unknown as Options,
+  ): Promise<CreateBatchResponse<Options>> {
     const emails: EmailApiOptions[] = [];
 
     for (const email of payload) {
@@ -46,20 +45,17 @@ export class Batch {
       emails.push(parseEmailToApiOptions(email));
     }
 
-    const data = await this.resend.post<CreateBatchSuccessResponse>(
+    const data = await this.resend.post<CreateBatchSuccessResponse<Options>>(
       '/emails/batch',
       emails,
-      options,
+      {
+        ...options,
+        headers: {
+          'x-batch-validation': options.batchValidation ?? 'strict',
+          ...options.headers,
+        },
+      },
     );
-
-    // If the permissive header is not set, remove errors to maintain backward compatibility
-    if (data.data && options.headers?.['x-batch-validation'] !== 'permissive') {
-      const { errors: _errors, ...dataWithoutErrors } = data.data;
-      return {
-        ...data,
-        data: dataWithoutErrors,
-      };
-    }
 
     return data;
   }

--- a/src/batch/interfaces/create-batch-options.interface.ts
+++ b/src/batch/interfaces/create-batch-options.interface.ts
@@ -7,22 +7,37 @@ export type CreateBatchOptions = CreateEmailOptions[];
 
 export interface CreateBatchRequestOptions
   extends PostOptions,
-    IdempotentRequest {}
+    IdempotentRequest {
+  /**
+   * @default 'strict'
+   */
+  batchValidation?: 'strict' | 'permissive';
+}
 
-export interface CreateBatchSuccessResponse {
+export type CreateBatchSuccessResponse<
+  Options extends CreateBatchRequestOptions,
+> = {
   data: {
     /** The ID of the newly created email. */
     id: string;
   }[];
-  errors?:
-    | {
-        // Only present when header "x-batch-validation" is present.
-        // The index of the failed email in the batch
+} & (Options['batchValidation'] extends 'permissive'
+  ? {
+      /**
+       * Only present when header "x-batch-validation" is present.
+       */
+      errors: {
+        /**
+         * The index of the failed email in the batch
+         */
         index: number;
-        // The error message for the failed email
+        /**
+         * The error message for the failed email
+         */
         message: string;
-      }[]
-    | null;
-}
+      }[]; // This always being an array depends on us doing https://github.com/resend/resend-api/pull/2025/files#r2303897690
+    }
+  : Record<string, never>);
 
-export type CreateBatchResponse = Response<CreateBatchSuccessResponse>;
+export type CreateBatchResponse<Options extends CreateBatchRequestOptions> =
+  Response<CreateBatchSuccessResponse<Options>>;

--- a/src/batch/interfaces/create-batch-options.interface.ts
+++ b/src/batch/interfaces/create-batch-options.interface.ts
@@ -24,7 +24,7 @@ export type CreateBatchSuccessResponse<
 } & (Options['batchValidation'] extends 'permissive'
   ? {
       /**
-       * Only present when header "x-batch-validation" is present.
+       * Only present when header "x-batch-validation" is set to 'permissive'.
        */
       errors: {
         /**

--- a/src/batch/interfaces/create-batch-options.interface.ts
+++ b/src/batch/interfaces/create-batch-options.interface.ts
@@ -15,7 +15,7 @@ export interface CreateBatchRequestOptions
 }
 
 export type CreateBatchSuccessResponse<
-  Options extends CreateBatchRequestOptions,
+  Options extends CreateBatchRequestOptions = CreateBatchRequestOptions,
 > = {
   data: {
     /** The ID of the newly created email. */

--- a/src/common/interfaces/get-option.interface.ts
+++ b/src/common/interfaces/get-option.interface.ts
@@ -1,3 +1,4 @@
 export interface GetOptions {
   query?: Record<string, unknown>;
+  headers?: HeadersInit;
 }

--- a/src/common/interfaces/patch-option.interface.ts
+++ b/src/common/interfaces/patch-option.interface.ts
@@ -1,3 +1,4 @@
 export interface PatchOptions {
   query?: { [key: string]: unknown };
+  headers?: HeadersInit;
 }

--- a/src/common/interfaces/post-option.interface.ts
+++ b/src/common/interfaces/post-option.interface.ts
@@ -1,4 +1,4 @@
 export interface PostOptions {
   query?: { [key: string]: unknown };
-  headers?: { [key: string]: string };
+  headers?: HeadersInit;
 }

--- a/src/common/interfaces/put-option.interface.ts
+++ b/src/common/interfaces/put-option.interface.ts
@@ -1,3 +1,4 @@
 export interface PutOptions {
   query?: { [key: string]: unknown };
+  headers?: HeadersInit;
 }

--- a/src/emails/emails.spec.ts
+++ b/src/emails/emails.spec.ts
@@ -70,14 +70,11 @@ describe('Emails', () => {
       // Inspect the last fetch call and body
       const lastCall = fetchMock.mock.calls[0];
       expect(lastCall).toBeDefined();
+      const request = lastCall[1];
+      expect(request).toBeDefined();
 
-      //@ts-expect-error
-      const hasIdempotencyKey = lastCall[1]?.headers.has('Idempotency-Key');
-      expect(hasIdempotencyKey).toBeFalsy();
-
-      //@ts-expect-error
-      const usedIdempotencyKey = lastCall[1]?.headers.get('Idempotency-Key');
-      expect(usedIdempotencyKey).toBeNull();
+      const headers = new Headers(request?.headers);
+      expect(headers.has('Idempotency-Key')).toBe(false);
     });
 
     it('sends the Idempotency-Key header when idempotencyKey is provided', async () => {
@@ -105,17 +102,9 @@ describe('Emails', () => {
       const lastCall = fetchMock.mock.calls[0];
       expect(lastCall).toBeDefined();
 
-      // Check if headers contains Idempotency-Key
-      // In the mock, headers is an object with key-value pairs
-      expect(fetchMock.mock.calls[0][1]?.headers).toBeDefined();
-
-      //@ts-expect-error
-      const hasIdempotencyKey = lastCall[1]?.headers.has('Idempotency-Key');
-      expect(hasIdempotencyKey).toBeTruthy();
-
-      //@ts-expect-error
-      const usedIdempotencyKey = lastCall[1]?.headers.get('Idempotency-Key');
-      expect(usedIdempotencyKey).toBe(idempotencyKey);
+      const headers = new Headers(lastCall[1]?.headers);
+      expect(headers.has('Idempotency-Key')).toBe(true);
+      expect(headers.get('Idempotency-Key')).toBe(idempotencyKey);
     });
   });
 

--- a/src/resend.ts
+++ b/src/resend.ts
@@ -120,17 +120,17 @@ export class Resend {
     entity?: unknown,
     options: PostOptions & IdempotentRequest = {},
   ) {
-    const headers = new Headers(this.headers);
-
-    if (options.idempotencyKey) {
-      headers.set('Idempotency-Key', options.idempotencyKey);
-    }
-
     const requestOptions = {
       method: 'POST',
-      headers: headers,
       body: JSON.stringify(entity),
       ...options,
+      headers: new Headers({
+        ...this.headers,
+        ...options.headers,
+        ...(options.idempotencyKey && {
+          'Idempotency-Key': options.idempotencyKey,
+        }),
+      }),
     };
 
     return this.fetchRequest<T>(path, requestOptions);
@@ -139,8 +139,11 @@ export class Resend {
   async get<T>(path: string, options: GetOptions = {}) {
     const requestOptions = {
       method: 'GET',
-      headers: this.headers,
       ...options,
+      headers: new Headers({
+        ...this.headers,
+        ...options.headers,
+      }),
     };
 
     return this.fetchRequest<T>(path, requestOptions);
@@ -149,9 +152,12 @@ export class Resend {
   async put<T>(path: string, entity: unknown, options: PutOptions = {}) {
     const requestOptions = {
       method: 'PUT',
-      headers: this.headers,
       body: JSON.stringify(entity),
       ...options,
+      headers: new Headers({
+        ...this.headers,
+        ...options.headers,
+      }),
     };
 
     return this.fetchRequest<T>(path, requestOptions);
@@ -160,9 +166,12 @@ export class Resend {
   async patch<T>(path: string, entity: unknown, options: PatchOptions = {}) {
     const requestOptions = {
       method: 'PATCH',
-      headers: this.headers,
       body: JSON.stringify(entity),
       ...options,
+      headers: new Headers({
+        ...this.headers,
+        ...options.headers,
+      }),
     };
 
     return this.fetchRequest<T>(path, requestOptions);
@@ -171,7 +180,6 @@ export class Resend {
   async delete<T>(path: string, query?: unknown) {
     const requestOptions = {
       method: 'DELETE',
-      headers: this.headers,
       body: JSON.stringify(query),
     };
 

--- a/src/resend.ts
+++ b/src/resend.ts
@@ -120,58 +120,70 @@ export class Resend {
     entity?: unknown,
     options: PostOptions & IdempotentRequest = {},
   ) {
+    const headers = new Headers(this.headers);
+    if (options.headers) {
+      for (const [key, value] of new Headers(options.headers).entries()) {
+        headers.set(key, value);
+      }
+    }
+    if (options.idempotencyKey) {
+      headers.set('Idempotency-Key', options.idempotencyKey);
+    }
     const requestOptions = {
       method: 'POST',
       body: JSON.stringify(entity),
       ...options,
-      headers: new Headers({
-        ...this.headers,
-        ...options.headers,
-        ...(options.idempotencyKey && {
-          'Idempotency-Key': options.idempotencyKey,
-        }),
-      }),
+      headers,
     };
 
     return this.fetchRequest<T>(path, requestOptions);
   }
 
   async get<T>(path: string, options: GetOptions = {}) {
+    const headers = new Headers(this.headers);
+    if (options.headers) {
+      for (const [key, value] of new Headers(options.headers).entries()) {
+        headers.set(key, value);
+      }
+    }
     const requestOptions = {
       method: 'GET',
       ...options,
-      headers: new Headers({
-        ...this.headers,
-        ...options.headers,
-      }),
+      headers,
     };
 
     return this.fetchRequest<T>(path, requestOptions);
   }
 
   async put<T>(path: string, entity: unknown, options: PutOptions = {}) {
+    const headers = new Headers(this.headers);
+    if (options.headers) {
+      for (const [key, value] of new Headers(options.headers).entries()) {
+        headers.set(key, value);
+      }
+    }
     const requestOptions = {
       method: 'PUT',
       body: JSON.stringify(entity),
       ...options,
-      headers: new Headers({
-        ...this.headers,
-        ...options.headers,
-      }),
+      headers,
     };
 
     return this.fetchRequest<T>(path, requestOptions);
   }
 
   async patch<T>(path: string, entity: unknown, options: PatchOptions = {}) {
+    const headers = new Headers(this.headers);
+    if (options.headers) {
+      for (const [key, value] of new Headers(options.headers).entries()) {
+        headers.set(key, value);
+      }
+    }
     const requestOptions = {
       method: 'PATCH',
       body: JSON.stringify(entity),
       ...options,
-      headers: new Headers({
-        ...this.headers,
-        ...options.headers,
-      }),
+      headers,
     };
 
     return this.fetchRequest<T>(path, requestOptions);


### PR DESCRIPTION
this is a stacked change on #599. The idea for this is that users can pass in if they want then permissive or strict validation on an option, so the usage would be like:

```ts
const response = resend.batch.send(..., { batchValidation: 'permissive' });

// Should always be an array, even if empty.
console.log(response.data.errors)
```

This options also allows us to use typescript's inference on type parameters to automatically change the return type to not have the `errors` when `batchValidation` is `'strict'`.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a batchValidation option to Batch.send/create that sets the x-batch-validation header automatically. Responses are now type-safe: errors are only present when using permissive mode.

- New Features
  - Add CreateBatchRequestOptions.batchValidation ('strict' | 'permissive', default 'strict').
  - Automatically sets x-batch-validation header based on the option.
  - Generic response typing: errors are available only in permissive mode; no client-side stripping.

- Migration
  - Use { batchValidation: 'permissive' } to get partial failures with an errors[] array. Default behavior stays strict.

<!-- End of auto-generated description by cubic. -->

