### PR TITLE
chore: support any `@react-email/render` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "homepage": "https://github.com/resendlabs/resend-node#readme",
   "peerDependencies": {
-    "@react-email/render": "^1.1.0"
+    "@react-email/render": "*"
   },
   "peerDependenciesMeta": {
     "@react-email/render": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       '@react-email/render':
-        specifier: ^1.1.0
+        specifier: '*'
         version: 1.2.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
     devDependencies:
       '@biomejs/biome':

--- a/src/render.ts
+++ b/src/render.ts
@@ -10,7 +10,7 @@ export function render(node: React.ReactNode) {
       .catch(() => {
         reject(
           Error(
-            'Failed to render React component. Make sure to install `@react-email/render`',
+            'Failed to render React component. Make sure to install `@react-email/render` or `@react-email/components`.',
           ),
         );
       });


### PR DESCRIPTION
Tested it out with `@react-email/render@0.0.1` and it works just fine at rendering, and at runtime, so it should be fine for us to support all versions.
    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Support any @react-email/render version by loosening the peer dependency to improve compatibility and avoid version conflicts. Also updated the render error message to guide users to install @react-email/render or @react-email/components.

<!-- End of auto-generated description by cubic. -->

