### PR TITLE
fix: headers not sent to `DELETE` requests

### DIFF
--- a/src/resend.ts
+++ b/src/resend.ts
@@ -180,6 +180,7 @@ export class Resend {
     const requestOptions = {
       method: 'DELETE',
       body: JSON.stringify(query),
+      headers: this.headers,
     };
 
     return this.fetchRequest<T>(path, requestOptions);


### PR DESCRIPTION
These were accidentally lost in the shuffle when some header features were added in #599.

As a result, I'm currently getting `401 Unauthorized` errors when trying to `Resend.broadcasts.remove`.

```
{
  "statusCode": 401,
  "message": "Missing API Key",
  "name": "missing_api_key"
}
```

This change fixes the errors for me and lets me delete broadcasts again.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Send auth headers with DELETE requests so the API key is included, fixing 401 Unauthorized on Resend.broadcasts.remove and restoring broadcast deletion.

<!-- End of auto-generated description by cubic. -->

