### PR TITLE
fix: changes headers name to keep standard

### DIFF
--- a/src/batch/batch.spec.ts
+++ b/src/batch/batch.spec.ts
@@ -319,7 +319,7 @@ describe('Batch', () => {
       const request = lastCall[1];
       expect(request).toBeDefined();
       const headers = new Headers(request?.headers);
-      expect(headers.get('x-batch-validation')).toBe('permissive');
+      expect(headers.get('x-resend-batch-validation')).toBe('permissive');
 
       expect(result.data).toEqual({
         data: [],

--- a/src/batch/batch.ts
+++ b/src/batch/batch.ts
@@ -51,7 +51,7 @@ export class Batch {
       {
         ...options,
         headers: {
-          'x-batch-validation': options?.batchValidation ?? 'strict',
+          'x-resend-batch-validation': options?.batchValidation ?? 'strict',
           ...options?.headers,
         },
       },

--- a/src/batch/interfaces/create-batch-options.interface.ts
+++ b/src/batch/interfaces/create-batch-options.interface.ts
@@ -24,7 +24,7 @@ export type CreateBatchSuccessResponse<
 } & (Options['batchValidation'] extends 'permissive'
   ? {
       /**
-       * Only present when header "x-batch-validation" is set to 'permissive'.
+       * Only present when header "x-resend-batch-validation" is set to 'permissive'.
        */
       errors: {
         /**


### PR DESCRIPTION
Add prefix `resend`  to headers name in order to keep our standard
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Renamed the batch validation header to x-resend-batch-validation to align with our x-resend-* standard. Updated request headers, tests, and inline docs; the batchValidation option and behavior are unchanged.

<!-- End of auto-generated description by cubic. -->

