### PR TITLE
feat: add emails.list method

### DIFF
--- a/src/emails/emails.spec.ts
+++ b/src/emails/emails.spec.ts
@@ -10,6 +10,7 @@ import type {
   CreateEmailResponseSuccess,
 } from './interfaces/create-email-options.interface';
 import type { GetEmailResponseSuccess } from './interfaces/get-email-options.interface';
+import type { ListEmailsResponseSuccess } from './interfaces/list-emails-options.interface';
 
 const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
 
@@ -543,6 +544,105 @@ describe('Emails', () => {
   },
 }
 `);
+      });
+    });
+  });
+
+  describe('list', () => {
+    const response: ListEmailsResponseSuccess = {
+      object: 'list',
+      has_more: false,
+      data: [
+        {
+          id: '67d9bcdb-5a02-42d7-8da9-0d6feea18cff',
+          to: ['zeno@resend.com'],
+          from: 'bu@resend.com',
+          created_at: '2023-04-07T23:13:52.669661+00:00',
+          subject: 'Test email',
+          bcc: null,
+          cc: null,
+          reply_to: null,
+          last_event: 'delivered',
+          scheduled_at: null,
+        },
+      ],
+    };
+    const headers = {
+      Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+    };
+
+    describe('when no pagination options provided', () => {
+      it('calls endpoint without query params and return the response', async () => {
+        mockSuccessResponse(response, {
+          headers,
+        });
+
+        const result = await resend.emails.list();
+        expect(result).toEqual({
+          data: response,
+          error: null,
+          rateLimiting: {
+            limit: 2,
+            remainingRequests: 2,
+            shouldResetAfter: 1,
+          },
+        });
+        expect(fetchMock.mock.calls[0][0]).toBe(
+          'https://api.resend.com/emails',
+        );
+      });
+    });
+
+    describe('when pagination options are provided', () => {
+      it('calls endpoint passing limit param and return the response', async () => {
+        mockSuccessResponse(response, { headers });
+        const result = await resend.emails.list({ limit: 10 });
+        expect(result).toEqual({
+          data: response,
+          error: null,
+          rateLimiting: {
+            limit: 2,
+            remainingRequests: 2,
+            shouldResetAfter: 1,
+          },
+        });
+        expect(fetchMock.mock.calls[0][0]).toBe(
+          'https://api.resend.com/emails?limit=10',
+        );
+      });
+
+      it('calls endpoint passing after param and return the response', async () => {
+        mockSuccessResponse(response, { headers });
+        const result = await resend.emails.list({ after: 'cursor123' });
+        expect(result).toEqual({
+          data: response,
+          error: null,
+          rateLimiting: {
+            limit: 2,
+            remainingRequests: 2,
+            shouldResetAfter: 1,
+          },
+        });
+        expect(fetchMock.mock.calls[0][0]).toBe(
+          'https://api.resend.com/emails?after=cursor123',
+        );
+      });
+
+      it('calls endpoint passing before param and return the response', async () => {
+        mockSuccessResponse(response, { headers });
+        const result = await resend.emails.list({ before: 'cursor123' });
+        expect(result).toEqual({
+          data: response,
+          error: null,
+          rateLimiting: {
+            limit: 2,
+            remainingRequests: 2,
+            shouldResetAfter: 1,
+          },
+        });
+        expect(fetchMock.mock.calls[0][0]).toBe(
+          'https://api.resend.com/emails?before=cursor123',
+        );
       });
     });
   });

--- a/src/emails/emails.ts
+++ b/src/emails/emails.ts
@@ -16,6 +16,11 @@ import type {
   GetEmailResponseSuccess,
 } from './interfaces/get-email-options.interface';
 import type {
+  ListEmailsOptions,
+  ListEmailsResponse,
+  ListEmailsResponseSuccess,
+} from './interfaces/list-emails-options.interface';
+import type {
   UpdateEmailOptions,
   UpdateEmailResponse,
   UpdateEmailResponseSuccess,
@@ -66,6 +71,29 @@ export class Emails {
     const data = await this.resend.get<GetEmailResponseSuccess>(
       `/emails/${id}`,
     );
+
+    return data;
+  }
+
+  async list(options: ListEmailsOptions = {}): Promise<ListEmailsResponse> {
+    const searchParams = new URLSearchParams();
+
+    if (options.limit !== undefined) {
+      searchParams.set('limit', options.limit.toString());
+    }
+
+    if ('after' in options && options.after !== undefined) {
+      searchParams.set('after', options.after);
+    }
+
+    if ('before' in options && options.before !== undefined) {
+      searchParams.set('before', options.before);
+    }
+
+    const queryString = searchParams.toString();
+    const url = queryString ? `/emails?${queryString}` : '/emails';
+
+    const data = await this.resend.get<ListEmailsResponseSuccess>(url);
 
     return data;
   }

--- a/src/emails/interfaces/list-emails-options.interface.ts
+++ b/src/emails/interfaces/list-emails-options.interface.ts
@@ -1,0 +1,37 @@
+import type { Response } from '../../interfaces';
+import type { GetEmailResponseSuccess } from './get-email-options.interface';
+
+// Pagination options using cursor-based approach
+export type ListEmailsOptions = {
+  /**
+   * Maximum number of emails to return (1-100, default: 20)
+   */
+  limit?: number;
+} & (
+  | {
+      /**
+       * Get emails after this cursor (cannot be used with 'before')
+       */
+      after?: string;
+    }
+  | {
+      /**
+       * Get emails before this cursor (cannot be used with 'after')
+       */
+      before?: string;
+    }
+);
+
+// Base email type for listing (subset of full email)
+export type ListEmail = Omit<
+  GetEmailResponseSuccess,
+  'html' | 'text' | 'tags' | 'object'
+>;
+
+export type ListEmailsResponseSuccess = {
+  object: 'list';
+  has_more: boolean;
+  data: ListEmail[];
+};
+
+export type ListEmailsResponse = Response<ListEmailsResponseSuccess>;


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds emails.list to the Node SDK to list sent emails with cursor-based pagination, aligning with Linear ENG-4360. Returns a typed list response with minimal email fields.

- **New Features**
  - Added Emails.list(options) with limit, after, or before query params.
  - Options: limit (1–100); after or before (mutually exclusive).
  - Typed response: { object: 'list', has_more, data: Email[] } (subset of GetEmail).
  - Unit tests for default call and each option, verifying URLs and response handling.

<!-- End of auto-generated description by cubic. -->

