### PR TITLE
fix: links in js doc comments on rate limiting API

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -21,30 +21,32 @@ export const RESEND_ERROR_CODES_BY_KEY = {
 
 export type RESEND_ERROR_CODE_KEY = keyof typeof RESEND_ERROR_CODES_BY_KEY;
 
+export type RateLimitExceededErrorResponse = {
+  message: string;
+  name: Extract<RESEND_ERROR_CODE_KEY, 'rate_limit_exceeded'>;
+  /**
+   * Time in seconds.
+   */
+  retryAfter: number;
+};
+
 export type ErrorResponse =
   | {
-      message: string;
-      name: Exclude<RESEND_ERROR_CODE_KEY, 'rate_limit_exceeded'>;
-    }
-  | {
-      message: string;
-      name: Extract<RESEND_ERROR_CODE_KEY, 'rate_limit_exceeded'>;
-      /**
-       * Time in seconds.
-       */
-      retryAfter: number;
-    };
+    message: string;
+    name: Exclude<RESEND_ERROR_CODE_KEY, 'rate_limit_exceeded'>;
+  }
+  | RateLimitExceededErrorResponse;
 
 export type Response<Data> =
   | {
-      data: Data;
-      rateLimiting: RateLimit;
-      error: null;
-    }
+    data: Data;
+    rateLimiting: RateLimit;
+    error: null;
+  }
   | {
-      data: null;
-      rateLimiting: RateLimit | null;
-      error: ErrorResponse;
-    };
+    data: null;
+    rateLimiting: RateLimit | null;
+    error: ErrorResponse;
+  };
 
 export type Tag = { name: string; value: string };

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -32,21 +32,21 @@ export type RateLimitExceededErrorResponse = {
 
 export type ErrorResponse =
   | {
-    message: string;
-    name: Exclude<RESEND_ERROR_CODE_KEY, 'rate_limit_exceeded'>;
-  }
+      message: string;
+      name: Exclude<RESEND_ERROR_CODE_KEY, 'rate_limit_exceeded'>;
+    }
   | RateLimitExceededErrorResponse;
 
 export type Response<Data> =
   | {
-    data: Data;
-    rateLimiting: RateLimit;
-    error: null;
-  }
+      data: Data;
+      rateLimiting: RateLimit;
+      error: null;
+    }
   | {
-    data: null;
-    rateLimiting: RateLimit | null;
-    error: ErrorResponse;
-  };
+      data: null;
+      rateLimiting: RateLimit | null;
+      error: ErrorResponse;
+    };
 
 export type Tag = { name: string; value: string };

--- a/src/rate-limiting.ts
+++ b/src/rate-limiting.ts
@@ -1,10 +1,8 @@
-// @ts-expect-error: this is used in the jsdoc for `shouldResetAfter`
-// biome-ignore lint/correctness/noUnusedImports: this is used in the jsdoc for `shouldResetAfter`
-import type { Response } from './interfaces';
+import type { RateLimitExceededErrorResponse } from './interfaces';
 
 export type RateLimit = {
   /**
-   * The maximum amount of requests that can be made in the time window of {@link shouldResetAfter}.
+   * The maximum amount of requests that can be made in the time window of {@link RateLimit.shouldResetAfter}.
    */
   limit: number;
   /**
@@ -18,7 +16,7 @@ export type RateLimit = {
    * and {@link RateLimit.remainingRequests} goes back to the value of
    * {@link RateLimit.limit}.
    *
-   * @see {@link import('./interfaces').Response.retryAfter}
+   * @see {@link RateLimitExceededErrorResponse.retryAfter}
    */
   shouldResetAfter: number;
 };


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes broken JSDoc links in the rate-limiting API so editor hovers and generated docs reference the correct fields. Adds a named RateLimitExceededErrorResponse type and updates comments to link to RateLimit.shouldResetAfter and RateLimitExceededErrorResponse.retryAfter; removes unused import/ts-expect-error. No runtime changes.

<!-- End of auto-generated description by cubic. -->

