### PR TITLE
feat: add list and object types in the templates creation/update

### DIFF
--- a/src/common/utils/parse-template-to-api-options.spec.ts
+++ b/src/common/utils/parse-template-to-api-options.spec.ts
@@ -220,7 +220,7 @@ describe('parseTemplateToApiOptions', () => {
     expect(apiOptions.variables).toEqual([]);
   });
 
-  it('should handle object and list variable types for create template', () => {
+  it('handles object and list variable types for create template', () => {
     const templatePayload: CreateTemplateOptions = {
       name: 'Complex Variables Template',
       html: '<h1>Complex template</h1>',

--- a/src/common/utils/parse-template-to-api-options.spec.ts
+++ b/src/common/utils/parse-template-to-api-options.spec.ts
@@ -304,7 +304,7 @@ describe('parseTemplateToApiOptions', () => {
     ]);
   });
 
-  it('should handle object and list variable types for update template', () => {
+  it('handles object and list variable types for update template', () => {
     const updatePayload: UpdateTemplateOptions = {
       subject: 'Updated Complex Template',
       variables: [

--- a/src/common/utils/parse-template-to-api-options.spec.ts
+++ b/src/common/utils/parse-template-to-api-options.spec.ts
@@ -231,11 +231,6 @@ describe('parseTemplateToApiOptions', () => {
           fallbackValue: { name: 'John', age: 30 },
         },
         {
-          key: 'userProfileNull',
-          type: 'object',
-          fallbackValue: null,
-        },
-        {
           key: 'tags',
           type: 'list',
           fallbackValue: ['premium', 'vip'],
@@ -255,11 +250,6 @@ describe('parseTemplateToApiOptions', () => {
           type: 'list',
           fallbackValue: [{ id: 1 }, { id: 2 }],
         },
-        {
-          key: 'emptyList',
-          type: 'list',
-          fallbackValue: null,
-        },
       ],
     };
 
@@ -270,11 +260,6 @@ describe('parseTemplateToApiOptions', () => {
         key: 'userProfile',
         type: 'object',
         fallback_value: { name: 'John', age: 30 },
-      },
-      {
-        key: 'userProfileNull',
-        type: 'object',
-        fallback_value: null,
       },
       {
         key: 'tags',
@@ -296,11 +281,6 @@ describe('parseTemplateToApiOptions', () => {
         type: 'list',
         fallback_value: [{ id: 1 }, { id: 2 }],
       },
-      {
-        key: 'emptyList',
-        type: 'list',
-        fallback_value: null,
-      },
     ]);
   });
 
@@ -312,11 +292,6 @@ describe('parseTemplateToApiOptions', () => {
           key: 'config',
           type: 'object',
           fallbackValue: { theme: 'dark', lang: 'en' },
-        },
-        {
-          key: 'configNull',
-          type: 'object',
-          fallbackValue: null,
         },
         {
           key: 'permissions',
@@ -338,11 +313,6 @@ describe('parseTemplateToApiOptions', () => {
           type: 'list',
           fallbackValue: [{ key: 'a' }, { key: 'b' }],
         },
-        {
-          key: 'emptyList',
-          type: 'list',
-          fallbackValue: null,
-        },
       ],
     };
 
@@ -353,11 +323,6 @@ describe('parseTemplateToApiOptions', () => {
         key: 'config',
         type: 'object',
         fallback_value: { theme: 'dark', lang: 'en' },
-      },
-      {
-        key: 'configNull',
-        type: 'object',
-        fallback_value: null,
       },
       {
         key: 'permissions',
@@ -378,11 +343,6 @@ describe('parseTemplateToApiOptions', () => {
         key: 'metadata',
         type: 'list',
         fallback_value: [{ key: 'a' }, { key: 'b' }],
-      },
-      {
-        key: 'emptyList',
-        type: 'list',
-        fallback_value: null,
       },
     ]);
   });

--- a/src/common/utils/parse-template-to-api-options.spec.ts
+++ b/src/common/utils/parse-template-to-api-options.spec.ts
@@ -219,4 +219,171 @@ describe('parseTemplateToApiOptions', () => {
 
     expect(apiOptions.variables).toEqual([]);
   });
+
+  it('should handle object and list variable types for create template', () => {
+    const templatePayload: CreateTemplateOptions = {
+      name: 'Complex Variables Template',
+      html: '<h1>Complex template</h1>',
+      variables: [
+        {
+          key: 'userProfile',
+          type: 'object',
+          fallbackValue: { name: 'John', age: 30 },
+        },
+        {
+          key: 'userProfileNull',
+          type: 'object',
+          fallbackValue: null,
+        },
+        {
+          key: 'tags',
+          type: 'list',
+          fallbackValue: ['premium', 'vip'],
+        },
+        {
+          key: 'scores',
+          type: 'list',
+          fallbackValue: [95, 87, 92],
+        },
+        {
+          key: 'flags',
+          type: 'list',
+          fallbackValue: [true, false, true],
+        },
+        {
+          key: 'items',
+          type: 'list',
+          fallbackValue: [{ id: 1 }, { id: 2 }],
+        },
+        {
+          key: 'emptyList',
+          type: 'list',
+          fallbackValue: null,
+        },
+      ],
+    };
+
+    const apiOptions = parseTemplateToApiOptions(templatePayload);
+
+    expect(apiOptions.variables).toEqual([
+      {
+        key: 'userProfile',
+        type: 'object',
+        fallback_value: { name: 'John', age: 30 },
+      },
+      {
+        key: 'userProfileNull',
+        type: 'object',
+        fallback_value: null,
+      },
+      {
+        key: 'tags',
+        type: 'list',
+        fallback_value: ['premium', 'vip'],
+      },
+      {
+        key: 'scores',
+        type: 'list',
+        fallback_value: [95, 87, 92],
+      },
+      {
+        key: 'flags',
+        type: 'list',
+        fallback_value: [true, false, true],
+      },
+      {
+        key: 'items',
+        type: 'list',
+        fallback_value: [{ id: 1 }, { id: 2 }],
+      },
+      {
+        key: 'emptyList',
+        type: 'list',
+        fallback_value: null,
+      },
+    ]);
+  });
+
+  it('should handle object and list variable types for update template', () => {
+    const updatePayload: UpdateTemplateOptions = {
+      subject: 'Updated Complex Template',
+      variables: [
+        {
+          key: 'config',
+          type: 'object',
+          fallbackValue: { theme: 'dark', lang: 'en' },
+        },
+        {
+          key: 'configNull',
+          type: 'object',
+          fallbackValue: null,
+        },
+        {
+          key: 'permissions',
+          type: 'list',
+          fallbackValue: ['read', 'write'],
+        },
+        {
+          key: 'counts',
+          type: 'list',
+          fallbackValue: [10, 20, 30],
+        },
+        {
+          key: 'enabled',
+          type: 'list',
+          fallbackValue: [true, false],
+        },
+        {
+          key: 'metadata',
+          type: 'list',
+          fallbackValue: [{ key: 'a' }, { key: 'b' }],
+        },
+        {
+          key: 'emptyList',
+          type: 'list',
+          fallbackValue: null,
+        },
+      ],
+    };
+
+    const apiOptions = parseTemplateToApiOptions(updatePayload);
+
+    expect(apiOptions.variables).toEqual([
+      {
+        key: 'config',
+        type: 'object',
+        fallback_value: { theme: 'dark', lang: 'en' },
+      },
+      {
+        key: 'configNull',
+        type: 'object',
+        fallback_value: null,
+      },
+      {
+        key: 'permissions',
+        type: 'list',
+        fallback_value: ['read', 'write'],
+      },
+      {
+        key: 'counts',
+        type: 'list',
+        fallback_value: [10, 20, 30],
+      },
+      {
+        key: 'enabled',
+        type: 'list',
+        fallback_value: [true, false],
+      },
+      {
+        key: 'metadata',
+        type: 'list',
+        fallback_value: [{ key: 'a' }, { key: 'b' }],
+      },
+      {
+        key: 'emptyList',
+        type: 'list',
+        fallback_value: null,
+      },
+    ]);
+  });
 });

--- a/src/common/utils/parse-template-to-api-options.ts
+++ b/src/common/utils/parse-template-to-api-options.ts
@@ -1,10 +1,17 @@
 import type { CreateTemplateOptions } from '../../templates/interfaces/create-template-options.interface';
+import type { TemplateVariableListFallbackType } from '../../templates/interfaces/template';
 import type { UpdateTemplateOptions } from '../../templates/interfaces/update-template.interface';
 
 interface TemplateVariableApiOptions {
   key: string;
-  type: 'string' | 'number' | 'boolean';
-  fallback_value?: string | number | boolean | null;
+  type: 'string' | 'number' | 'boolean' | 'object' | 'list';
+  fallback_value?:
+    | string
+    | number
+    | boolean
+    | object
+    | TemplateVariableListFallbackType
+    | null;
 }
 
 interface TemplateApiOptions {

--- a/src/common/utils/parse-template-to-api-options.ts
+++ b/src/common/utils/parse-template-to-api-options.ts
@@ -9,7 +9,7 @@ interface TemplateVariableApiOptions {
     | string
     | number
     | boolean
-    | object
+    | Record<string, unknown>
     | TemplateVariableListFallbackType
     | null;
 }

--- a/src/templates/interfaces/create-template-options.interface.ts
+++ b/src/templates/interfaces/create-template-options.interface.ts
@@ -1,19 +1,40 @@
 import type { PostOptions } from '../../common/interfaces';
 import type { RequireAtLeastOne } from '../../common/interfaces/require-at-least-one';
 import type { ErrorResponse } from '../../interfaces';
-import type { Template, TemplateVariable } from './template';
+import type {
+  Template,
+  TemplateVariable,
+  TemplateVariableListFallbackType,
+} from './template';
 
 type TemplateContentCreationOptions = RequireAtLeastOne<{
   html: string;
   react: React.ReactNode;
 }>;
 
-type TemplateVariableCreationOptions = Pick<
-  TemplateVariable,
-  'key' | 'type'
-> & {
-  fallbackValue?: string | number | boolean | null;
-};
+type TemplateVariableCreationOptions = Pick<TemplateVariable, 'key' | 'type'> &
+  (
+    | {
+        type: 'string';
+        fallbackValue?: string | null;
+      }
+    | {
+        type: 'number';
+        fallbackValue?: number | null;
+      }
+    | {
+        type: 'boolean';
+        fallbackValue?: boolean | null;
+      }
+    | {
+        type: 'object';
+        fallbackValue: object | null;
+      }
+    | {
+        type: 'list';
+        fallbackValue: TemplateVariableListFallbackType | null;
+      }
+  );
 
 type TemplateOptionalFieldsForCreation = Partial<
   Pick<Template, 'subject' | 'text' | 'alias' | 'from'>

--- a/src/templates/interfaces/create-template-options.interface.ts
+++ b/src/templates/interfaces/create-template-options.interface.ts
@@ -28,11 +28,11 @@ type TemplateVariableCreationOptions = Pick<TemplateVariable, 'key' | 'type'> &
       }
     | {
         type: 'object';
-        fallbackValue: Record<string, unknown> | null;
+        fallbackValue: Record<string, unknown>;
       }
     | {
         type: 'list';
-        fallbackValue: TemplateVariableListFallbackType | null;
+        fallbackValue: TemplateVariableListFallbackType;
       }
   );
 

--- a/src/templates/interfaces/create-template-options.interface.ts
+++ b/src/templates/interfaces/create-template-options.interface.ts
@@ -28,7 +28,7 @@ type TemplateVariableCreationOptions = Pick<TemplateVariable, 'key' | 'type'> &
       }
     | {
         type: 'object';
-        fallbackValue: object | null;
+        fallbackValue: Record<string, unknown> | null;
       }
     | {
         type: 'list';

--- a/src/templates/interfaces/template.ts
+++ b/src/templates/interfaces/template.ts
@@ -18,14 +18,15 @@ export type TemplateVariableListFallbackType =
   | string[]
   | number[]
   | boolean[]
-  | object[];
+  | Record<string, unknown>[];
+
 export interface TemplateVariable {
   key: string;
   fallback_value:
     | string
     | number
     | boolean
-    | object
+    | Record<string, unknown>
     | TemplateVariableListFallbackType
     | null;
   type: 'string' | 'number' | 'boolean' | 'object' | 'list';

--- a/src/templates/interfaces/template.ts
+++ b/src/templates/interfaces/template.ts
@@ -14,10 +14,21 @@ export interface Template {
   updated_at: string;
 }
 
+export type TemplateVariableListFallbackType =
+  | string[]
+  | number[]
+  | boolean[]
+  | object[];
 export interface TemplateVariable {
   key: string;
-  fallback_value: string | number | boolean | null;
-  type: 'string' | 'number' | 'boolean';
+  fallback_value:
+    | string
+    | number
+    | boolean
+    | object
+    | TemplateVariableListFallbackType
+    | null;
+  type: 'string' | 'number' | 'boolean' | 'object' | 'list';
   created_at: string;
   updated_at: string;
 }

--- a/src/templates/interfaces/update-template.interface.ts
+++ b/src/templates/interfaces/update-template.interface.ts
@@ -21,7 +21,7 @@ type TemplateVariableUpdateOptions = Pick<TemplateVariable, 'key' | 'type'> &
       }
     | {
         type: 'object';
-        fallbackValue: object | null;
+        fallbackValue: Record<string, unknown> | null;
       }
     | {
         type: 'list';

--- a/src/templates/interfaces/update-template.interface.ts
+++ b/src/templates/interfaces/update-template.interface.ts
@@ -21,11 +21,11 @@ type TemplateVariableUpdateOptions = Pick<TemplateVariable, 'key' | 'type'> &
       }
     | {
         type: 'object';
-        fallbackValue: Record<string, unknown> | null;
+        fallbackValue: Record<string, unknown>;
       }
     | {
         type: 'list';
-        fallbackValue: TemplateVariableListFallbackType | null;
+        fallbackValue: TemplateVariableListFallbackType;
       }
   );
 

--- a/src/templates/interfaces/update-template.interface.ts
+++ b/src/templates/interfaces/update-template.interface.ts
@@ -1,9 +1,33 @@
 import type { ErrorResponse } from '../../interfaces';
-import type { Template, TemplateVariable } from './template';
+import type {
+  Template,
+  TemplateVariable,
+  TemplateVariableListFallbackType,
+} from './template';
 
-type TemplateVariableUpdateOptions = Pick<TemplateVariable, 'key' | 'type'> & {
-  fallbackValue?: string | number | boolean | null;
-};
+type TemplateVariableUpdateOptions = Pick<TemplateVariable, 'key' | 'type'> &
+  (
+    | {
+        type: 'string';
+        fallbackValue?: string | null;
+      }
+    | {
+        type: 'number';
+        fallbackValue?: number | null;
+      }
+    | {
+        type: 'boolean';
+        fallbackValue?: boolean | null;
+      }
+    | {
+        type: 'object';
+        fallbackValue: object | null;
+      }
+    | {
+        type: 'list';
+        fallbackValue: TemplateVariableListFallbackType | null;
+      }
+  );
 
 export interface UpdateTemplateOptions
   extends Partial<

--- a/src/templates/templates.spec.ts
+++ b/src/templates/templates.spec.ts
@@ -259,6 +259,71 @@ describe('Templates', () => {
         'Failed to render React component. Make sure to install `@react-email/render`',
       );
     });
+
+    it('creates a template with object and list variable types', async () => {
+      const payload: CreateTemplateOptions = {
+        name: 'Complex Variables Template',
+        html: '<h1>Welcome {{{userProfile.name}}}!</h1><p>Your tags: {{{tags}}}</p>',
+        variables: [
+          {
+            key: 'userProfile',
+            type: 'object',
+            fallbackValue: { name: 'John', age: 30 },
+          },
+          {
+            key: 'userProfileNull',
+            type: 'object',
+            fallbackValue: null,
+          },
+          {
+            key: 'tags',
+            type: 'list',
+            fallbackValue: ['premium', 'vip'],
+          },
+          {
+            key: 'scores',
+            type: 'list',
+            fallbackValue: [95, 87, 92],
+          },
+          {
+            key: 'flags',
+            type: 'list',
+            fallbackValue: [true, false, true],
+          },
+          {
+            key: 'items',
+            type: 'list',
+            fallbackValue: [{ id: 1 }, { id: 2 }],
+          },
+          {
+            key: 'emptyList',
+            type: 'list',
+            fallbackValue: null,
+          },
+        ],
+      };
+      const response: CreateTemplateResponseSuccess = {
+        object: 'template',
+        id: 'fd61172c-cafc-40f5-b049-b45947779a29',
+      };
+
+      mockSuccessResponse(response, {
+        headers: { Authorization: `Bearer ${TEST_API_KEY}` },
+      });
+
+      const resend = new Resend(TEST_API_KEY);
+      await expect(
+        resend.templates.create(payload),
+      ).resolves.toMatchInlineSnapshot(`
+        {
+          "data": {
+            "id": "fd61172c-cafc-40f5-b049-b45947779a29",
+            "object": "template",
+          },
+          "error": null,
+        }
+      `);
+    });
   });
 
   describe('remove', () => {
@@ -478,6 +543,75 @@ describe('Templates', () => {
             "message": "Template not found",
             "name": "not_found",
           },
+        }
+      `);
+    });
+
+    it('updates a template with object and list variable types', async () => {
+      const id = 'fd61172c-cafc-40f5-b049-b45947779a29';
+      const payload: UpdateTemplateOptions = {
+        name: 'Updated Complex Variables Template',
+        html: '<h1>Updated Welcome {{{config.theme}}}!</h1><p>Permissions: {{{permissions}}}</p>',
+        variables: [
+          {
+            key: 'config',
+            type: 'object',
+            fallbackValue: { theme: 'dark', lang: 'en' },
+          },
+          {
+            key: 'configNull',
+            type: 'object',
+            fallbackValue: null,
+          },
+          {
+            key: 'permissions',
+            type: 'list',
+            fallbackValue: ['read', 'write'],
+          },
+          {
+            key: 'counts',
+            type: 'list',
+            fallbackValue: [10, 20, 30],
+          },
+          {
+            key: 'enabled',
+            type: 'list',
+            fallbackValue: [true, false],
+          },
+          {
+            key: 'metadata',
+            type: 'list',
+            fallbackValue: [{ key: 'a' }, { key: 'b' }],
+          },
+          {
+            key: 'emptyList',
+            type: 'list',
+            fallbackValue: null,
+          },
+        ],
+      };
+      const response = {
+        object: 'template',
+        id,
+      };
+
+      mockSuccessResponse(response, {
+        headers: {
+          Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      await expect(
+        resend.templates.update(id, payload),
+      ).resolves.toMatchInlineSnapshot(`
+        {
+          "data": {
+            "id": "fd61172c-cafc-40f5-b049-b45947779a29",
+            "object": "template",
+          },
+          "error": null,
         }
       `);
     });

--- a/src/templates/templates.spec.ts
+++ b/src/templates/templates.spec.ts
@@ -271,11 +271,6 @@ describe('Templates', () => {
             fallbackValue: { name: 'John', age: 30 },
           },
           {
-            key: 'userProfileNull',
-            type: 'object',
-            fallbackValue: null,
-          },
-          {
             key: 'tags',
             type: 'list',
             fallbackValue: ['premium', 'vip'],
@@ -294,11 +289,6 @@ describe('Templates', () => {
             key: 'items',
             type: 'list',
             fallbackValue: [{ id: 1 }, { id: 2 }],
-          },
-          {
-            key: 'emptyList',
-            type: 'list',
-            fallbackValue: null,
           },
         ],
       };
@@ -559,11 +549,6 @@ describe('Templates', () => {
             fallbackValue: { theme: 'dark', lang: 'en' },
           },
           {
-            key: 'configNull',
-            type: 'object',
-            fallbackValue: null,
-          },
-          {
             key: 'permissions',
             type: 'list',
             fallbackValue: ['read', 'write'],
@@ -582,11 +567,6 @@ describe('Templates', () => {
             key: 'metadata',
             type: 'list',
             fallbackValue: [{ key: 'a' }, { key: 'b' }],
-          },
-          {
-            key: 'emptyList',
-            type: 'list',
-            fallbackValue: null,
           },
         ],
       };


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds support for object and list variable types in the Templates SDK for create and update. Enables structured fallback values and proper API serialization, addressing Linear PRODUCT-708.

- **New Features**
  - Accepts variable types: object and list in CreateTemplateOptions and UpdateTemplateOptions.
  - List fallback supports string[], number[], boolean[], or object[] (or null).
  - parseTemplateToApiOptions maps fallbackValue to fallback_value and handles new types.

- **Migration**
  - For type "object" or "list", fallbackValue is required (object | null or array | null). No changes needed for existing primitive types.

<!-- End of auto-generated description by cubic. -->

