### PR TITLE
feat: add pagination support for all old endpoints

### DIFF
--- a/src/api-keys/api-keys.spec.ts
+++ b/src/api-keys/api-keys.spec.ts
@@ -262,8 +262,10 @@ describe('API Keys', () => {
   });
 
   describe('list', () => {
-    it('lists api keys', async () => {
-      const response: ListApiKeysResponseSuccess = [
+    const response: ListApiKeysResponseSuccess = {
+      object: 'list',
+      has_more: false,
+      data: [
         {
           id: '5262504e-8ed7-4fac-bd16-0d4be94bc9f2',
           name: 'My API Key 1',
@@ -274,35 +276,114 @@ describe('API Keys', () => {
           name: 'My API Key 2',
           created_at: '2023-04-06T23:09:49.093947+00:00',
         },
-      ];
-      mockSuccessResponse(response, {
-        headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
+      ],
+    };
+
+    describe('when no pagination options are provided', () => {
+      it('lists api keys', async () => {
+        mockSuccessResponse(response, {
+          headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+        const result = await resend.apiKeys.list();
+        expect(result).toEqual({
+          data: response,
+          error: null,
+          rateLimiting: {
+            limit: 2,
+            remainingRequests: 2,
+            shouldResetAfter: 1,
+          },
+        });
+      });
+    });
+
+    describe('when pagination options are provided', () => {
+      it('passes limit param and returns a response', async () => {
+        mockSuccessResponse(response, {
+          headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+        const result = await resend.apiKeys.list({ limit: 1 });
+        expect(result).toEqual({
+          data: response,
+          error: null,
+          rateLimiting: {
+            limit: 2,
+            remainingRequests: 2,
+            shouldResetAfter: 1,
+          },
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://api.resend.com/api-keys?limit=1',
+          expect.objectContaining({
+            method: 'GET',
+            headers: expect.any(Headers),
+          }),
+        );
       });
 
-      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      it('passes after param and returns a response', async () => {
+        mockSuccessResponse(response, {
+          headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
+        });
 
-      await expect(resend.apiKeys.list()).resolves.toMatchInlineSnapshot(`
-{
-  "data": [
-    {
-      "created_at": "2023-04-07T20:29:10.666968+00:00",
-      "id": "5262504e-8ed7-4fac-bd16-0d4be94bc9f2",
-      "name": "My API Key 1",
-    },
-    {
-      "created_at": "2023-04-06T23:09:49.093947+00:00",
-      "id": "98c37b35-1473-4afe-a627-78e975a36fab",
-      "name": "My API Key 2",
-    },
-  ],
-  "error": null,
-  "rateLimiting": {
-    "limit": 2,
-    "remainingRequests": 2,
-    "shouldResetAfter": 1,
-  },
-}
-`);
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+        const result = await resend.apiKeys.list({
+          limit: 1,
+          after: 'cursor-value',
+        });
+        expect(result).toEqual({
+          data: response,
+          error: null,
+          rateLimiting: {
+            limit: 2,
+            remainingRequests: 2,
+            shouldResetAfter: 1,
+          },
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://api.resend.com/api-keys?limit=1&after=cursor-value',
+          expect.objectContaining({
+            method: 'GET',
+            headers: expect.any(Headers),
+          }),
+        );
+      });
+
+      it('passes before param and returns a response', async () => {
+        mockSuccessResponse(response, {
+          headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+        const result = await resend.apiKeys.list({
+          limit: 1,
+          before: 'cursor-value',
+        });
+        expect(result).toEqual({
+          data: response,
+          error: null,
+          rateLimiting: {
+            limit: 2,
+            remainingRequests: 2,
+            shouldResetAfter: 1,
+          },
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://api.resend.com/api-keys?limit=1&before=cursor-value',
+          expect.objectContaining({
+            method: 'GET',
+            headers: expect.any(Headers),
+          }),
+        );
+      });
     });
   });
 

--- a/src/api-keys/api-keys.spec.ts
+++ b/src/api-keys/api-keys.spec.ts
@@ -297,6 +297,14 @@ describe('API Keys', () => {
             shouldResetAfter: 1,
           },
         });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://api.resend.com/api-keys',
+          expect.objectContaining({
+            method: 'GET',
+            headers: expect.any(Headers),
+          }),
+        );
       });
     });
 

--- a/src/api-keys/api-keys.ts
+++ b/src/api-keys/api-keys.ts
@@ -1,3 +1,4 @@
+import { buildPaginationQuery } from '../common/utils/build-pagination-query';
 import type { Resend } from '../resend';
 import type {
   CreateApiKeyOptions,
@@ -6,6 +7,7 @@ import type {
   CreateApiKeyResponseSuccess,
 } from './interfaces/create-api-key-options.interface';
 import type {
+  ListApiKeysOptions,
   ListApiKeysResponse,
   ListApiKeysResponseSuccess,
 } from './interfaces/list-api-keys.interface';
@@ -30,8 +32,11 @@ export class ApiKeys {
     return data;
   }
 
-  async list(): Promise<ListApiKeysResponse> {
-    const data = await this.resend.get<ListApiKeysResponseSuccess>('/api-keys');
+  async list(options: ListApiKeysOptions = {}): Promise<ListApiKeysResponse> {
+    const queryString = buildPaginationQuery(options);
+    const url = queryString ? `/api-keys?${queryString}` : '/api-keys';
+
+    const data = await this.resend.get<ListApiKeysResponseSuccess>(url);
     return data;
   }
 

--- a/src/api-keys/interfaces/list-api-keys.interface.ts
+++ b/src/api-keys/interfaces/list-api-keys.interface.ts
@@ -1,9 +1,13 @@
+import type { PaginationOptions } from '../../common/interfaces';
 import type { Response } from '../../interfaces';
 import type { ApiKey } from './api-key';
 
-export type ListApiKeysResponseSuccess = Pick<
-  ApiKey,
-  'name' | 'id' | 'created_at'
->[];
+export type ListApiKeysOptions = PaginationOptions;
+
+export type ListApiKeysResponseSuccess = {
+  object: 'list';
+  has_more: boolean;
+  data: Pick<ApiKey, 'name' | 'id' | 'created_at'>[];
+};
 
 export type ListApiKeysResponse = Response<ListApiKeysResponseSuccess>;

--- a/src/audiences/audiences.spec.ts
+++ b/src/audiences/audiences.spec.ts
@@ -81,53 +81,128 @@ describe('Audiences', () => {
   });
 
   describe('list', () => {
-    it('lists audiences', async () => {
-      const response: ListAudiencesResponseSuccess = {
-        object: 'list',
-        data: [
-          {
-            id: 'b6d24b8e-af0b-4c3c-be0c-359bbd97381e',
-            name: 'resend.com',
-            created_at: '2023-04-07T23:13:52.669661+00:00',
+    const response: ListAudiencesResponseSuccess = {
+      object: 'list',
+      has_more: false,
+      data: [
+        {
+          id: 'b6d24b8e-af0b-4c3c-be0c-359bbd97381e',
+          name: 'resend.com',
+          created_at: '2023-04-07T23:13:52.669661+00:00',
+        },
+        {
+          id: 'ac7503ac-e027-4aea-94b3-b0acd46f65f9',
+          name: 'react.email',
+          created_at: '2023-04-07T23:13:20.417116+00:00',
+        },
+      ],
+    };
+
+    describe('when no pagination options are provided', () => {
+      it('lists audiences', async () => {
+        mockSuccessResponse(response, {
+          headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+        const result = await resend.audiences.list();
+        expect(result).toEqual({
+          data: response,
+          error: null,
+          rateLimiting: {
+            limit: 2,
+            remainingRequests: 2,
+            shouldResetAfter: 1,
           },
-          {
-            id: 'ac7503ac-e027-4aea-94b3-b0acd46f65f9',
-            name: 'react.email',
-            created_at: '2023-04-07T23:13:20.417116+00:00',
+        });
+      });
+    });
+
+    describe('when pagination options are provided', () => {
+      it('passes limit param and returns a response', async () => {
+        mockSuccessResponse(response, {
+          headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+        const result = await resend.audiences.list({ limit: 1 });
+        expect(result).toEqual({
+          data: response,
+          error: null,
+          rateLimiting: {
+            limit: 2,
+            remainingRequests: 2,
+            shouldResetAfter: 1,
           },
-        ],
-      };
-      mockSuccessResponse(response, {
-        headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://api.resend.com/audiences?limit=1',
+          expect.objectContaining({
+            method: 'GET',
+            headers: expect.any(Headers),
+          }),
+        );
       });
 
-      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      it('passes after param and returns a response', async () => {
+        mockSuccessResponse(response, {
+          headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
+        });
 
-      await expect(resend.audiences.list()).resolves.toMatchInlineSnapshot(`
-{
-  "data": {
-    "data": [
-      {
-        "created_at": "2023-04-07T23:13:52.669661+00:00",
-        "id": "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
-        "name": "resend.com",
-      },
-      {
-        "created_at": "2023-04-07T23:13:20.417116+00:00",
-        "id": "ac7503ac-e027-4aea-94b3-b0acd46f65f9",
-        "name": "react.email",
-      },
-    ],
-    "object": "list",
-  },
-  "error": null,
-  "rateLimiting": {
-    "limit": 2,
-    "remainingRequests": 2,
-    "shouldResetAfter": 1,
-  },
-}
-`);
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+        const result = await resend.audiences.list({
+          limit: 1,
+          after: 'cursor-value',
+        });
+        expect(result).toEqual({
+          data: response,
+          error: null,
+          rateLimiting: {
+            limit: 2,
+            remainingRequests: 2,
+            shouldResetAfter: 1,
+          },
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://api.resend.com/audiences?limit=1&after=cursor-value',
+          expect.objectContaining({
+            method: 'GET',
+            headers: expect.any(Headers),
+          }),
+        );
+      });
+
+      it('passes before param and returns a response', async () => {
+        mockSuccessResponse(response, {
+          headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+        const result = await resend.audiences.list({
+          limit: 1,
+          before: 'cursor-value',
+        });
+        expect(result).toEqual({
+          data: response,
+          error: null,
+          rateLimiting: {
+            limit: 2,
+            remainingRequests: 2,
+            shouldResetAfter: 1,
+          },
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://api.resend.com/audiences?limit=1&before=cursor-value',
+          expect.objectContaining({
+            method: 'GET',
+            headers: expect.any(Headers),
+          }),
+        );
+      });
     });
   });
 

--- a/src/audiences/audiences.spec.ts
+++ b/src/audiences/audiences.spec.ts
@@ -116,6 +116,14 @@ describe('Audiences', () => {
             shouldResetAfter: 1,
           },
         });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://api.resend.com/audiences',
+          expect.objectContaining({
+            method: 'GET',
+            headers: expect.any(Headers),
+          }),
+        );
       });
     });
 

--- a/src/audiences/audiences.ts
+++ b/src/audiences/audiences.ts
@@ -1,3 +1,4 @@
+import { buildPaginationQuery } from '../common/utils/build-pagination-query';
 import type { Resend } from '../resend';
 import type {
   CreateAudienceOptions,
@@ -10,6 +11,7 @@ import type {
   GetAudienceResponseSuccess,
 } from './interfaces/get-audience.interface';
 import type {
+  ListAudiencesOptions,
   ListAudiencesResponse,
   ListAudiencesResponseSuccess,
 } from './interfaces/list-audiences.interface';
@@ -33,9 +35,13 @@ export class Audiences {
     return data;
   }
 
-  async list(): Promise<ListAudiencesResponse> {
-    const data =
-      await this.resend.get<ListAudiencesResponseSuccess>('/audiences');
+  async list(
+    options: ListAudiencesOptions = {},
+  ): Promise<ListAudiencesResponse> {
+    const queryString = buildPaginationQuery(options);
+    const url = queryString ? `/audiences?${queryString}` : '/audiences';
+
+    const data = await this.resend.get<ListAudiencesResponseSuccess>(url);
     return data;
   }
 

--- a/src/audiences/interfaces/list-audiences.interface.ts
+++ b/src/audiences/interfaces/list-audiences.interface.ts
@@ -1,9 +1,13 @@
+import type { PaginationOptions } from '../../common/interfaces';
 import type { Response } from '../../interfaces';
 import type { Audience } from './audience';
+
+export type ListAudiencesOptions = PaginationOptions;
 
 export type ListAudiencesResponseSuccess = {
   object: 'list';
   data: Audience[];
+  has_more: boolean;
 };
 
 export type ListAudiencesResponse = Response<ListAudiencesResponseSuccess>;

--- a/src/broadcasts/broadcasts.spec.ts
+++ b/src/broadcasts/broadcasts.spec.ts
@@ -312,6 +312,14 @@ describe('Broadcasts', () => {
             shouldResetAfter: 1,
           },
         });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://api.resend.com/broadcasts',
+          expect.objectContaining({
+            method: 'GET',
+            headers: expect.any(Headers),
+          }),
+        );
       });
     });
 

--- a/src/broadcasts/broadcasts.spec.ts
+++ b/src/broadcasts/broadcasts.spec.ts
@@ -269,69 +269,136 @@ describe('Broadcasts', () => {
   });
 
   describe('list', () => {
-    it('lists broadcasts', async () => {
-      const response: ListBroadcastsResponseSuccess = {
-        object: 'list',
-        data: [
-          {
-            id: '49a3999c-0ce1-4ea6-ab68-afcd6dc2e794',
-            audience_id: '78261eea-8f8b-4381-83c6-79fa7120f1cf',
-            name: 'broadcast 1',
-            status: 'draft',
-            created_at: '2024-11-01T15:13:31.723Z',
-            scheduled_at: null,
-            sent_at: null,
+    const response: ListBroadcastsResponseSuccess = {
+      object: 'list',
+      has_more: false,
+      data: [
+        {
+          id: '49a3999c-0ce1-4ea6-ab68-afcd6dc2e794',
+          audience_id: '78261eea-8f8b-4381-83c6-79fa7120f1cf',
+          name: 'broadcast 1',
+          status: 'draft',
+          created_at: '2024-11-01T15:13:31.723Z',
+          scheduled_at: null,
+          sent_at: null,
+        },
+        {
+          id: '559ac32e-9ef5-46fb-82a1-b76b840c0f7b',
+          audience_id: '78261eea-8f8b-4381-83c6-79fa7120f1cf',
+          name: 'broadcast 2',
+          status: 'sent',
+          created_at: '2024-12-01T19:32:22.980Z',
+          scheduled_at: '2024-12-02T19:32:22.980Z',
+          sent_at: '2024-12-02T19:32:22.980Z',
+        },
+      ],
+    };
+
+    describe('when no pagination options are provided', () => {
+      it('lists broadcasts', async () => {
+        mockSuccessResponse(response, {
+          headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+        const result = await resend.broadcasts.list();
+        expect(result).toEqual({
+          data: response,
+          error: null,
+          rateLimiting: {
+            limit: 2,
+            remainingRequests: 2,
+            shouldResetAfter: 1,
           },
-          {
-            id: '559ac32e-9ef5-46fb-82a1-b76b840c0f7b',
-            audience_id: '78261eea-8f8b-4381-83c6-79fa7120f1cf',
-            name: 'broadcast 2',
-            status: 'sent',
-            created_at: '2024-12-01T19:32:22.980Z',
-            scheduled_at: '2024-12-02T19:32:22.980Z',
-            sent_at: '2024-12-02T19:32:22.980Z',
+        });
+      });
+    });
+
+    describe('when pagination options are provided', () => {
+      it('passes limit param and returns a response', async () => {
+        mockSuccessResponse(response, {
+          headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+        const result = await resend.broadcasts.list({ limit: 1 });
+        expect(result).toEqual({
+          data: response,
+          error: null,
+          rateLimiting: {
+            limit: 2,
+            remainingRequests: 2,
+            shouldResetAfter: 1,
           },
-        ],
-      };
-      mockSuccessResponse(response, {
-        headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://api.resend.com/broadcasts?limit=1',
+          expect.objectContaining({
+            method: 'GET',
+            headers: expect.any(Headers),
+          }),
+        );
       });
 
-      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      it('passes after param and returns a response', async () => {
+        mockSuccessResponse(response, {
+          headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
+        });
 
-      await expect(resend.broadcasts.list()).resolves.toMatchInlineSnapshot(`
-{
-  "data": {
-    "data": [
-      {
-        "audience_id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
-        "created_at": "2024-11-01T15:13:31.723Z",
-        "id": "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794",
-        "name": "broadcast 1",
-        "scheduled_at": null,
-        "sent_at": null,
-        "status": "draft",
-      },
-      {
-        "audience_id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
-        "created_at": "2024-12-01T19:32:22.980Z",
-        "id": "559ac32e-9ef5-46fb-82a1-b76b840c0f7b",
-        "name": "broadcast 2",
-        "scheduled_at": "2024-12-02T19:32:22.980Z",
-        "sent_at": "2024-12-02T19:32:22.980Z",
-        "status": "sent",
-      },
-    ],
-    "object": "list",
-  },
-  "error": null,
-  "rateLimiting": {
-    "limit": 2,
-    "remainingRequests": 2,
-    "shouldResetAfter": 1,
-  },
-}
-`);
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+        const result = await resend.broadcasts.list({
+          limit: 1,
+          after: 'cursor-value',
+        });
+        expect(result).toEqual({
+          data: response,
+          error: null,
+          rateLimiting: {
+            limit: 2,
+            remainingRequests: 2,
+            shouldResetAfter: 1,
+          },
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://api.resend.com/broadcasts?limit=1&after=cursor-value',
+          expect.objectContaining({
+            method: 'GET',
+            headers: expect.any(Headers),
+          }),
+        );
+      });
+
+      it('passes before param and returns a response', async () => {
+        mockSuccessResponse(response, {
+          headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+        const result = await resend.broadcasts.list({
+          limit: 1,
+          before: 'cursor-value',
+        });
+        expect(result).toEqual({
+          data: response,
+          error: null,
+          rateLimiting: {
+            limit: 2,
+            remainingRequests: 2,
+            shouldResetAfter: 1,
+          },
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://api.resend.com/broadcasts?limit=1&before=cursor-value',
+          expect.objectContaining({
+            method: 'GET',
+            headers: expect.any(Headers),
+          }),
+        );
+      });
     });
   });
 

--- a/src/broadcasts/broadcasts.ts
+++ b/src/broadcasts/broadcasts.ts
@@ -1,4 +1,5 @@
 import type * as React from 'react';
+import { buildPaginationQuery } from '../common/utils/build-pagination-query';
 import type { Resend } from '../resend';
 import type {
   CreateBroadcastOptions,
@@ -9,6 +10,7 @@ import type {
   GetBroadcastResponseSuccess,
 } from './interfaces/get-broadcast.interface';
 import type {
+  ListBroadcastsOptions,
   ListBroadcastsResponse,
   ListBroadcastsResponseSuccess,
 } from './interfaces/list-broadcasts.interface';
@@ -82,9 +84,13 @@ export class Broadcasts {
     return data;
   }
 
-  async list(): Promise<ListBroadcastsResponse> {
-    const data =
-      await this.resend.get<ListBroadcastsResponseSuccess>('/broadcasts');
+  async list(
+    options: ListBroadcastsOptions = {},
+  ): Promise<ListBroadcastsResponse> {
+    const queryString = buildPaginationQuery(options);
+    const url = queryString ? `/broadcasts?${queryString}` : '/broadcasts';
+
+    const data = await this.resend.get<ListBroadcastsResponseSuccess>(url);
     return data;
   }
 

--- a/src/broadcasts/interfaces/list-broadcasts.interface.ts
+++ b/src/broadcasts/interfaces/list-broadcasts.interface.ts
@@ -1,8 +1,12 @@
+import type { PaginationOptions } from '../../common/interfaces';
 import type { Response } from '../../interfaces';
 import type { Broadcast } from './broadcast';
 
+export type ListBroadcastsOptions = PaginationOptions;
+
 export type ListBroadcastsResponseSuccess = {
   object: 'list';
+  has_more: boolean;
   data: Pick<
     Broadcast,
     | 'id'

--- a/src/common/interfaces/index.ts
+++ b/src/common/interfaces/index.ts
@@ -1,4 +1,5 @@
 export * from './get-option.interface';
 export * from './list-option.interface';
+export * from './pagination-options.interface';
 export * from './post-option.interface';
 export * from './put-option.interface';

--- a/src/common/interfaces/pagination-options.interface.ts
+++ b/src/common/interfaces/pagination-options.interface.ts
@@ -1,0 +1,20 @@
+// Pagination options using cursor-based approach
+export type PaginationOptions = {
+  /**
+   * Maximum number of items to return (1-100, default: 20)
+   */
+  limit?: number;
+} & (
+  | {
+      /**
+       * Get items after this cursor (cannot be used with 'before')
+       */
+      after?: string;
+    }
+  | {
+      /**
+       * Get items before this cursor (cannot be used with 'after')
+       */
+      before?: string;
+    }
+);

--- a/src/common/utils/build-pagination-query.ts
+++ b/src/common/utils/build-pagination-query.ts
@@ -1,0 +1,24 @@
+import type { PaginationOptions } from '../interfaces/pagination-options.interface';
+
+/**
+ * Builds a query string from pagination options
+ * @param options - Pagination options containing limit, after, and/or before
+ * @returns Query string (without leading '?') or empty string if no options
+ */
+export function buildPaginationQuery(options: PaginationOptions): string {
+  const searchParams = new URLSearchParams();
+
+  if (options.limit !== undefined) {
+    searchParams.set('limit', options.limit.toString());
+  }
+
+  if ('after' in options && options.after !== undefined) {
+    searchParams.set('after', options.after);
+  }
+
+  if ('before' in options && options.before !== undefined) {
+    searchParams.set('before', options.before);
+  }
+
+  return searchParams.toString();
+}

--- a/src/contacts/contacts.spec.ts
+++ b/src/contacts/contacts.spec.ts
@@ -95,40 +95,42 @@ describe('Contacts', () => {
   });
 
   describe('list', () => {
-    it('lists contacts', async () => {
-      const options: ListContactsOptions = {
-        audienceId: 'b6d24b8e-af0b-4c3c-be0c-359bbd97381a',
-      };
-      const response: ListContactsResponseSuccess = {
-        object: 'list',
-        data: [
-          {
-            id: 'b6d24b8e-af0b-4c3c-be0c-359bbd97381e',
-            email: 'team@resend.com',
-            created_at: '2023-04-07T23:13:52.669661+00:00',
-            unsubscribed: false,
-            first_name: 'John',
-            last_name: 'Smith',
-          },
-          {
-            id: 'ac7503ac-e027-4aea-94b3-b0acd46f65f9',
-            email: 'team@react.email',
-            created_at: '2023-04-07T23:13:20.417116+00:00',
-            unsubscribed: false,
-            first_name: 'John',
-            last_name: 'Smith',
-          },
-        ],
-      };
-      mockSuccessResponse(response, {
-        headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
-      });
+    describe('without pagination', () => {
+      it('lists contacts', async () => {
+        const options: ListContactsOptions = {
+          audienceId: 'b6d24b8e-af0b-4c3c-be0c-359bbd97381a',
+        };
+        const response: ListContactsResponseSuccess = {
+          object: 'list',
+          has_more: false,
+          data: [
+            {
+              id: 'b6d24b8e-af0b-4c3c-be0c-359bbd97381e',
+              email: 'team@resend.com',
+              created_at: '2023-04-07T23:13:52.669661+00:00',
+              unsubscribed: false,
+              first_name: 'John',
+              last_name: 'Smith',
+            },
+            {
+              id: 'ac7503ac-e027-4aea-94b3-b0acd46f65f9',
+              email: 'team@react.email',
+              created_at: '2023-04-07T23:13:20.417116+00:00',
+              unsubscribed: false,
+              first_name: 'John',
+              last_name: 'Smith',
+            },
+          ],
+        };
+        mockSuccessResponse(response, {
+          headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
+        });
 
-      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
 
-      await expect(
-        resend.contacts.list(options),
-      ).resolves.toMatchInlineSnapshot(`
+        await expect(
+          resend.contacts.list(options),
+        ).resolves.toMatchInlineSnapshot(`
 {
   "data": {
     "data": [
@@ -149,6 +151,7 @@ describe('Contacts', () => {
         "unsubscribed": false,
       },
     ],
+    "has_more": false,
     "object": "list",
   },
   "error": null,
@@ -159,6 +162,113 @@ describe('Contacts', () => {
   },
 }
 `);
+      });
+    });
+
+    describe('when pagination options are provided', () => {
+      const response: ListContactsResponseSuccess = {
+        object: 'list',
+        has_more: true,
+        data: [
+          {
+            id: 'b6d24b8e-af0b-4c3c-be0c-359bbd97381e',
+            email: 'team@resend.com',
+            created_at: '2023-04-07T23:13:52.669661+00:00',
+            unsubscribed: false,
+            first_name: 'John',
+            last_name: 'Smith',
+          },
+        ],
+      };
+
+      it('passes limit param and returns a response', async () => {
+        mockSuccessResponse(response, {
+          headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+        const result = await resend.contacts.list({
+          audienceId: 'b6d24b8e-af0b-4c3c-be0c-359bbd97381a',
+          limit: 1,
+        });
+        expect(result).toEqual({
+          data: response,
+          error: null,
+          rateLimiting: {
+            limit: 2,
+            remainingRequests: 2,
+            shouldResetAfter: 1,
+          },
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://api.resend.com/audiences/b6d24b8e-af0b-4c3c-be0c-359bbd97381a/contacts?limit=1',
+          expect.objectContaining({
+            method: 'GET',
+            headers: expect.any(Headers),
+          }),
+        );
+      });
+
+      it('passes limit and after params and returns a response', async () => {
+        mockSuccessResponse(response, {
+          headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+        const result = await resend.contacts.list({
+          audienceId: 'b6d24b8e-af0b-4c3c-be0c-359bbd97381a',
+          limit: 1,
+          after: 'cursor-value',
+        });
+        expect(result).toEqual({
+          data: response,
+          error: null,
+          rateLimiting: {
+            limit: 2,
+            remainingRequests: 2,
+            shouldResetAfter: 1,
+          },
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://api.resend.com/audiences/b6d24b8e-af0b-4c3c-be0c-359bbd97381a/contacts?limit=1&after=cursor-value',
+          expect.objectContaining({
+            method: 'GET',
+            headers: expect.any(Headers),
+          }),
+        );
+      });
+
+      it('passes limit and before params and returns a response', async () => {
+        mockSuccessResponse(response, {
+          headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+        const result = await resend.contacts.list({
+          audienceId: 'b6d24b8e-af0b-4c3c-be0c-359bbd97381a',
+          limit: 1,
+          before: 'cursor-value',
+        });
+        expect(result).toEqual({
+          data: response,
+          error: null,
+          rateLimiting: {
+            limit: 2,
+            remainingRequests: 2,
+            shouldResetAfter: 1,
+          },
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://api.resend.com/audiences/b6d24b8e-af0b-4c3c-be0c-359bbd97381a/contacts?limit=1&before=cursor-value',
+          expect.objectContaining({
+            method: 'GET',
+            headers: expect.any(Headers),
+          }),
+        );
+      });
     });
   });
 

--- a/src/contacts/contacts.spec.ts
+++ b/src/contacts/contacts.spec.ts
@@ -128,40 +128,24 @@ describe('Contacts', () => {
 
         const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
 
-        await expect(
-          resend.contacts.list(options),
-        ).resolves.toMatchInlineSnapshot(`
-{
-  "data": {
-    "data": [
-      {
-        "created_at": "2023-04-07T23:13:52.669661+00:00",
-        "email": "team@resend.com",
-        "first_name": "John",
-        "id": "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
-        "last_name": "Smith",
-        "unsubscribed": false,
-      },
-      {
-        "created_at": "2023-04-07T23:13:20.417116+00:00",
-        "email": "team@react.email",
-        "first_name": "John",
-        "id": "ac7503ac-e027-4aea-94b3-b0acd46f65f9",
-        "last_name": "Smith",
-        "unsubscribed": false,
-      },
-    ],
-    "has_more": false,
-    "object": "list",
-  },
-  "error": null,
-  "rateLimiting": {
-    "limit": 2,
-    "remainingRequests": 2,
-    "shouldResetAfter": 1,
-  },
-}
-`);
+        const result = await resend.contacts.list(options);
+        expect(result).toEqual({
+          data: response,
+          error: null,
+          rateLimiting: {
+            limit: 2,
+            remainingRequests: 2,
+            shouldResetAfter: 1,
+          },
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://api.resend.com/audiences/b6d24b8e-af0b-4c3c-be0c-359bbd97381a/contacts',
+          expect.objectContaining({
+            method: 'GET',
+            headers: expect.any(Headers),
+          }),
+        );
       });
     });
 

--- a/src/contacts/contacts.ts
+++ b/src/contacts/contacts.ts
@@ -1,3 +1,4 @@
+import { buildPaginationQuery } from '../common/utils/build-pagination-query';
 import type { Resend } from '../resend';
 import type {
   CreateContactOptions,
@@ -47,9 +48,13 @@ export class Contacts {
   }
 
   async list(options: ListContactsOptions): Promise<ListContactsResponse> {
-    const data = await this.resend.get<ListContactsResponseSuccess>(
-      `/audiences/${options.audienceId}/contacts`,
-    );
+    const { audienceId, ...paginationOptions } = options;
+    const queryString = buildPaginationQuery(paginationOptions);
+    const url = queryString
+      ? `/audiences/${audienceId}/contacts?${queryString}`
+      : `/audiences/${audienceId}/contacts`;
+
+    const data = await this.resend.get<ListContactsResponseSuccess>(url);
     return data;
   }
 

--- a/src/contacts/interfaces/list-contacts.interface.ts
+++ b/src/contacts/interfaces/list-contacts.interface.ts
@@ -1,13 +1,15 @@
+import type { PaginationOptions } from '../../common/interfaces';
 import type { Response } from '../../interfaces';
 import type { Contact } from './contact';
 
-export interface ListContactsOptions {
+export type ListContactsOptions = {
   audienceId: string;
-}
+} & PaginationOptions;
 
 export interface ListContactsResponseSuccess {
   object: 'list';
   data: Contact[];
+  has_more: boolean;
 }
 
 export type ListContactsResponse = Response<ListContactsResponseSuccess>;

--- a/src/domains/domains.spec.ts
+++ b/src/domains/domains.spec.ts
@@ -379,59 +379,132 @@ describe('Domains', () => {
   });
 
   describe('list', () => {
-    it('lists domains', async () => {
-      const response: ListDomainsResponseSuccess = {
-        data: [
-          {
-            id: 'b6d24b8e-af0b-4c3c-be0c-359bbd97381e',
-            name: 'resend.com',
-            status: 'not_started',
-            created_at: '2023-04-07T23:13:52.669661+00:00',
-            region: 'eu-west-1',
+    const response: ListDomainsResponseSuccess = {
+      has_more: false,
+      object: 'list',
+      data: [
+        {
+          id: 'b6d24b8e-af0b-4c3c-be0c-359bbd97381e',
+          name: 'resend.com',
+          status: 'not_started',
+          created_at: '2023-04-07T23:13:52.669661+00:00',
+          region: 'eu-west-1',
+        },
+        {
+          id: 'ac7503ac-e027-4aea-94b3-b0acd46f65f9',
+          name: 'react.email',
+          status: 'not_started',
+          created_at: '2023-04-07T23:13:20.417116+00:00',
+          region: 'us-east-1',
+        },
+      ],
+    };
+
+    describe('when no pagination options are provided', () => {
+      it('lists domains', async () => {
+        mockSuccessResponse(response, {
+          headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+        const result = await resend.domains.list();
+        expect(result).toEqual({
+          data: response,
+          error: null,
+          rateLimiting: {
+            limit: 2,
+            remainingRequests: 2,
+            shouldResetAfter: 1,
           },
-          {
-            id: 'ac7503ac-e027-4aea-94b3-b0acd46f65f9',
-            name: 'react.email',
-            status: 'not_started',
-            created_at: '2023-04-07T23:13:20.417116+00:00',
-            region: 'us-east-1',
+        });
+      });
+    });
+
+    describe('when pagination options are provided', () => {
+      it('passes limit param and returns a response', async () => {
+        mockSuccessResponse(response, {
+          headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+        const result = await resend.domains.list({ limit: 1 });
+        expect(result).toEqual({
+          data: response,
+          error: null,
+          rateLimiting: {
+            limit: 2,
+            remainingRequests: 2,
+            shouldResetAfter: 1,
           },
-        ],
-      };
-      mockSuccessResponse(response, {
-        headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://api.resend.com/domains?limit=1',
+          expect.objectContaining({
+            method: 'GET',
+            headers: expect.any(Headers),
+          }),
+        );
       });
 
-      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      it('passes after param and returns a response', async () => {
+        mockSuccessResponse(response, {
+          headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
+        });
 
-      await expect(resend.domains.list()).resolves.toMatchInlineSnapshot(`
-{
-  "data": {
-    "data": [
-      {
-        "created_at": "2023-04-07T23:13:52.669661+00:00",
-        "id": "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
-        "name": "resend.com",
-        "region": "eu-west-1",
-        "status": "not_started",
-      },
-      {
-        "created_at": "2023-04-07T23:13:20.417116+00:00",
-        "id": "ac7503ac-e027-4aea-94b3-b0acd46f65f9",
-        "name": "react.email",
-        "region": "us-east-1",
-        "status": "not_started",
-      },
-    ],
-  },
-  "error": null,
-  "rateLimiting": {
-    "limit": 2,
-    "remainingRequests": 2,
-    "shouldResetAfter": 1,
-  },
-}
-`);
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+        const result = await resend.domains.list({
+          limit: 1,
+          after: 'cursor-value',
+        });
+        expect(result).toEqual({
+          data: response,
+          error: null,
+          rateLimiting: {
+            limit: 2,
+            remainingRequests: 2,
+            shouldResetAfter: 1,
+          },
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://api.resend.com/domains?limit=1&after=cursor-value',
+          expect.objectContaining({
+            method: 'GET',
+            headers: expect.any(Headers),
+          }),
+        );
+      });
+
+      it('passes before param and returns a response', async () => {
+        mockSuccessResponse(response, {
+          headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+        const result = await resend.domains.list({
+          limit: 1,
+          before: 'cursor-value',
+        });
+        expect(result).toEqual({
+          data: response,
+          error: null,
+          rateLimiting: {
+            limit: 2,
+            remainingRequests: 2,
+            shouldResetAfter: 1,
+          },
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://api.resend.com/domains?limit=1&before=cursor-value',
+          expect.objectContaining({
+            method: 'GET',
+            headers: expect.any(Headers),
+          }),
+        );
+      });
     });
   });
 

--- a/src/domains/domains.spec.ts
+++ b/src/domains/domains.spec.ts
@@ -418,6 +418,14 @@ describe('Domains', () => {
             shouldResetAfter: 1,
           },
         });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://api.resend.com/domains',
+          expect.objectContaining({
+            method: 'GET',
+            headers: expect.any(Headers),
+          }),
+        );
       });
     });
 

--- a/src/domains/domains.ts
+++ b/src/domains/domains.ts
@@ -11,6 +11,7 @@ import type {
   GetDomainResponseSuccess,
 } from './interfaces/get-domain.interface';
 import type {
+  ListDomainsOptions,
   ListDomainsResponse,
   ListDomainsResponseSuccess,
 } from './interfaces/list-domains.interface';
@@ -43,8 +44,25 @@ export class Domains {
     return data;
   }
 
-  async list(): Promise<ListDomainsResponse> {
-    const data = await this.resend.get<ListDomainsResponseSuccess>('/domains');
+  async list(options: ListDomainsOptions = {}): Promise<ListDomainsResponse> {
+    const searchParams = new URLSearchParams();
+
+    if (options.limit !== undefined) {
+      searchParams.set('limit', options.limit.toString());
+    }
+
+    if ('after' in options && options.after !== undefined) {
+      searchParams.set('after', options.after);
+    }
+
+    if ('before' in options && options.before !== undefined) {
+      searchParams.set('before', options.before);
+    }
+
+    const queryString = searchParams.toString();
+    const url = queryString ? `/domains?${queryString}` : '/domains';
+
+    const data = await this.resend.get<ListDomainsResponseSuccess>(url);
     return data;
   }
 

--- a/src/domains/domains.ts
+++ b/src/domains/domains.ts
@@ -1,3 +1,4 @@
+import { buildPaginationQuery } from '../common/utils/build-pagination-query';
 import { parseDomainToApiOptions } from '../common/utils/parse-domain-to-api-options';
 import type { Resend } from '../resend';
 import type {
@@ -45,21 +46,7 @@ export class Domains {
   }
 
   async list(options: ListDomainsOptions = {}): Promise<ListDomainsResponse> {
-    const searchParams = new URLSearchParams();
-
-    if (options.limit !== undefined) {
-      searchParams.set('limit', options.limit.toString());
-    }
-
-    if ('after' in options && options.after !== undefined) {
-      searchParams.set('after', options.after);
-    }
-
-    if ('before' in options && options.before !== undefined) {
-      searchParams.set('before', options.before);
-    }
-
-    const queryString = searchParams.toString();
+    const queryString = buildPaginationQuery(options);
     const url = queryString ? `/domains?${queryString}` : '/domains';
 
     const data = await this.resend.get<ListDomainsResponseSuccess>(url);

--- a/src/domains/interfaces/list-domains.interface.ts
+++ b/src/domains/interfaces/list-domains.interface.ts
@@ -1,6 +1,31 @@
 import type { Response } from '../../interfaces';
 import type { Domain } from './domain';
 
-export type ListDomainsResponseSuccess = { data: Domain[] };
+// Pagination options using cursor-based approach
+export type ListDomainsOptions = {
+  /**
+   * Maximum number of emails to return (1-100, default: 20)
+   */
+  limit?: number;
+} & (
+  | {
+      /**
+       * Get emails after this cursor (cannot be used with 'before')
+       */
+      after?: string;
+    }
+  | {
+      /**
+       * Get emails before this cursor (cannot be used with 'after')
+       */
+      before?: string;
+    }
+);
+
+export type ListDomainsResponseSuccess = {
+  data: Domain[];
+  object: 'list';
+  has_more: boolean;
+};
 
 export type ListDomainsResponse = Response<ListDomainsResponseSuccess>;

--- a/src/domains/interfaces/list-domains.interface.ts
+++ b/src/domains/interfaces/list-domains.interface.ts
@@ -1,26 +1,8 @@
+import type { PaginationOptions } from '../../common/interfaces';
 import type { Response } from '../../interfaces';
 import type { Domain } from './domain';
 
-// Pagination options using cursor-based approach
-export type ListDomainsOptions = {
-  /**
-   * Maximum number of emails to return (1-100, default: 20)
-   */
-  limit?: number;
-} & (
-  | {
-      /**
-       * Get emails after this cursor (cannot be used with 'before')
-       */
-      after?: string;
-    }
-  | {
-      /**
-       * Get emails before this cursor (cannot be used with 'after')
-       */
-      before?: string;
-    }
-);
+export type ListDomainsOptions = PaginationOptions;
 
 export type ListDomainsResponseSuccess = {
   data: Domain[];

--- a/src/emails/emails.ts
+++ b/src/emails/emails.ts
@@ -1,4 +1,5 @@
 import type * as React from 'react';
+import { buildPaginationQuery } from '../common/utils/build-pagination-query';
 import { parseEmailToApiOptions } from '../common/utils/parse-email-to-api-options';
 import type { Resend } from '../resend';
 import type {
@@ -76,21 +77,7 @@ export class Emails {
   }
 
   async list(options: ListEmailsOptions = {}): Promise<ListEmailsResponse> {
-    const searchParams = new URLSearchParams();
-
-    if (options.limit !== undefined) {
-      searchParams.set('limit', options.limit.toString());
-    }
-
-    if ('after' in options && options.after !== undefined) {
-      searchParams.set('after', options.after);
-    }
-
-    if ('before' in options && options.before !== undefined) {
-      searchParams.set('before', options.before);
-    }
-
-    const queryString = searchParams.toString();
+    const queryString = buildPaginationQuery(options);
     const url = queryString ? `/emails?${queryString}` : '/emails';
 
     const data = await this.resend.get<ListEmailsResponseSuccess>(url);

--- a/src/emails/interfaces/list-emails-options.interface.ts
+++ b/src/emails/interfaces/list-emails-options.interface.ts
@@ -1,26 +1,8 @@
+import type { PaginationOptions } from '../../common/interfaces';
 import type { Response } from '../../interfaces';
 import type { GetEmailResponseSuccess } from './get-email-options.interface';
 
-// Pagination options using cursor-based approach
-export type ListEmailsOptions = {
-  /**
-   * Maximum number of emails to return (1-100, default: 20)
-   */
-  limit?: number;
-} & (
-  | {
-      /**
-       * Get emails after this cursor (cannot be used with 'before')
-       */
-      after?: string;
-    }
-  | {
-      /**
-       * Get emails before this cursor (cannot be used with 'after')
-       */
-      before?: string;
-    }
-);
+export type ListEmailsOptions = PaginationOptions;
 
 // Base email type for listing (subset of full email)
 export type ListEmail = Omit<


### PR DESCRIPTION
This PR adds pagination support for all old endpoints that are unpaginated by default. As with the API, we will only paginate the results if users pass a `limit` parameter in their options.

This was implemented following the pagination for the new email endpoint added in https://github.com/resend/resend-node/pull/609.

Tip for reviewers: you might want to check each commit individually instead of reviewing all at once. That's because each commit is quite small and they all do something very similar.