### PR TITLE
fix: create topics camel case

### DIFF
--- a/src/common/utils/create-pagination-query.spec.ts
+++ b/src/common/utils/create-pagination-query.spec.ts
@@ -1,4 +1,4 @@
-import { PaginationOptions } from '../interfaces/pagination';
+import type { PaginationOptions } from '../interfaces/pagination';
 import { createPaginationQuery } from './create-pagination-query';
 
 describe('createPaginationQuery', () => {

--- a/src/contacts/topics/contact-topics.spec.ts
+++ b/src/contacts/topics/contact-topics.spec.ts
@@ -260,20 +260,19 @@ describe('ContactTopics', () => {
         id: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223',
       };
       const response: GetContactTopicsResponseSuccess = {
-      has_more: false,
-      object: 'list',
-      data: {
-        
-        email: 'carolina@resend.com',
-        topics: [
-          {
-            id: 'c7e1e488-ae2c-4255-a40c-a4db3af7ed0b',
-            name: 'Test Topic',
-            description: 'This is a test topic',
-            subscription: 'opt_in',
-          },
-        ],
-      },
+        has_more: false,
+        object: 'list',
+        data: {
+          email: 'carolina@resend.com',
+          topics: [
+            {
+              id: 'c7e1e488-ae2c-4255-a40c-a4db3af7ed0b',
+              name: 'Test Topic',
+              description: 'This is a test topic',
+              subscription: 'opt_in',
+            },
+          ],
+        },
       };
 
       mockSuccessResponse(response, {

--- a/src/contacts/topics/interfaces/get-contact-topics.interface.ts
+++ b/src/contacts/topics/interfaces/get-contact-topics.interface.ts
@@ -1,5 +1,9 @@
 import type { GetOptions } from '../../../common/interfaces';
-import { PaginatedApiResponse, PaginatedData, PaginationOptions } from '../../../common/interfaces/pagination';
+import type {
+  PaginatedApiResponse,
+  PaginatedData,
+  PaginationOptions,
+} from '../../../common/interfaces/pagination';
 import type { ErrorResponse } from '../../../interfaces';
 
 interface GetContactTopicsBaseOptions {
@@ -7,7 +11,8 @@ interface GetContactTopicsBaseOptions {
   email?: string;
 }
 
-export type GetContactTopicsOptions = GetContactTopicsBaseOptions & PaginationOptions<string>;
+export type GetContactTopicsOptions = GetContactTopicsBaseOptions &
+  PaginationOptions<string>;
 
 export interface GetContactTopicsRequestOptions extends GetOptions {}
 
@@ -21,10 +26,9 @@ export interface ContactTopic {
 export type GetContactTopicsResponseSuccess = PaginatedApiResponse<{
   email: string;
   topics: ContactTopic[];
-}>
+}>;
 
-
-export type GetContactTopicsResponse = 
+export type GetContactTopicsResponse =
   | {
       data: PaginatedData<{
         email: string;
@@ -36,4 +40,3 @@ export type GetContactTopicsResponse =
       data: null;
       error: ErrorResponse;
     };
-

--- a/src/emails/emails.spec.ts
+++ b/src/emails/emails.spec.ts
@@ -77,7 +77,7 @@ describe('Emails', () => {
         '{"from":"admin@resend.com","html":"<h1>Test</h1>","subject":"Not Idempotent Test","to":"user@resend.com","topic_id":"9f31e56e-3083-46cf-8e96-c6995e0e576a"}',
       );
 
-      //@ts-ignore
+      //@ts-expect-error
       const hasIdempotencyKey = lastCall[1]?.headers.has('Idempotency-Key');
       expect(hasIdempotencyKey).toBeFalsy();
 

--- a/src/topics/interfaces/create-topic-options.interface.ts
+++ b/src/topics/interfaces/create-topic-options.interface.ts
@@ -4,7 +4,7 @@ import type { Topic } from './topic';
 export interface CreateTopicOptions {
   name: string;
   description?: string;
-  default_subscription: 'opt_in' | 'opt_out';
+  defaultSubscription: 'opt_in' | 'opt_out';
 }
 
 export type CreateTopicResponseSuccess = Pick<Topic, 'id'>;

--- a/src/topics/topics.spec.ts
+++ b/src/topics/topics.spec.ts
@@ -92,7 +92,7 @@ describe('Topics', () => {
       };
       const response: ErrorResponse = {
         name: 'missing_required_field',
-        message: 'Missing `defaultSubscription` field.',
+        message: 'Missing `default_subscription` field.',
       };
 
       mockErrorResponse(response, {
@@ -109,7 +109,7 @@ describe('Topics', () => {
 {
   "data": null,
   "error": {
-    "message": "Missing \`defaultSubscription\` field.",
+    "message": "Missing \`default_subscription\` field.",
     "name": "missing_required_field",
   },
   "rateLimiting": {

--- a/src/topics/topics.spec.ts
+++ b/src/topics/topics.spec.ts
@@ -21,7 +21,7 @@ describe('Topics', () => {
       const payload: CreateTopicOptions = {
         name: 'Newsletter',
         description: 'Weekly newsletter updates',
-        default_subscription: 'opt_in',
+        defaultSubscription: 'opt_in',
       };
       const response: CreateTopicResponseSuccess = {
         id: '3deaccfb-f47f-440a-8875-ea14b1716b43',
@@ -52,7 +52,7 @@ describe('Topics', () => {
     it('throws error when missing name', async () => {
       const payload: CreateTopicOptions = {
         name: '',
-        default_subscription: 'opt_in',
+        defaultSubscription: 'opt_in',
       };
       const response: ErrorResponse = {
         name: 'missing_required_field',
@@ -85,14 +85,14 @@ describe('Topics', () => {
 `);
     });
 
-    it('throws error when missing default_subscription', async () => {
+    it('throws error when missing defaultSubscription', async () => {
       const payload = {
         name: 'Newsletter',
         description: 'Weekly newsletter updates',
       };
       const response: ErrorResponse = {
         name: 'missing_required_field',
-        message: 'Missing `default_subscription` field.',
+        message: 'Missing `defaultSubscription` field.',
       };
 
       mockErrorResponse(response, {
@@ -109,7 +109,7 @@ describe('Topics', () => {
 {
   "data": null,
   "error": {
-    "message": "Missing \`default_subscription\` field.",
+    "message": "Missing \`defaultSubscription\` field.",
     "name": "missing_required_field",
   },
   "rateLimiting": {
@@ -130,14 +130,14 @@ describe('Topics', () => {
             id: 'b6d24b8e-af0b-4c3c-be0c-359bbd97381e',
             name: 'Newsletter',
             description: 'Weekly newsletter updates',
-            default_subscription: 'opt_in',
+            defaultSubscription: 'opt_in',
             created_at: '2023-04-07T23:13:52.669661+00:00',
           },
           {
             id: 'ac7503ac-e027-4aea-94b3-b0acd46f65f9',
             name: 'Product Updates',
             description: 'Product announcements and updates',
-            default_subscription: 'opt_out',
+            defaultSubscription: 'opt_out',
             created_at: '2023-04-07T23:13:20.417116+00:00',
           },
         ],
@@ -154,14 +154,14 @@ describe('Topics', () => {
     "data": [
       {
         "created_at": "2023-04-07T23:13:52.669661+00:00",
-        "default_subscription": "opt_in",
+        "defaultSubscription": "opt_in",
         "description": "Weekly newsletter updates",
         "id": "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
         "name": "Newsletter",
       },
       {
         "created_at": "2023-04-07T23:13:20.417116+00:00",
-        "default_subscription": "opt_out",
+        "defaultSubscription": "opt_out",
         "description": "Product announcements and updates",
         "id": "ac7503ac-e027-4aea-94b3-b0acd46f65f9",
         "name": "Product Updates",
@@ -221,7 +221,7 @@ describe('Topics', () => {
         id: 'fd61172c-cafc-40f5-b049-b45947779a29',
         name: 'Newsletter',
         description: 'Weekly newsletter updates',
-        default_subscription: 'opt_in',
+        defaultSubscription: 'opt_in',
         created_at: '2024-01-16T18:12:26.514Z',
       };
 
@@ -236,7 +236,7 @@ describe('Topics', () => {
 {
   "data": {
     "created_at": "2024-01-16T18:12:26.514Z",
-    "default_subscription": "opt_in",
+    "defaultSubscription": "opt_in",
     "description": "Weekly newsletter updates",
     "id": "fd61172c-cafc-40f5-b049-b45947779a29",
     "name": "Newsletter",

--- a/src/topics/topics.spec.ts
+++ b/src/topics/topics.spec.ts
@@ -130,14 +130,14 @@ describe('Topics', () => {
             id: 'b6d24b8e-af0b-4c3c-be0c-359bbd97381e',
             name: 'Newsletter',
             description: 'Weekly newsletter updates',
-            defaultSubscription: 'opt_in',
+            default_subscription: 'opt_in',
             created_at: '2023-04-07T23:13:52.669661+00:00',
           },
           {
             id: 'ac7503ac-e027-4aea-94b3-b0acd46f65f9',
             name: 'Product Updates',
             description: 'Product announcements and updates',
-            defaultSubscription: 'opt_out',
+            default_subscription: 'opt_out',
             created_at: '2023-04-07T23:13:20.417116+00:00',
           },
         ],
@@ -154,14 +154,14 @@ describe('Topics', () => {
     "data": [
       {
         "created_at": "2023-04-07T23:13:52.669661+00:00",
-        "defaultSubscription": "opt_in",
+        "default_subscription": "opt_in",
         "description": "Weekly newsletter updates",
         "id": "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
         "name": "Newsletter",
       },
       {
         "created_at": "2023-04-07T23:13:20.417116+00:00",
-        "defaultSubscription": "opt_out",
+        "default_subscription": "opt_out",
         "description": "Product announcements and updates",
         "id": "ac7503ac-e027-4aea-94b3-b0acd46f65f9",
         "name": "Product Updates",

--- a/src/topics/topics.ts
+++ b/src/topics/topics.ts
@@ -27,11 +27,11 @@ export class Topics {
 
   async create(payload: CreateTopicOptions): Promise<CreateTopicResponse> {
     const { defaultSubscription, ...body } = payload;
-    
-    const data = await this.resend.post<CreateTopicResponseSuccess>(
-      '/topics',
-      { ...body, default_subscription: payload.defaultSubscription },
-    );
+
+    const data = await this.resend.post<CreateTopicResponseSuccess>('/topics', {
+      ...body,
+      default_subscription: defaultSubscription,
+    });
 
     return data;
   }

--- a/src/topics/topics.ts
+++ b/src/topics/topics.ts
@@ -26,9 +26,11 @@ export class Topics {
   constructor(private readonly resend: Resend) {}
 
   async create(payload: CreateTopicOptions): Promise<CreateTopicResponse> {
+    const { defaultSubscription, ...body } = payload;
+    
     const data = await this.resend.post<CreateTopicResponseSuccess>(
       '/topics',
-      payload,
+      { ...body, default_subscription: payload.defaultSubscription },
     );
 
     return data;


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Renamed the create topic option from default_subscription to defaultSubscription to use camelCase consistently. Updated tests and error messages to match.

- **Migration**
  - Replace default_subscription with defaultSubscription when creating topics.

<!-- End of auto-generated description by cubic. -->

