### PR TITLE
feat(contacts): apply changes to contacts endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.2.0-preview-contacts.0",
+  "version": "6.2.0-preview-contacts.1",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.2.0-preview-topics.0",
+  "version": "6.2.0-preview-contacts.0",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/common/interfaces/pagination.ts
+++ b/src/common/interfaces/pagination.ts
@@ -1,0 +1,23 @@
+export type PaginationOptions<IdType> =
+  | {
+      limit?: number;
+      after?: IdType;
+      before?: never;
+    }
+  | {
+      limit?: number;
+      before?: IdType;
+      after?: never;
+    };
+
+export type PaginatedData<Data> = {
+  object: 'list';
+  data: Data;
+  hasMore: boolean;
+};
+
+export type PaginatedApiResponse<Data> = {
+  object: 'list';
+  data: Data;
+  has_more: boolean;
+};

--- a/src/common/utils/create-pagination-query.spec.ts
+++ b/src/common/utils/create-pagination-query.spec.ts
@@ -1,0 +1,54 @@
+import { PaginationOptions } from '../interfaces/pagination';
+import { createPaginationQuery } from './create-pagination-query';
+
+describe('createPaginationQuery', () => {
+  it('creates the pagination query object with after', () => {
+    const options: PaginationOptions<string> = {
+      after: 'ac7503ac-e027-4aea-94b3-b0acd46f65f9',
+    };
+
+    const query = createPaginationQuery(options);
+
+    expect(query).toEqual({
+      after: 'ac7503ac-e027-4aea-94b3-b0acd46f65f9',
+    });
+  });
+
+  it('creates the pagination query object with before', () => {
+    const options: PaginationOptions<string> = {
+      before: 'ac7503ac-e027-4aea-94b3-b0acd46f65f9',
+    };
+
+    const query = createPaginationQuery(options);
+
+    expect(query).toEqual({
+      before: 'ac7503ac-e027-4aea-94b3-b0acd46f65f9',
+    });
+  });
+
+  it('creates the pagination query object with limit', () => {
+    const options: PaginationOptions<string> = {
+      limit: 10,
+    };
+
+    const query = createPaginationQuery(options);
+
+    expect(query).toEqual({
+      limit: 10,
+    });
+  });
+
+  it('creates the pagination query object with both limit and a cursor option (after)', () => {
+    const options: PaginationOptions<string> = {
+      limit: 10,
+      after: 'ac7503ac-e027-4aea-94b3-b0acd46f65f9',
+    };
+
+    const query = createPaginationQuery(options);
+
+    expect(query).toEqual({
+      limit: 10,
+      after: 'ac7503ac-e027-4aea-94b3-b0acd46f65f9',
+    });
+  });
+});

--- a/src/common/utils/create-pagination-query.ts
+++ b/src/common/utils/create-pagination-query.ts
@@ -3,9 +3,9 @@ import type { PaginationOptions } from '../interfaces/pagination';
 export function createPaginationQuery<
   T extends PaginationOptions<IdType>,
   IdType,
