### PR TITLE
feat: bump version for inbound release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.1.1",
+  "version": "6.2.1-canary.0",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.2.1-canary.0",
+  "version": "6.2.0-canary.0",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Bumped the package version to 6.2.1-canary.0 to prepare the inbound canary release. No functional changes; only the version in package.json was updated for publishing.

<!-- End of auto-generated description by cubic. -->

