### PR TITLE
fix: reverts changes in batch API headers name

### DIFF
--- a/src/batch/batch.spec.ts
+++ b/src/batch/batch.spec.ts
@@ -319,7 +319,7 @@ describe('Batch', () => {
       const request = lastCall[1];
       expect(request).toBeDefined();
       const headers = new Headers(request?.headers);
-      expect(headers.get('x-resend-batch-validation')).toBe('permissive');
+      expect(headers.get('x-batch-validation')).toBe('permissive');
 
       expect(result.data).toEqual({
         data: [],

--- a/src/batch/batch.ts
+++ b/src/batch/batch.ts
@@ -51,7 +51,7 @@ export class Batch {
       {
         ...options,
         headers: {
-          'x-resend-batch-validation': options?.batchValidation ?? 'strict',
+          'x-batch-validation': options?.batchValidation ?? 'strict',
           ...options?.headers,
         },
       },

--- a/src/batch/interfaces/create-batch-options.interface.ts
+++ b/src/batch/interfaces/create-batch-options.interface.ts
@@ -24,7 +24,7 @@ export type CreateBatchSuccessResponse<
 } & (Options['batchValidation'] extends 'permissive'
   ? {
       /**
-       * Only present when header "x-resend-batch-validation" is set to 'permissive'.
+       * Only present when header "x-batch-validation" is set to 'permissive'.
        */
       errors: {
         /**


### PR DESCRIPTION
Reverts resend/resend-node#608

As explained in this [revert PR](https://github.com/resend/resend-api/pull/2077), we are reverting because `resend` prefix is only for internal usage. And the Batch API is public.

Also, this header is not being used in prod, so no worries about breaking changes.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Reverts the Batch API header name back to x-batch-validation (from x-resend-batch-validation) in requests, tests, and types to match the public API. The prior change used an internal-only prefix; no production impact.

<!-- End of auto-generated description by cubic. -->