->(options: T): Record<string, string | number | IdType | undefined> {
+>(options: T = {} as T): Record<string, string | number | IdType | undefined> {
   return {
-    limit: options.limit,
+    limit: 'limit' in options ? options.limit : undefined,
     after: 'after' in options ? options.after : undefined,
     before: 'before' in options ? options.before : undefined,
   };

--- a/src/common/utils/create-pagination-query.ts
+++ b/src/common/utils/create-pagination-query.ts
@@ -1,0 +1,12 @@
+import type { PaginationOptions } from '../interfaces/pagination';
+
+export function createPaginationQuery<
+  T extends PaginationOptions<IdType>,
+  IdType,
+>(options: T): Record<string, string | number | IdType | undefined> {
+  return {
+    limit: options.limit,
+    after: 'after' in options ? options.after : undefined,
+    before: 'before' in options ? options.before : undefined,
+  };
+}

--- a/src/common/utils/format-paginated-response.spec.ts
+++ b/src/common/utils/format-paginated-response.spec.ts
@@ -1,0 +1,50 @@
+import { formatPaginatedResponse } from './format-paginated-response';
+
+describe('formatPaginatedResponse', () => {
+  it('formats paginated response', () => {
+    const response = {
+      data: {
+        object: 'list' as const,
+        data: [],
+        has_more: false,
+      },
+      rateLimiting: {
+        limit: 100,
+        remainingRequests: 99,
+        shouldResetAfter: 1000,
+      },
+      error: null,
+    };
+
+    const formattedResponse = formatPaginatedResponse(response);
+
+    expect(formattedResponse).toEqual({
+      data: {
+        object: 'list',
+        data: [],
+        hasMore: false,
+      },
+      rateLimiting: {
+        limit: 100,
+        remainingRequests: 99,
+        shouldResetAfter: 1000,
+      },
+      error: null,
+    });
+  });
+
+  it('should return original response if data is missing', () => {
+    const response = {
+      data: null,
+      rateLimiting: null,
+      error: {
+        message: 'Missing `id` or `email` field.',
+        name: 'missing_required_field' as const,
+      },
+    };
+
+    const formattedResponse = formatPaginatedResponse(response);
+
+    expect(formattedResponse).toEqual(response);
+  });
+});

--- a/src/common/utils/format-paginated-response.ts
+++ b/src/common/utils/format-paginated-response.ts
@@ -1,0 +1,22 @@
+import type { Response } from '../../interfaces';
+import type {
+  PaginatedApiResponse,
+  PaginatedData,
+} from '../interfaces/pagination';
+
+export function formatPaginatedResponse<Data>(
+  response: Response<PaginatedApiResponse<Data>>,
+): Response<PaginatedData<Data>> {
+  if (!response.data) {
+    return response;
+  }
+
+  return {
+    ...response,
+    data: {
+      object: 'list',
+      data: response.data.data,
+      hasMore: response.data.has_more,
+    },
+  };
+}

--- a/src/contacts/audiences/contact-audiences.spec.ts
+++ b/src/contacts/audiences/contact-audiences.spec.ts
@@ -1,0 +1,320 @@
+import { Resend } from '../../resend';
+import { mockSuccessResponse } from '../../test-utils/mock-fetch';
+import type {
+  AddContactAudiencesOptions,
+  AddContactAudiencesResponseSuccess,
+} from './interfaces/add-contact-audience.interface';
+import type {
+  ListContactAudiencesApiResponseSuccess,
+  ListContactAudiencesOptions,
+} from './interfaces/list-contact-audiences.interface';
+import type {
+  RemoveContactAudiencesOptions,
+  RemoveContactAudiencesResponseSuccess,
+} from './interfaces/remove-contact-audience.interface';
+
+describe('ContactAudiences', () => {
+  afterEach(() => fetchMock.resetMocks());
+
+  describe('list', () => {
+    it('gets contact audiences by email', async () => {
+      const options: ListContactAudiencesOptions = {
+        email: 'carolina@resend.com',
+      };
+      const response: ListContactAudiencesApiResponseSuccess = {
+        object: 'list',
+        data: [
+          {
+            id: 'c7e1e488-ae2c-4255-a40c-a4db3af7ed0b',
+            name: 'Test Audience',
+            created_at: '2021-01-01T00:00:00.000Z',
+          },
+          {
+            id: 'd7e1e488-ae2c-4255-a40c-a4db3af7ed0c',
+            name: 'Another Audience',
+            created_at: '2021-01-02T00:00:00.000Z',
+          },
+        ],
+        has_more: false,
+      };
+
+      mockSuccessResponse(response, {
+        headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      await expect(
+        resend.contacts.audiences.list(options),
+      ).resolves.toMatchInlineSnapshot(`
+{
+  "data": {
+    "data": [
+      {
+        "created_at": "2021-01-01T00:00:00.000Z",
+        "id": "c7e1e488-ae2c-4255-a40c-a4db3af7ed0b",
+        "name": "Test Audience",
+      },
+      {
+        "created_at": "2021-01-02T00:00:00.000Z",
+        "id": "d7e1e488-ae2c-4255-a40c-a4db3af7ed0c",
+        "name": "Another Audience",
+      },
+    ],
+    "hasMore": false,
+    "object": "list",
+  },
+  "error": null,
+  "rateLimiting": {
+    "limit": 2,
+    "remainingRequests": 2,
+    "shouldResetAfter": 1,
+  },
+}
+`);
+    });
+
+    it('gets contact audiences by ID', async () => {
+      const options: ListContactAudiencesOptions = {
+        contactId: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223',
+        limit: 1,
+        after: '584a472d-bc6d-4dd2-aa9d-d3d50ce87222',
+      };
+      const response: ListContactAudiencesApiResponseSuccess = {
+        object: 'list',
+        data: [
+          {
+            id: 'c7e1e488-ae2c-4255-a40c-a4db3af7ed0b',
+            name: 'Test Audience',
+            created_at: '2021-01-01T00:00:00.000Z',
+          },
+        ],
+        has_more: true,
+      };
+
+      mockSuccessResponse(response, {
+        headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      await expect(
+        resend.contacts.audiences.list(options),
+      ).resolves.toMatchInlineSnapshot(`
+{
+  "data": {
+    "data": [
+      {
+        "created_at": "2021-01-01T00:00:00.000Z",
+        "id": "c7e1e488-ae2c-4255-a40c-a4db3af7ed0b",
+        "name": "Test Audience",
+      },
+    ],
+    "hasMore": true,
+    "object": "list",
+  },
+  "error": null,
+  "rateLimiting": {
+    "limit": 2,
+    "remainingRequests": 2,
+    "shouldResetAfter": 1,
+  },
+}
+`);
+    });
+
+    it('returns error when missing both id and email', async () => {
+      const options = {};
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      const result = resend.contacts.audiences.list(
+        options as ListContactAudiencesOptions,
+      );
+
+      await expect(result).resolves.toMatchInlineSnapshot(`
+{
+  "data": null,
+  "error": {
+    "message": "Missing \`id\` or \`email\` field.",
+    "name": "missing_required_field",
+  },
+  "rateLimiting": null,
+}
+`);
+    });
+  });
+
+  describe('add', () => {
+    it('adds a contact to an audience', async () => {
+      const options: AddContactAudiencesOptions = {
+        email: 'carolina@resend.com',
+        audienceId: 'c7e1e488-ae2c-4255-a40c-a4db3af7ed0b',
+      };
+
+      const response: AddContactAudiencesResponseSuccess = {
+        id: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223',
+      };
+
+      mockSuccessResponse(response, {
+        headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      await expect(
+        resend.contacts.audiences.add(options),
+      ).resolves.toMatchInlineSnapshot(`
+{
+  "data": {
+    "id": "3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223",
+  },
+  "error": null,
+  "rateLimiting": {
+    "limit": 2,
+    "remainingRequests": 2,
+    "shouldResetAfter": 1,
+  },
+}
+`);
+    });
+
+    it('adds a contact to an audience by ID', async () => {
+      const options: AddContactAudiencesOptions = {
+        contactId: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223',
+        audienceId: 'c7e1e488-ae2c-4255-a40c-a4db3af7ed0b',
+      };
+
+      const response: AddContactAudiencesResponseSuccess = {
+        id: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223',
+      };
+
+      mockSuccessResponse(response, {
+        headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      await expect(
+        resend.contacts.audiences.add(options),
+      ).resolves.toMatchInlineSnapshot(`
+{
+  "data": {
+    "id": "3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223",
+  },
+  "error": null,
+  "rateLimiting": {
+    "limit": 2,
+    "remainingRequests": 2,
+    "shouldResetAfter": 1,
+  },
+}
+`);
+    });
+
+    it('returns error when missing both id and email', async () => {
+      const options = {};
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      const result = resend.contacts.audiences.add(
+        options as AddContactAudiencesOptions,
+      );
+
+      await expect(result).resolves.toMatchInlineSnapshot(`
+{
+  "data": null,
+  "error": {
+    "message": "Missing \`id\` or \`email\` field.",
+    "name": "missing_required_field",
+  },
+  "rateLimiting": null,
+}
+`);
+    });
+  });
+
+  describe('remove', () => {
+    it('removes a contact from an audience', async () => {
+      const options: RemoveContactAudiencesOptions = {
+        email: 'carolina@resend.com',
+        audienceId: 'c7e1e488-ae2c-4255-a40c-a4db3af7ed0b',
+      };
+
+      const response: RemoveContactAudiencesResponseSuccess = {
+        id: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223',
+        deleted: true,
+      };
+
+      mockSuccessResponse(response, {
+        headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      await expect(
+        resend.contacts.audiences.remove(options),
+      ).resolves.toMatchInlineSnapshot(`
+{
+  "data": {
+    "deleted": true,
+    "id": "3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223",
+  },
+  "error": null,
+  "rateLimiting": {
+    "limit": 2,
+    "remainingRequests": 2,
+    "shouldResetAfter": 1,
+  },
+}
+`);
+    });
+
+    it('removes a contact from an audience by ID', async () => {
+      const options: RemoveContactAudiencesOptions = {
+        contactId: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223',
+        audienceId: 'c7e1e488-ae2c-4255-a40c-a4db3af7ed0b',
+      };
+
+      const response: RemoveContactAudiencesResponseSuccess = {
+        id: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223',
+        deleted: true,
+      };
+
+      mockSuccessResponse(response, {
+        headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      await expect(
+        resend.contacts.audiences.remove(options),
+      ).resolves.toMatchInlineSnapshot(`
+{
+  "data": {
+    "deleted": true,
+    "id": "3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223",
+  },
+  "error": null,
+  "rateLimiting": {
+    "limit": 2,
+    "remainingRequests": 2,
+    "shouldResetAfter": 1,
+  },
+}
+`);
+    });
+
+    it('returns error when missing both id and email', async () => {
+      const options = {};
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      const result = resend.contacts.audiences.remove(
+        options as RemoveContactAudiencesOptions,
+      );
+
+      await expect(result).resolves.toMatchInlineSnapshot(`
+{
+  "data": null,
+  "error": {
+    "message": "Missing \`id\` or \`email\` field.",
+    "name": "missing_required_field",
+  },
+  "rateLimiting": null,
+}
+`);
+    });
+  });
+});

--- a/src/contacts/audiences/contact-audiences.ts
+++ b/src/contacts/audiences/contact-audiences.ts
@@ -39,7 +39,7 @@ export class ContactAudiences {
 
     const data = await this.resend.get<ListContactAudiencesApiResponseSuccess>(
       `/contacts/${identifier}/audiences`,
-      query,
+      { query },
     );
     return formatPaginatedResponse(data);
   }

--- a/src/contacts/audiences/contact-audiences.ts
+++ b/src/contacts/audiences/contact-audiences.ts
@@ -1,0 +1,86 @@
+import { createPaginationQuery } from '../../common/utils/create-pagination-query';
+import { formatPaginatedResponse } from '../../common/utils/format-paginated-response';
+import type { Resend } from '../../resend';
+import type {
+  AddContactAudiencesOptions,
+  AddContactAudiencesResponse,
+  AddContactAudiencesResponseSuccess,
+} from './interfaces/add-contact-audience.interface';
+import type {
+  ListContactAudiencesApiResponseSuccess,
+  ListContactAudiencesOptions,
+  ListContactAudiencesResponse,
+} from './interfaces/list-contact-audiences.interface';
+import type {
+  RemoveContactAudiencesOptions,
+  RemoveContactAudiencesResponse,
+  RemoveContactAudiencesResponseSuccess,
+} from './interfaces/remove-contact-audience.interface';
+
+export class ContactAudiences {
+  constructor(private readonly resend: Resend) {}
+
+  async list(
+    options: ListContactAudiencesOptions,
+  ): Promise<ListContactAudiencesResponse> {
+    if (!options.contactId && !options.email) {
+      return {
+        data: null,
+        rateLimiting: null,
+        error: {
+          message: 'Missing `id` or `email` field.',
+          name: 'missing_required_field',
+        },
+      };
+    }
+
+    const identifier = options.email ? options.email : options.contactId;
+    const query = createPaginationQuery(options);
+
+    const data = await this.resend.get<ListContactAudiencesApiResponseSuccess>(
+      `/contacts/${identifier}/audiences`,
+      query,
+    );
+    return formatPaginatedResponse(data);
+  }
+
+  async add(
+    options: AddContactAudiencesOptions,
+  ): Promise<AddContactAudiencesResponse> {
+    if (!options.contactId && !options.email) {
+      return {
+        data: null,
+        rateLimiting: null,
+        error: {
+          message: 'Missing `id` or `email` field.',
+          name: 'missing_required_field',
+        },
+      };
+    }
+
+    const identifier = options.email ? options.email : options.contactId;
+    return this.resend.post<AddContactAudiencesResponseSuccess>(
+      `/contacts/${identifier}/audiences/${options.audienceId}`,
+    );
+  }
+
+  async remove(
+    options: RemoveContactAudiencesOptions,
+  ): Promise<RemoveContactAudiencesResponse> {
+    if (!options.contactId && !options.email) {
+      return {
+        data: null,
+        rateLimiting: null,
+        error: {
+          message: 'Missing `id` or `email` field.',
+          name: 'missing_required_field',
+        },
+      };
+    }
+
+    const identifier = options.email ? options.email : options.contactId;
+    return this.resend.delete<RemoveContactAudiencesResponseSuccess>(
+      `/contacts/${identifier}/audiences/${options.audienceId}`,
+    );
+  }
+}

--- a/src/contacts/audiences/interfaces/add-contact-audience.interface.ts
+++ b/src/contacts/audiences/interfaces/add-contact-audience.interface.ts
@@ -1,0 +1,13 @@
+import type { Response } from '../../../interfaces';
+import type { ContactAudiencesBaseOptions } from './contact-audiences.interface';
+
+export type AddContactAudiencesResponse =
+  Response<AddContactAudiencesResponseSuccess>;
+
+export interface AddContactAudiencesResponseSuccess {
+  id: string;
+}
+
+export type AddContactAudiencesOptions = ContactAudiencesBaseOptions & {
+  audienceId: string;
+};

--- a/src/contacts/audiences/interfaces/contact-audiences.interface.ts
+++ b/src/contacts/audiences/interfaces/contact-audiences.interface.ts
@@ -1,0 +1,9 @@
+export type ContactAudiencesBaseOptions =
+  | {
+      contactId: string;
+      email?: never;
+    }
+  | {
+      contactId?: never;
+      email: string;
+    };

--- a/src/contacts/audiences/interfaces/list-contact-audiences.interface.ts
+++ b/src/contacts/audiences/interfaces/list-contact-audiences.interface.ts
@@ -1,0 +1,19 @@
+import type { Audience } from '../../../audiences/interfaces/audience';
+import type {
+  PaginatedApiResponse,
+  PaginatedData,
+  PaginationOptions,
+} from '../../../common/interfaces/pagination';
+import type { Response } from '../../../interfaces';
+import type { ContactAudiencesBaseOptions } from './contact-audiences.interface';
+
+export type ListContactAudiencesOptions = PaginationOptions<string> &
+  ContactAudiencesBaseOptions;
+
+export type ListContactAudiencesApiResponseSuccess = PaginatedApiResponse<
+  Audience[]
+>;
+
+export type ListContactAudiencesResponseSuccess = PaginatedData<Audience[]>;
+export type ListContactAudiencesResponse =
+  Response<ListContactAudiencesResponseSuccess>;

--- a/src/contacts/audiences/interfaces/remove-contact-audience.interface.ts
+++ b/src/contacts/audiences/interfaces/remove-contact-audience.interface.ts
@@ -1,0 +1,14 @@
+import type { Response } from '../../../interfaces';
+import type { ContactAudiencesBaseOptions } from './contact-audiences.interface';
+
+export type RemoveContactAudiencesResponse =
+  Response<RemoveContactAudiencesResponseSuccess>;
+
+export interface RemoveContactAudiencesResponseSuccess {
+  id: string;
+  deleted: boolean;
+}
+
+export type RemoveContactAudiencesOptions = ContactAudiencesBaseOptions & {
+  audienceId: string;
+};

--- a/src/contacts/contacts.spec.ts
+++ b/src/contacts/contacts.spec.ts
@@ -17,7 +17,6 @@ import type {
   ListAudienceContactsResponseSuccess,
   ListContactsApiResponseSuccess,
   ListContactsOptions,
-  ListContactsResponseSuccess,
 } from './interfaces/list-contacts.interface';
 import type {
   RemoveContactOptions,

--- a/src/contacts/contacts.spec.ts
+++ b/src/contacts/contacts.spec.ts
@@ -13,6 +13,9 @@ import type {
   GetContactResponseSuccess,
 } from './interfaces/get-contact.interface';
 import type {
+  ListAudienceContactsOptions,
+  ListAudienceContactsResponseSuccess,
+  ListContactsApiResponseSuccess,
   ListContactsOptions,
   ListContactsResponseSuccess,
 } from './interfaces/list-contacts.interface';
@@ -95,40 +98,113 @@ describe('Contacts', () => {
   });
 
   describe('list', () => {
-    it('lists contacts', async () => {
-      const options: ListContactsOptions = {
-        audienceId: 'b6d24b8e-af0b-4c3c-be0c-359bbd97381a',
-      };
-      const response: ListContactsResponseSuccess = {
-        object: 'list',
-        data: [
-          {
-            id: 'b6d24b8e-af0b-4c3c-be0c-359bbd97381e',
-            email: 'team@resend.com',
-            created_at: '2023-04-07T23:13:52.669661+00:00',
-            unsubscribed: false,
-            first_name: 'John',
-            last_name: 'Smith',
-          },
-          {
-            id: 'ac7503ac-e027-4aea-94b3-b0acd46f65f9',
-            email: 'team@react.email',
-            created_at: '2023-04-07T23:13:20.417116+00:00',
-            unsubscribed: false,
-            first_name: 'John',
-            last_name: 'Smith',
-          },
-        ],
-      };
-      mockSuccessResponse(response, {
-        headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
+    describe('when audienceId is not provided', () => {
+      it('lists contacts', async () => {
+        const options: ListContactsOptions = {
+          limit: 10,
+          after: 'ac7503ac-e027-4aea-94b3-b0acd46f65f9',
+        };
+
+        const response: ListContactsApiResponseSuccess = {
+          object: 'list',
+          data: [
+            {
+              id: 'b6d24b8e-af0b-4c3c-be0c-359bbd97381e',
+              email: 'team@resend.com',
+              created_at: '2023-04-07T23:13:52.669661+00:00',
+              unsubscribed: false,
+              first_name: 'John',
+              last_name: 'Smith',
+            },
+            {
+              id: 'ac7503ac-e027-4aea-94b3-b0acd46f65f9',
+              email: 'team@react.email',
+              created_at: '2023-04-07T23:13:20.417116+00:00',
+              unsubscribed: false,
+              first_name: 'John',
+              last_name: 'Smith',
+            },
+          ],
+          has_more: false,
+        };
+
+        mockSuccessResponse(response, {
+          headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+        await expect(
+          resend.contacts.list(options),
+        ).resolves.toMatchInlineSnapshot(`
+{
+  "data": {
+    "data": [
+      {
+        "created_at": "2023-04-07T23:13:52.669661+00:00",
+        "email": "team@resend.com",
+        "first_name": "John",
+        "id": "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
+        "last_name": "Smith",
+        "unsubscribed": false,
+      },
+      {
+        "created_at": "2023-04-07T23:13:20.417116+00:00",
+        "email": "team@react.email",
+        "first_name": "John",
+        "id": "ac7503ac-e027-4aea-94b3-b0acd46f65f9",
+        "last_name": "Smith",
+        "unsubscribed": false,
+      },
+    ],
+    "hasMore": false,
+    "object": "list",
+  },
+  "error": null,
+  "rateLimiting": {
+    "limit": 2,
+    "remainingRequests": 2,
+    "shouldResetAfter": 1,
+  },
+}
+`);
       });
+    });
+    describe('when audienceId is provided', () => {
+      it('lists contacts', async () => {
+        const options: ListAudienceContactsOptions = {
+          audienceId: 'b6d24b8e-af0b-4c3c-be0c-359bbd97381a',
+        };
+        const response: ListAudienceContactsResponseSuccess = {
+          object: 'list',
+          data: [
+            {
+              id: 'b6d24b8e-af0b-4c3c-be0c-359bbd97381e',
+              email: 'team@resend.com',
+              created_at: '2023-04-07T23:13:52.669661+00:00',
+              unsubscribed: false,
+              first_name: 'John',
+              last_name: 'Smith',
+            },
+            {
+              id: 'ac7503ac-e027-4aea-94b3-b0acd46f65f9',
+              email: 'team@react.email',
+              created_at: '2023-04-07T23:13:20.417116+00:00',
+              unsubscribed: false,
+              first_name: 'John',
+              last_name: 'Smith',
+            },
+          ],
+        };
+        mockSuccessResponse(response, {
+          headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
+        });
 
-      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
 
-      await expect(
-        resend.contacts.list(options),
-      ).resolves.toMatchInlineSnapshot(`
+        await expect(
+          resend.contacts.list(options),
+        ).resolves.toMatchInlineSnapshot(`
 {
   "data": {
     "data": [
@@ -159,6 +235,7 @@ describe('Contacts', () => {
   },
 }
 `);
+      });
     });
   });
 

--- a/src/contacts/contacts.ts
+++ b/src/contacts/contacts.ts
@@ -129,6 +129,18 @@ export class Contacts {
       };
     }
 
+    if (!options.audienceId) {
+      const data = await this.resend.patch<UpdateContactResponseSuccess>(
+        `/contacts/${options?.email ? options?.email : options?.id}`,
+        {
+          unsubscribed: options.unsubscribed,
+          first_name: options.firstName,
+          last_name: options.lastName,
+        },
+      );
+      return data;
+    }
+
     const data = await this.resend.patch<UpdateContactResponseSuccess>(
       `/audiences/${options.audienceId}/contacts/${options?.email ? options?.email : options?.id}`,
       {

--- a/src/contacts/contacts.ts
+++ b/src/contacts/contacts.ts
@@ -1,6 +1,7 @@
 import { createPaginationQuery } from '../common/utils/create-pagination-query';
 import { formatPaginatedResponse } from '../common/utils/format-paginated-response';
 import type { Resend } from '../resend';
+import { ContactAudiences } from './audiences/contact-audiences';
 import type {
   CreateContactOptions,
   CreateContactRequestOptions,
@@ -34,9 +35,11 @@ import { ContactTopics } from './topics/contact-topics';
 
 export class Contacts {
   readonly topics: ContactTopics;
+  readonly audiences: ContactAudiences;
 
   constructor(private readonly resend: Resend) {
     this.topics = new ContactTopics(this.resend);
+    this.audiences = new ContactAudiences(this.resend);
   }
 
   async create(

--- a/src/contacts/contacts.ts
+++ b/src/contacts/contacts.ts
@@ -38,6 +38,20 @@ export class Contacts {
     payload: CreateContactOptions,
     options: CreateContactRequestOptions = {},
   ): Promise<CreateContactResponse> {
+    if (!payload.audienceId) {
+      const data = await this.resend.post<CreateContactResponseSuccess>(
+        '/contacts',
+        {
+          unsubscribed: payload.unsubscribed,
+          email: payload.email,
+          first_name: payload.firstName,
+          last_name: payload.lastName,
+        },
+        options,
+      );
+      return data;
+    }
+
     const data = await this.resend.post<CreateContactResponseSuccess>(
       `/audiences/${payload.audienceId}/contacts`,
       {
@@ -68,6 +82,13 @@ export class Contacts {
           name: 'missing_required_field',
         },
       };
+    }
+
+    if (!options.audienceId) {
+      const data = await this.resend.get<GetContactResponseSuccess>(
+        `/contacts/${options?.email ? options?.email : options?.id}`,
+      );
+      return data;
     }
 
     const data = await this.resend.get<GetContactResponseSuccess>(
@@ -111,11 +132,19 @@ export class Contacts {
       };
     }
 
+    if (!payload.audienceId) {
+      const data = await this.resend.delete<RemoveContactsResponseSuccess>(
+        `/contacts/${payload?.email ? payload?.email : payload?.id}`,
+      );
+      return data;
+    }
+
     const data = await this.resend.delete<RemoveContactsResponseSuccess>(
       `/audiences/${payload.audienceId}/contacts/${
         payload?.email ? payload?.email : payload?.id
       }`,
     );
+
     return data;
   }
 }

--- a/src/contacts/contacts.ts
+++ b/src/contacts/contacts.ts
@@ -1,3 +1,5 @@
+import { createPaginationQuery } from '../common/utils/create-pagination-query';
+import { formatPaginatedResponse } from '../common/utils/format-paginated-response';
 import type { Resend } from '../resend';
 import type {
   CreateContactOptions,
@@ -11,9 +13,12 @@ import type {
   GetContactResponseSuccess,
 } from './interfaces/get-contact.interface';
 import type {
+  ListAudienceContactsOptions,
+  ListAudienceContactsResponse,
+  ListAudienceContactsResponseSuccess,
+  ListContactsApiResponseSuccess,
   ListContactsOptions,
   ListContactsResponse,
-  ListContactsResponseSuccess,
 } from './interfaces/list-contacts.interface';
 import type {
   RemoveContactOptions,
@@ -65,8 +70,23 @@ export class Contacts {
     return data;
   }
 
-  async list(options: ListContactsOptions): Promise<ListContactsResponse> {
-    const data = await this.resend.get<ListContactsResponseSuccess>(
+  async list(options: ListContactsOptions): Promise<ListContactsResponse>;
+  async list(
+    options: ListAudienceContactsOptions,
+  ): Promise<ListAudienceContactsResponse>;
+  async list(
+    options: ListContactsOptions | ListAudienceContactsOptions,
+  ): Promise<ListContactsResponse | ListAudienceContactsResponse> {
+    if (!('audienceId' in options)) {
+      const query = createPaginationQuery(options);
+      const data = await this.resend.get<ListContactsApiResponseSuccess>(
+        '/contacts',
+        { query },
+      );
+      return formatPaginatedResponse(data);
+    }
+
+    const data = await this.resend.get<ListAudienceContactsResponseSuccess>(
       `/audiences/${options.audienceId}/contacts`,
     );
     return data;

--- a/src/contacts/contacts.ts
+++ b/src/contacts/contacts.ts
@@ -73,12 +73,12 @@ export class Contacts {
     return data;
   }
 
-  async list(options: ListContactsOptions): Promise<ListContactsResponse>;
+  async list(options?: ListContactsOptions): Promise<ListContactsResponse>;
   async list(
     options: ListAudienceContactsOptions,
   ): Promise<ListAudienceContactsResponse>;
   async list(
-    options: ListContactsOptions | ListAudienceContactsOptions,
+    options: ListContactsOptions | ListAudienceContactsOptions = {},
   ): Promise<ListContactsResponse | ListAudienceContactsResponse> {
     if (!('audienceId' in options)) {
       const query = createPaginationQuery(options);

--- a/src/contacts/interfaces/create-contact-options.interface.ts
+++ b/src/contacts/interfaces/create-contact-options.interface.ts
@@ -3,7 +3,7 @@ import type { Response } from '../../interfaces';
 import type { Contact } from './contact';
 
 export interface CreateContactOptions {
-  audienceId: string;
+  audienceId?: string;
   email: string;
   unsubscribed?: boolean;
   firstName?: string;

--- a/src/contacts/interfaces/get-contact.interface.ts
+++ b/src/contacts/interfaces/get-contact.interface.ts
@@ -2,7 +2,7 @@ import type { Response } from '../../interfaces';
 import type { Contact, SelectingField } from './contact';
 
 export type GetContactOptions = {
-  audienceId: string;
+  audienceId?: string;
 } & SelectingField;
 
 export interface GetContactResponseSuccess

--- a/src/contacts/interfaces/list-contacts.interface.ts
+++ b/src/contacts/interfaces/list-contacts.interface.ts
@@ -1,13 +1,25 @@
+import type {
+  PaginatedApiResponse,
+  PaginatedData,
+  PaginationOptions,
+} from '../../common/interfaces/pagination';
 import type { Response } from '../../interfaces';
 import type { Contact } from './contact';
 
-export interface ListContactsOptions {
+export interface ListAudienceContactsOptions {
   audienceId: string;
 }
 
-export interface ListContactsResponseSuccess {
+export type ListContactsOptions = PaginationOptions<string>;
+
+export interface ListAudienceContactsResponseSuccess {
   object: 'list';
   data: Contact[];
 }
+export type ListAudienceContactsResponse =
+  Response<ListAudienceContactsResponseSuccess>;
+
+export type ListContactsApiResponseSuccess = PaginatedApiResponse<Contact[]>;
+export type ListContactsResponseSuccess = PaginatedData<Contact[]>;
 
 export type ListContactsResponse = Response<ListContactsResponseSuccess>;

--- a/src/contacts/interfaces/remove-contact.interface.ts
+++ b/src/contacts/interfaces/remove-contact.interface.ts
@@ -8,7 +8,7 @@ export type RemoveContactsResponseSuccess = {
 };
 
 export type RemoveContactOptions = SelectingField & {
-  audienceId: string;
+  audienceId?: string;
 };
 
 export type RemoveContactsResponse = Response<RemoveContactsResponseSuccess>;

--- a/src/contacts/interfaces/update-contact.interface.ts
+++ b/src/contacts/interfaces/update-contact.interface.ts
@@ -2,7 +2,7 @@ import type { Response } from '../../interfaces';
 import type { Contact, SelectingField } from './contact';
 
 export type UpdateContactOptions = {
-  audienceId: string;
+  audienceId?: string;
   unsubscribed?: boolean;
   firstName?: string;
   lastName?: string;

--- a/src/contacts/topics/contact-topics.spec.ts
+++ b/src/contacts/topics/contact-topics.spec.ts
@@ -1,5 +1,5 @@
-import { enableFetchMocks } from 'jest-fetch-mock';
 import { Resend } from '../../resend';
+import { mockSuccessResponse } from '../../test-utils/mock-fetch';
 import type {
   GetContactTopicsOptions,
   GetContactTopicsResponseSuccess,
@@ -8,8 +8,6 @@ import type {
   UpdateContactTopicsOptions,
   UpdateContactTopicsResponseSuccess,
 } from './interfaces/update-contact-topics.interface';
-
-enableFetchMocks();
 
 describe('ContactTopics', () => {
   afterEach(() => fetchMock.resetMocks());
@@ -29,12 +27,8 @@ describe('ContactTopics', () => {
         id: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223',
       };
 
-      fetchMock.mockOnce(JSON.stringify(response), {
-        status: 200,
-        headers: {
-          'content-type': 'application/json',
-          Authorization: 'Bearer re_924b3rjh2387fbewf823',
-        },
+      mockSuccessResponse(response, {
+        headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
       });
 
       const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
@@ -46,6 +40,11 @@ describe('ContactTopics', () => {
     "id": "3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223",
   },
   "error": null,
+  "rateLimiting": {
+    "limit": 2,
+    "remainingRequests": 2,
+    "shouldResetAfter": 1,
+  },
 }
 `);
     });
@@ -64,12 +63,8 @@ describe('ContactTopics', () => {
         id: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223',
       };
 
-      fetchMock.mockOnce(JSON.stringify(response), {
-        status: 200,
-        headers: {
-          'content-type': 'application/json',
-          Authorization: 'Bearer re_924b3rjh2387fbewf823',
-        },
+      mockSuccessResponse(response, {
+        headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
       });
 
       const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
@@ -81,6 +76,11 @@ describe('ContactTopics', () => {
     "id": "3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223",
   },
   "error": null,
+  "rateLimiting": {
+    "limit": 2,
+    "remainingRequests": 2,
+    "shouldResetAfter": 1,
+  },
 }
 `);
     });
@@ -103,12 +103,8 @@ describe('ContactTopics', () => {
         id: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223',
       };
 
-      fetchMock.mockOnce(JSON.stringify(response), {
-        status: 200,
-        headers: {
-          'content-type': 'application/json',
-          Authorization: 'Bearer re_924b3rjh2387fbewf823',
-        },
+      mockSuccessResponse(response, {
+        headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
       });
 
       const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
@@ -120,6 +116,11 @@ describe('ContactTopics', () => {
     "id": "3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223",
   },
   "error": null,
+  "rateLimiting": {
+    "limit": 2,
+    "remainingRequests": 2,
+    "shouldResetAfter": 1,
+  },
 }
 `);
     });
@@ -164,12 +165,8 @@ describe('ContactTopics', () => {
         id: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223',
       };
 
-      fetchMock.mockOnce(JSON.stringify(response), {
-        status: 200,
-        headers: {
-          'content-type': 'application/json',
-          Authorization: 'Bearer re_924b3rjh2387fbewf823',
-        },
+      mockSuccessResponse(response, {
+        headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
       });
 
       const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
@@ -181,6 +178,11 @@ describe('ContactTopics', () => {
     "id": "3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223",
   },
   "error": null,
+  "rateLimiting": {
+    "limit": 2,
+    "remainingRequests": 2,
+    "shouldResetAfter": 1,
+  },
 }
 `);
     });
@@ -209,12 +211,8 @@ describe('ContactTopics', () => {
         ],
       };
 
-      fetchMock.mockOnce(JSON.stringify(response), {
-        status: 200,
-        headers: {
-          'content-type': 'application/json',
-          Authorization: 'Bearer re_924b3rjh2387fbewf823',
-        },
+      mockSuccessResponse(response, {
+        headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
       });
 
       const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
@@ -240,6 +238,11 @@ describe('ContactTopics', () => {
     ],
   },
   "error": null,
+  "rateLimiting": {
+    "limit": 2,
+    "remainingRequests": 2,
+    "shouldResetAfter": 1,
+  },
 }
 `);
     });
@@ -260,12 +263,8 @@ describe('ContactTopics', () => {
         ],
       };
 
-      fetchMock.mockOnce(JSON.stringify(response), {
-        status: 200,
-        headers: {
-          'content-type': 'application/json',
-          Authorization: 'Bearer re_924b3rjh2387fbewf823',
-        },
+      mockSuccessResponse(response, {
+        headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
       });
 
       const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
@@ -285,6 +284,11 @@ describe('ContactTopics', () => {
     ],
   },
   "error": null,
+  "rateLimiting": {
+    "limit": 2,
+    "remainingRequests": 2,
+    "shouldResetAfter": 1,
+  },
 }
 `);
     });

--- a/src/resend.ts
+++ b/src/resend.ts
@@ -56,9 +56,22 @@ export class Resend {
     });
   }
 
-  async fetchRequest<T>(path: string, options = {}): Promise<Response<T>> {
+  async fetchRequest<T>(
+    path: string,
+    options: RequestInit & { query?: Record<string, unknown> } = {},
+  ): Promise<Response<T>> {
     try {
-      const response = await fetch(`${baseUrl}${path}`, options);
+      const url = new URL(path, baseUrl);
+      if (options.query) {
+        for (const [key, value] of Object.entries(options.query)) {
+          const valueString = value?.toString?.();
+          if (valueString !== undefined) {
+            url.searchParams.set(key, valueString);
+          }
+        }
+      }
+
+      const response = await fetch(url.toString(), options);
 
       const rateLimiting = parseRateLimit(response.headers);
 

--- a/src/resend.ts
+++ b/src/resend.ts
@@ -61,7 +61,7 @@ export class Resend {
     options: RequestInit & { query?: Record<string, unknown> } = {},
   ): Promise<Response<T>> {
     try {
-      const url = new URL(path, baseUrl);
+      const url = new URL(`${baseUrl}${path}`);
       if (options.query) {
         for (const [key, value] of Object.entries(options.query)) {
           const valueString = value?.toString?.();

--- a/src/topics/topics.spec.ts
+++ b/src/topics/topics.spec.ts
@@ -1,6 +1,9 @@
-import { enableFetchMocks } from 'jest-fetch-mock';
 import type { ErrorResponse } from '../interfaces';
 import { Resend } from '../resend';
+import {
+  mockErrorResponse,
+  mockSuccessResponse,
+} from '../test-utils/mock-fetch';
 import type {
   CreateTopicOptions,
   CreateTopicResponseSuccess,
@@ -9,8 +12,6 @@ import type { GetTopicResponseSuccess } from './interfaces/get-contact.interface
 import type { ListTopicsResponseSuccess } from './interfaces/list-topics.interface';
 import type { RemoveTopicResponseSuccess } from './interfaces/remove-topic.interface';
 import type { UpdateTopicOptions } from './interfaces/update-topic.interface';
-
-enableFetchMocks();
 
 describe('Topics', () => {
   afterEach(() => fetchMock.resetMocks());
@@ -26,12 +27,8 @@ describe('Topics', () => {
         id: '3deaccfb-f47f-440a-8875-ea14b1716b43',
       };
 
-      fetchMock.mockOnce(JSON.stringify(response), {
-        status: 200,
-        headers: {
-          'content-type': 'application/json',
-          Authorization: 'Bearer re_924b3rjh2387fbewf823',
-        },
+      mockSuccessResponse(response, {
+        headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
       });
 
       const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
@@ -43,6 +40,11 @@ describe('Topics', () => {
     "id": "3deaccfb-f47f-440a-8875-ea14b1716b43",
   },
   "error": null,
+  "rateLimiting": {
+    "limit": 2,
+    "remainingRequests": 2,
+    "shouldResetAfter": 1,
+  },
 }
 `);
     });
@@ -57,11 +59,9 @@ describe('Topics', () => {
         message: 'Missing `name` field.',
       };
 
-      fetchMock.mockOnce(JSON.stringify(response), {
-        status: 422,
+      mockErrorResponse(response, {
         headers: {
-          'content-type': 'application/json',
-          Authorization: 'Bearer re_924b3rjh2387fbewf823',
+          Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
         },
       });
 
@@ -75,6 +75,11 @@ describe('Topics', () => {
   "error": {
     "message": "Missing \`name\` field.",
     "name": "missing_required_field",
+  },
+  "rateLimiting": {
+    "limit": 2,
+    "remainingRequests": 2,
+    "shouldResetAfter": 1,
   },
 }
 `);
@@ -90,11 +95,9 @@ describe('Topics', () => {
         message: 'Missing `default_subscription` field.',
       };
 
-      fetchMock.mockOnce(JSON.stringify(response), {
-        status: 422,
+      mockErrorResponse(response, {
         headers: {
-          'content-type': 'application/json',
-          Authorization: 'Bearer re_924b3rjh2387fbewf823',
+          Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
         },
       });
 
@@ -108,6 +111,11 @@ describe('Topics', () => {
   "error": {
     "message": "Missing \`default_subscription\` field.",
     "name": "missing_required_field",
+  },
+  "rateLimiting": {
+    "limit": 2,
+    "remainingRequests": 2,
+    "shouldResetAfter": 1,
   },
 }
 `);
@@ -134,12 +142,8 @@ describe('Topics', () => {
           },
         ],
       };
-      fetchMock.mockOnce(JSON.stringify(response), {
-        status: 200,
-        headers: {
-          'content-type': 'application/json',
-          Authorization: 'Bearer re_924b3rjh2387fbewf823',
-        },
+      mockSuccessResponse(response, {
+        headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
       });
 
       const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
@@ -165,6 +169,11 @@ describe('Topics', () => {
     ],
   },
   "error": null,
+  "rateLimiting": {
+    "limit": 2,
+    "remainingRequests": 2,
+    "shouldResetAfter": 1,
+  },
 }
 `);
     });
@@ -178,11 +187,9 @@ describe('Topics', () => {
           message: 'Topic not found',
         };
 
-        fetchMock.mockOnce(JSON.stringify(response), {
-          status: 404,
+        mockErrorResponse(response, {
           headers: {
-            'content-type': 'application/json',
-            Authorization: 'Bearer re_924b3rjh2387fbewf823',
+            Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
           },
         });
 
@@ -199,6 +206,11 @@ describe('Topics', () => {
     "message": "Topic not found",
     "name": "not_found",
   },
+  "rateLimiting": {
+    "limit": 2,
+    "remainingRequests": 2,
+    "shouldResetAfter": 1,
+  },
 }
 `);
       });
@@ -213,12 +225,8 @@ describe('Topics', () => {
         created_at: '2024-01-16T18:12:26.514Z',
       };
 
-      fetchMock.mockOnce(JSON.stringify(response), {
-        status: 200,
-        headers: {
-          'content-type': 'application/json',
-          Authorization: 'Bearer re_924b3rjh2387fbewf823',
-        },
+      mockSuccessResponse(response, {
+        headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
       });
 
       const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
@@ -234,6 +242,11 @@ describe('Topics', () => {
     "name": "Newsletter",
   },
   "error": null,
+  "rateLimiting": {
+    "limit": 2,
+    "remainingRequests": 2,
+    "shouldResetAfter": 1,
+  },
 }
 `);
     });
@@ -264,12 +277,8 @@ describe('Topics', () => {
       const response = {
         id: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223',
       };
-      fetchMock.mockOnce(JSON.stringify(response), {
-        status: 200,
-        headers: {
-          'content-type': 'application/json',
-          Authorization: 'Bearer re_924b3rjh2387fbewf823',
-        },
+      mockSuccessResponse(response, {
+        headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
       });
 
       const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
@@ -282,6 +291,11 @@ describe('Topics', () => {
     "id": "3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223",
   },
   "error": null,
+  "rateLimiting": {
+    "limit": 2,
+    "remainingRequests": 2,
+    "shouldResetAfter": 1,
+  },
 }
 `);
     });
@@ -313,12 +327,8 @@ describe('Topics', () => {
         object: 'topic',
         deleted: true,
       };
-      fetchMock.mockOnce(JSON.stringify(response), {
-        status: 200,
-        headers: {
-          'content-type': 'application/json',
-          Authorization: 'Bearer re_924b3rjh2387fbewf823',
-        },
+      mockSuccessResponse(response, {
+        headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
       });
 
       const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
@@ -332,6 +342,11 @@ describe('Topics', () => {
     "object": "topic",
   },
   "error": null,
+  "rateLimiting": {
+    "limit": 2,
+    "remainingRequests": 2,
+    "shouldResetAfter": 1,
+  },
 }
 `);
     });


### PR DESCRIPTION
This PR includes changes to the existing methods on `resend.contacts` to make `audienceId` optional, as well as new methods for managing a contact's audiences.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Made audienceId optional across contacts APIs and added contacts.audiences to list, add, and remove a contact’s audiences. Introduces pagination for global contact and contact-audience lists and query-string handling in the client.

- **New Features**
  - audienceId is now optional for contacts.create/list/get/update/remove; when omitted, requests hit /contacts.
  - contacts.list without audienceId supports pagination (limit, after, before) and returns { object: 'list', data, hasMore }.
  - New contacts.audiences.{list,add,remove}; identify the contact by email or contactId. list is paginated with the same options.
  - Added pagination helpers and response formatting (has_more -> hasMore), plus fetchRequest now supports options.query for building query strings.

<!-- End of auto-generated description by cubic. -->

