### PR TITLE
fix: global contacts friction log

### DIFF
--- a/src/contacts/contacts.spec.ts
+++ b/src/contacts/contacts.spec.ts
@@ -697,5 +697,34 @@ describe('Contacts', () => {
   }
   `);
     });
+
+    it('removes a contact by string id', async () => {
+      const response: RemoveContactsResponseSuccess = {
+        contact: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223',
+        object: 'contact',
+        deleted: true,
+      };
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+          Authorization: 'Bearer re_924b3rjh2387fbewf823',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      await expect(
+        resend.contacts.remove('3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223'),
+      ).resolves.toMatchInlineSnapshot(`
+{
+  "data": {
+    "contact": "3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223",
+    "deleted": true,
+    "object": "contact",
+  },
+  "error": null,
+}
+`);
+    });
   });
 });

--- a/src/contacts/contacts.spec.ts
+++ b/src/contacts/contacts.spec.ts
@@ -419,6 +419,181 @@ describe('Contacts', () => {
 }
 `);
     });
+
+    describe('when audienceId is not provided', () => {
+      it('get contact by id', async () => {
+        const response: GetContactResponseSuccess = {
+          object: 'contact',
+          id: 'fd61172c-cafc-40f5-b049-b45947779a29',
+          email: 'team@resend.com',
+          first_name: '',
+          last_name: '',
+          created_at: '2024-01-16T18:12:26.514Z',
+          unsubscribed: false,
+        };
+
+        fetchMock.mockOnce(JSON.stringify(response), {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+            Authorization: 'Bearer re_924b3rjh2387fbewf823',
+          },
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+        const options: GetContactOptions = {
+          id: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223',
+        };
+        await expect(
+          resend.contacts.get(options),
+        ).resolves.toMatchInlineSnapshot(`
+{
+  "data": {
+    "created_at": "2024-01-16T18:12:26.514Z",
+    "email": "team@resend.com",
+    "first_name": "",
+    "id": "fd61172c-cafc-40f5-b049-b45947779a29",
+    "last_name": "",
+    "object": "contact",
+    "unsubscribed": false,
+  },
+  "error": null,
+}
+`);
+      });
+
+      it('get contact by email', async () => {
+        const response: GetContactResponseSuccess = {
+          object: 'contact',
+          id: 'fd61172c-cafc-40f5-b049-b45947779a29',
+          email: 'team@resend.com',
+          first_name: '',
+          last_name: '',
+          created_at: '2024-01-16T18:12:26.514Z',
+          unsubscribed: false,
+        };
+
+        fetchMock.mockOnce(JSON.stringify(response), {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+            Authorization: 'Bearer re_924b3rjh2387fbewf823',
+          },
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+        const options: GetContactOptions = {
+          email: 'team@resend.com',
+        };
+        await expect(
+          resend.contacts.get(options),
+        ).resolves.toMatchInlineSnapshot(`
+{
+  "data": {
+    "created_at": "2024-01-16T18:12:26.514Z",
+    "email": "team@resend.com",
+    "first_name": "",
+    "id": "fd61172c-cafc-40f5-b049-b45947779a29",
+    "last_name": "",
+    "object": "contact",
+    "unsubscribed": false,
+  },
+  "error": null,
+}
+`);
+      });
+      it('get contact by string id', async () => {
+        const response: GetContactResponseSuccess = {
+          object: 'contact',
+          id: 'fd61172c-cafc-40f5-b049-b45947779a29',
+          email: 'team@resend.com',
+          first_name: '',
+          last_name: '',
+          created_at: '2024-01-16T18:12:26.514Z',
+          unsubscribed: false,
+        };
+
+        fetchMock.mockOnce(JSON.stringify(response), {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+            Authorization: 'Bearer re_924b3rjh2387fbewf823',
+          },
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+        await expect(
+          resend.contacts.get('fd61172c-cafc-40f5-b049-b45947779a29'),
+        ).resolves.toMatchInlineSnapshot(`
+{
+  "data": {
+    "created_at": "2024-01-16T18:12:26.514Z",
+    "email": "team@resend.com",
+    "first_name": "",
+    "id": "fd61172c-cafc-40f5-b049-b45947779a29",
+    "last_name": "",
+    "object": "contact",
+    "unsubscribed": false,
+  },
+  "error": null,
+}
+`);
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://api.resend.com/contacts/fd61172c-cafc-40f5-b049-b45947779a29',
+          expect.objectContaining({
+            method: 'GET',
+            headers: expect.any(Headers),
+          }),
+        );
+      });
+
+      it('get contact by string email', async () => {
+        const response: GetContactResponseSuccess = {
+          object: 'contact',
+          id: 'fd61172c-cafc-40f5-b049-b45947779a29',
+          email: 'team@resend.com',
+          first_name: '',
+          last_name: '',
+          created_at: '2024-01-16T18:12:26.514Z',
+          unsubscribed: false,
+        };
+
+        fetchMock.mockOnce(JSON.stringify(response), {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+            Authorization: 'Bearer re_924b3rjh2387fbewf823',
+          },
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+        await expect(
+          resend.contacts.get('team@resend.com'),
+        ).resolves.toMatchInlineSnapshot(`
+{
+  "data": {
+    "created_at": "2024-01-16T18:12:26.514Z",
+    "email": "team@resend.com",
+    "first_name": "",
+    "id": "fd61172c-cafc-40f5-b049-b45947779a29",
+    "last_name": "",
+    "object": "contact",
+    "unsubscribed": false,
+  },
+  "error": null,
+}
+`);
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://api.resend.com/contacts/team@resend.com',
+          expect.objectContaining({
+            method: 'GET',
+            headers: expect.any(Headers),
+          }),
+        );
+      });
+    });
   });
 
   describe('update', () => {

--- a/src/contacts/contacts.ts
+++ b/src/contacts/contacts.ts
@@ -90,6 +90,13 @@ export class Contacts {
   }
 
   async get(options: GetContactOptions): Promise<GetContactResponse> {
+    if (typeof options === 'string') {
+      const data = await this.resend.get<GetContactResponseSuccess>(
+        `/contacts/${options}`,
+      );
+      return data;
+    }
+
     if (!options.id && !options.email) {
       return {
         data: null,

--- a/src/contacts/contacts.ts
+++ b/src/contacts/contacts.ts
@@ -155,6 +155,13 @@ export class Contacts {
   }
 
   async remove(payload: RemoveContactOptions): Promise<RemoveContactsResponse> {
+    if (typeof payload === 'string') {
+      const data = await this.resend.delete<RemoveContactsResponseSuccess>(
+        `/contacts/${payload}`,
+      );
+      return data;
+    }
+
     if (!payload.id && !payload.email) {
       return {
         data: null,

--- a/src/contacts/interfaces/get-contact.interface.ts
+++ b/src/contacts/interfaces/get-contact.interface.ts
@@ -1,9 +1,11 @@
 import type { ErrorResponse } from '../../interfaces';
 import type { Contact, SelectingField } from './contact';
 
-export type GetContactOptions = {
-  audienceId?: string;
-} & SelectingField;
+export type GetContactOptions =
+  | string
+  | ({
+      audienceId?: string;
+    } & SelectingField);
 
 export interface GetContactResponseSuccess
   extends Pick<

--- a/src/contacts/interfaces/remove-contact.interface.ts
+++ b/src/contacts/interfaces/remove-contact.interface.ts
@@ -7,9 +7,11 @@ export type RemoveContactsResponseSuccess = {
   contact: string;
 };
 
-export type RemoveContactOptions = SelectingField & {
-  audienceId?: string;
-};
+export type RemoveContactOptions =
+  | string
+  | (SelectingField & {
+      audienceId?: string;
+    });
 
 export type RemoveContactsResponse =
   | {


### PR DESCRIPTION
Enables getting and removing global contacts by passing a string id or email as an alternative to using an object.

All of the followings are valid:

```ts
// Traditional object parameter
resend.contacts.get({email: "foo@bar.com"})
resend.contacts.get({id: "b6acc733-5320-4e28-bdcd-70e6006db885"})

// New string parameter
resend.contacts.get("foo@bar.com")
resend.contacts.get("b6acc733-5320-4e28-bdcd-70e6006db885")
```


Others:

  - Added tests for string id/email and for cases where audienceId is omitted.


