### PR TITLE
fix: typo in `invalid_api_key` error

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -10,7 +10,7 @@ export const RESEND_ERROR_CODES_BY_KEY = {
   invalid_region: 422,
   rate_limit_exceeded: 429,
   missing_api_key: 401,
-  invalid_api_Key: 403,
+  invalid_api_key: 403,
   invalid_from_address: 403,
   validation_error: 403,
   not_found: 404,


### PR DESCRIPTION
Before this we had `invalid_api_Key` in the type, while the [docs](https://resend.com/docs/api-reference/errors#invalid-api-key) say it should be `invalid_api_key`. It also seems like we don't return this any more, and just return `validation_error` when the API Key is invalid/expired, but fixing the type anyways for now.
