### PR TITLE
fix: encode endpoint

### DIFF
--- a/src/api-keys/api-keys.ts
+++ b/src/api-keys/api-keys.ts
@@ -42,7 +42,7 @@ export class ApiKeys {
 
   async remove(id: string): Promise<RemoveApiKeyResponse> {
     const data = await this.resend.delete<RemoveApiKeyResponseSuccess>(
-      `/api-keys/${id}`,
+      `/api-keys/${encodeURIComponent(id)}`,
     );
     return data;
   }

--- a/src/automation-runs/automation-runs.ts
+++ b/src/automation-runs/automation-runs.ts
@@ -18,7 +18,7 @@ export class AutomationRuns {
     options: GetAutomationRunOptions,
   ): Promise<GetAutomationRunResponse> {
     const data = await this.resend.get<GetAutomationRunResponseSuccess>(
-      `/automations/${options.automationId}/runs/${options.runId}`,
+      `/automations/${encodeURIComponent(options.automationId)}/runs/${encodeURIComponent(options.runId)}`,
     );
     return data;
   }
@@ -37,9 +37,10 @@ export class AutomationRuns {
     }
 
     const qs = searchParams.toString();
+    const safeAutomationId = encodeURIComponent(options.automationId);
     const url = qs
-      ? `/automations/${options.automationId}/runs?${qs}`
-      : `/automations/${options.automationId}/runs`;
+      ? `/automations/${safeAutomationId}/runs?${qs}`
+      : `/automations/${safeAutomationId}/runs`;
 
     const data = await this.resend.get<ListAutomationRunsResponseSuccess>(url);
     return data;

--- a/src/automations/automations.ts
+++ b/src/automations/automations.ts
@@ -71,14 +71,14 @@ export class Automations {
 
   async get(id: string): Promise<GetAutomationResponse> {
     const data = await this.resend.get<GetAutomationResponseSuccess>(
-      `/automations/${id}`,
+      `/automations/${encodeURIComponent(id)}`,
     );
     return data;
   }
 
   async remove(id: string): Promise<RemoveAutomationResponse> {
     const data = await this.resend.delete<RemoveAutomationResponseSuccess>(
-      `/automations/${id}`,
+      `/automations/${encodeURIComponent(id)}`,
     );
     return data;
   }
@@ -103,7 +103,7 @@ export class Automations {
     }
 
     const data = await this.resend.patch<UpdateAutomationResponseSuccess>(
-      `/automations/${id}`,
+      `/automations/${encodeURIComponent(id)}`,
       apiPayload,
     );
     return data;
@@ -111,7 +111,7 @@ export class Automations {
 
   async stop(id: string): Promise<StopAutomationResponse> {
     const data = await this.resend.post<StopAutomationResponseSuccess>(
-      `/automations/${id}/stop`,
+      `/automations/${encodeURIComponent(id)}/stop`,
     );
     return data;
   }

--- a/src/broadcasts/broadcasts.ts
+++ b/src/broadcasts/broadcasts.ts
@@ -67,7 +67,7 @@ export class Broadcasts {
     payload?: SendBroadcastOptions,
   ): Promise<SendBroadcastResponse> {
     const data = await this.resend.post<SendBroadcastResponseSuccess>(
-      `/broadcasts/${id}/send`,
+      `/broadcasts/${encodeURIComponent(id)}/send`,
       { scheduled_at: payload?.scheduledAt },
     );
 
@@ -86,14 +86,14 @@ export class Broadcasts {
 
   async get(id: string): Promise<GetBroadcastResponse> {
     const data = await this.resend.get<GetBroadcastResponseSuccess>(
-      `/broadcasts/${id}`,
+      `/broadcasts/${encodeURIComponent(id)}`,
     );
     return data;
   }
 
   async remove(id: string): Promise<RemoveBroadcastResponse> {
     const data = await this.resend.delete<RemoveBroadcastResponseSuccess>(
-      `/broadcasts/${id}`,
+      `/broadcasts/${encodeURIComponent(id)}`,
     );
     return data;
   }
@@ -107,7 +107,7 @@ export class Broadcasts {
     }
 
     const data = await this.resend.patch<UpdateBroadcastResponseSuccess>(
-      `/broadcasts/${id}`,
+      `/broadcasts/${encodeURIComponent(id)}`,
       {
         name: payload.name,
         segment_id: payload.segmentId,

--- a/src/contact-properties/contact-properties.ts
+++ b/src/contact-properties/contact-properties.ts
@@ -82,7 +82,7 @@ export class ContactProperties {
       };
     }
     const response = await this.resend.get<GetContactPropertyResponseSuccess>(
-      `/contact-properties/${id}`,
+      `/contact-properties/${encodeURIComponent(id)}`,
     );
 
     if (response.data) {
@@ -116,7 +116,7 @@ export class ContactProperties {
 
     const apiOptions = parseContactPropertyToApiOptions(payload);
     const data = await this.resend.patch<UpdateContactPropertyResponseSuccess>(
-      `/contact-properties/${payload.id}`,
+      `/contact-properties/${encodeURIComponent(payload.id)}`,
       apiOptions,
     );
     return data;
@@ -135,7 +135,7 @@ export class ContactProperties {
       };
     }
     const data = await this.resend.delete<RemoveContactPropertyResponseSuccess>(
-      `/contact-properties/${id}`,
+      `/contact-properties/${encodeURIComponent(id)}`,
     );
     return data;
   }

--- a/src/contacts/__recordings__/Contacts-Integration-Tests-contacts-API-endpoint-get-retrieves-a-contact-by-email_2206692250/recording.har
+++ b/src/contacts/__recordings__/Contacts-Integration-Tests-contacts-API-endpoint-get-retrieves-a-contact-by-email_2206692250/recording.har
@@ -116,7 +116,7 @@
         }
       },
       {
-        "_id": "70c5e9377d072322ddac67f0c0bd118a",
+        "_id": "1a48bb48c19f8d09cd04bf4a03f1cfce",
         "_order": 0,
         "cache": {},
         "request": {
@@ -140,7 +140,7 @@
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://api.resend.com/contacts/test-get-by-email@example.com"
+          "url": "https://api.resend.com/contacts/test-get-by-email%40example.com"
         },
         "response": {
           "bodySize": 221,

--- a/src/contacts/__recordings__/Contacts-Integration-Tests-contacts-API-endpoint-remove-removes-a-contact-by-email_421891524/recording.har
+++ b/src/contacts/__recordings__/Contacts-Integration-Tests-contacts-API-endpoint-remove-removes-a-contact-by-email_421891524/recording.har
@@ -224,7 +224,7 @@
         }
       },
       {
-        "_id": "8bd97c70e6262ff3457e940564a57c1d",
+        "_id": "2f94ae5b19cd9c94f1c06496b359fdfe",
         "_order": 0,
         "cache": {},
         "request": {
@@ -248,7 +248,7 @@
           "httpVersion": "HTTP/1.1",
           "method": "DELETE",
           "queryString": [],
-          "url": "https://api.resend.com/audiences/d6a1792a-0a97-41aa-a3dd-7ebec2becceb/contacts/test-remove-by-email@example.com"
+          "url": "https://api.resend.com/audiences/d6a1792a-0a97-41aa-a3dd-7ebec2becceb/contacts/test-remove-by-email%40example.com"
         },
         "response": {
           "bodySize": 80,
@@ -331,7 +331,7 @@
         }
       },
       {
-        "_id": "2a82fb0d94b4d030d83a97cac5ebec39",
+        "_id": "c823249fe704ca057c26c0468aab6858",
         "_order": 0,
         "cache": {},
         "request": {
@@ -355,7 +355,7 @@
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://api.resend.com/audiences/d6a1792a-0a97-41aa-a3dd-7ebec2becceb/contacts/test-remove-by-email@example.com"
+          "url": "https://api.resend.com/audiences/d6a1792a-0a97-41aa-a3dd-7ebec2becceb/contacts/test-remove-by-email%40example.com"
         },
         "response": {
           "bodySize": 67,

--- a/src/contacts/__recordings__/Contacts-Integration-Tests-get-retrieves-a-contact-by-email_2183683318/recording.har
+++ b/src/contacts/__recordings__/Contacts-Integration-Tests-get-retrieves-a-contact-by-email_2183683318/recording.har
@@ -248,7 +248,7 @@
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://api.resend.com/audiences/b12a7fd8-7514-4893-8361-9ef21678dc4c/contacts/test-get-by-email@example.com"
+          "url": "https://api.resend.com/audiences/b12a7fd8-7514-4893-8361-9ef21678dc4c/contacts/test-get-by-email%40example.com"
         },
         "response": {
           "bodySize": 205,

--- a/src/contacts/__recordings__/Contacts-Integration-Tests-legacy-contacts-API-endpoint-get-retrieves-a-contact-by-email_321416205/recording.har
+++ b/src/contacts/__recordings__/Contacts-Integration-Tests-legacy-contacts-API-endpoint-get-retrieves-a-contact-by-email_321416205/recording.har
@@ -224,7 +224,7 @@
         }
       },
       {
-        "_id": "70c5e9377d072322ddac67f0c0bd118a",
+        "_id": "1a48bb48c19f8d09cd04bf4a03f1cfce",
         "_order": 0,
         "cache": {},
         "request": {
@@ -248,7 +248,7 @@
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://api.resend.com/contacts/test-get-by-email@example.com"
+          "url": "https://api.resend.com/contacts/test-get-by-email%40example.com"
         },
         "response": {
           "bodySize": 221,

--- a/src/contacts/__recordings__/Contacts-Integration-Tests-legacy-contacts-API-endpoint-remove-removes-a-contact-by-email_1387333173/recording.har
+++ b/src/contacts/__recordings__/Contacts-Integration-Tests-legacy-contacts-API-endpoint-remove-removes-a-contact-by-email_1387333173/recording.har
@@ -224,7 +224,7 @@
         }
       },
       {
-        "_id": "1fad80e2a22ff503e5f44f022f93de00",
+        "_id": "20dd181c0b8984945c9354cd579a2155",
         "_order": 0,
         "cache": {},
         "request": {
@@ -248,7 +248,7 @@
           "httpVersion": "HTTP/1.1",
           "method": "DELETE",
           "queryString": [],
-          "url": "https://api.resend.com/audiences/583da88a-79b0-407c-bb33-fe6b79487754/contacts/test-remove-by-email@example.com"
+          "url": "https://api.resend.com/audiences/583da88a-79b0-407c-bb33-fe6b79487754/contacts/test-remove-by-email%40example.com"
         },
         "response": {
           "bodySize": 80,
@@ -331,7 +331,7 @@
         }
       },
       {
-        "_id": "bfb41970ab8f65d8dc3d5fe083c888f3",
+        "_id": "e334867c6fa64600a91ee7311b6037a0",
         "_order": 0,
         "cache": {},
         "request": {
@@ -355,7 +355,7 @@
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://api.resend.com/audiences/583da88a-79b0-407c-bb33-fe6b79487754/contacts/test-remove-by-email@example.com"
+          "url": "https://api.resend.com/audiences/583da88a-79b0-407c-bb33-fe6b79487754/contacts/test-remove-by-email%40example.com"
         },
         "response": {
           "bodySize": 67,

--- a/src/contacts/__recordings__/Contacts-Integration-Tests-remove-removes-a-contact-by-email_1973365032/recording.har
+++ b/src/contacts/__recordings__/Contacts-Integration-Tests-remove-removes-a-contact-by-email_1973365032/recording.har
@@ -248,7 +248,7 @@
           "httpVersion": "HTTP/1.1",
           "method": "DELETE",
           "queryString": [],
-          "url": "https://api.resend.com/audiences/3810aa6d-856d-42e7-b1cb-05a3b21b8db6/contacts/test-remove-by-email@example.com"
+          "url": "https://api.resend.com/audiences/3810aa6d-856d-42e7-b1cb-05a3b21b8db6/contacts/test-remove-by-email%40example.com"
         },
         "response": {
           "bodySize": 80,
@@ -355,7 +355,7 @@
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://api.resend.com/audiences/3810aa6d-856d-42e7-b1cb-05a3b21b8db6/contacts/test-remove-by-email@example.com"
+          "url": "https://api.resend.com/audiences/3810aa6d-856d-42e7-b1cb-05a3b21b8db6/contacts/test-remove-by-email%40example.com"
         },
         "response": {
           "bodySize": 67,

--- a/src/contacts/contacts.spec.ts
+++ b/src/contacts/contacts.spec.ts
@@ -823,7 +823,7 @@ describe('Contacts', () => {
         `);
 
         expect(fetchMock).toHaveBeenCalledWith(
-          'https://api.resend.com/contacts/team@resend.com',
+          'https://api.resend.com/contacts/team%40resend.com',
           expect.objectContaining({
             method: 'GET',
             headers: expect.any(Headers),

--- a/src/contacts/contacts.ts
+++ b/src/contacts/contacts.ts
@@ -68,7 +68,7 @@ export class Contacts {
       }
 
       const data = await this.resend.post<CreateContactResponseSuccess>(
-        `/audiences/${payload.audienceId}/contacts`,
+        `/audiences/${encodeURIComponent(payload.audienceId)}/contacts`,
         {
           unsubscribed: payload.unsubscribed,
           email: payload.email,
@@ -109,15 +109,15 @@ export class Contacts {
 
     const queryString = buildPaginationQuery(options);
     const url = queryString
-      ? `/segments/${segmentId}/contacts?${queryString}`
-      : `/segments/${segmentId}/contacts`;
+      ? `/segments/${encodeURIComponent(segmentId)}/contacts?${queryString}`
+      : `/segments/${encodeURIComponent(segmentId)}/contacts`;
     const data = await this.resend.get<ListContactsResponseSuccess>(url);
     return data;
   }
 
   async get(options: GetContactOptions): Promise<GetContactResponse> {
     if (typeof options === 'string') {
-      return this.resend.get<GetContactResponseSuccess>(`/contacts/${options}`);
+      return this.resend.get<GetContactResponseSuccess>(`/contacts/${encodeURIComponent(options)}`);
     }
 
     if (!options.id && !options.email) {
@@ -134,12 +134,12 @@ export class Contacts {
 
     if (!options.audienceId) {
       return this.resend.get<GetContactResponseSuccess>(
-        `/contacts/${options?.email ? options?.email : options?.id}`,
+        `/contacts/${encodeURIComponent(options?.email ? options?.email : options?.id!)}`,
       );
     }
 
     return this.resend.get<GetContactResponseSuccess>(
-      `/audiences/${options.audienceId}/contacts/${options?.email ? options?.email : options?.id}`,
+      `/audiences/${encodeURIComponent(options.audienceId)}/contacts/${encodeURIComponent((options?.email ? options?.email : options?.id)!)}`,
     );
   }
 
@@ -158,7 +158,7 @@ export class Contacts {
 
     if (!options.audienceId) {
       const data = await this.resend.patch<UpdateContactResponseSuccess>(
-        `/contacts/${options?.email ? options?.email : options?.id}`,
+        `/contacts/${encodeURIComponent((options?.email ? options?.email : options?.id)!)}`,
         {
           unsubscribed: options.unsubscribed,
           first_name: options.firstName,
@@ -170,7 +170,7 @@ export class Contacts {
     }
 
     const data = await this.resend.patch<UpdateContactResponseSuccess>(
-      `/audiences/${options.audienceId}/contacts/${options?.email ? options?.email : options?.id}`,
+      `/audiences/${encodeURIComponent(options.audienceId)}/contacts/${encodeURIComponent((options?.email ? options?.email : options?.id)!)}`,
       {
         unsubscribed: options.unsubscribed,
         first_name: options.firstName,
@@ -184,7 +184,7 @@ export class Contacts {
   async remove(payload: RemoveContactOptions): Promise<RemoveContactsResponse> {
     if (typeof payload === 'string') {
       return this.resend.delete<RemoveContactsResponseSuccess>(
-        `/contacts/${payload}`,
+        `/contacts/${encodeURIComponent(payload)}`,
       );
     }
 
@@ -202,14 +202,12 @@ export class Contacts {
 
     if (!payload.audienceId) {
       return this.resend.delete<RemoveContactsResponseSuccess>(
-        `/contacts/${payload?.email ? payload?.email : payload?.id}`,
+        `/contacts/${encodeURIComponent((payload?.email ? payload?.email : payload?.id)!)}`,
       );
     }
 
     return this.resend.delete<RemoveContactsResponseSuccess>(
-      `/audiences/${payload.audienceId}/contacts/${
-        payload?.email ? payload?.email : payload?.id
-      }`,
+      `/audiences/${encodeURIComponent(payload.audienceId)}/contacts/${encodeURIComponent((payload?.email ? payload?.email : payload?.id)!)}`,
     );
   }
 }

--- a/src/contacts/contacts.ts
+++ b/src/contacts/contacts.ts
@@ -117,7 +117,9 @@ export class Contacts {
 
   async get(options: GetContactOptions): Promise<GetContactResponse> {
     if (typeof options === 'string') {
-      return this.resend.get<GetContactResponseSuccess>(`/contacts/${encodeURIComponent(options)}`);
+      return this.resend.get<GetContactResponseSuccess>(
+        `/contacts/${encodeURIComponent(options)}`,
+      );
     }
 
     if (!options.id && !options.email) {
@@ -134,12 +136,12 @@ export class Contacts {
 
     if (!options.audienceId) {
       return this.resend.get<GetContactResponseSuccess>(
-        `/contacts/${encodeURIComponent(options?.email ? options?.email : options?.id!)}`,
+        `/contacts/${encodeURIComponent(options.email ?? options.id ?? '')}`,
       );
     }
 
     return this.resend.get<GetContactResponseSuccess>(
-      `/audiences/${encodeURIComponent(options.audienceId)}/contacts/${encodeURIComponent((options?.email ? options?.email : options?.id)!)}`,
+      `/audiences/${encodeURIComponent(options.audienceId)}/contacts/${encodeURIComponent(options.email ?? options.id ?? '')}`,
     );
   }
 
@@ -158,7 +160,7 @@ export class Contacts {
 
     if (!options.audienceId) {
       const data = await this.resend.patch<UpdateContactResponseSuccess>(
-        `/contacts/${encodeURIComponent((options?.email ? options?.email : options?.id)!)}`,
+        `/contacts/${encodeURIComponent(options.email ?? options.id ?? '')}`,
         {
           unsubscribed: options.unsubscribed,
           first_name: options.firstName,
@@ -170,7 +172,7 @@ export class Contacts {
     }
 
     const data = await this.resend.patch<UpdateContactResponseSuccess>(
-      `/audiences/${encodeURIComponent(options.audienceId)}/contacts/${encodeURIComponent((options?.email ? options?.email : options?.id)!)}`,
+      `/audiences/${encodeURIComponent(options.audienceId)}/contacts/${encodeURIComponent(options.email ?? options.id ?? '')}`,
       {
         unsubscribed: options.unsubscribed,
         first_name: options.firstName,
@@ -202,12 +204,12 @@ export class Contacts {
 
     if (!payload.audienceId) {
       return this.resend.delete<RemoveContactsResponseSuccess>(
-        `/contacts/${encodeURIComponent((payload?.email ? payload?.email : payload?.id)!)}`,
+        `/contacts/${encodeURIComponent(payload.email ?? payload.id ?? '')}`,
       );
     }
 
     return this.resend.delete<RemoveContactsResponseSuccess>(
-      `/audiences/${encodeURIComponent(payload.audienceId)}/contacts/${encodeURIComponent((payload?.email ? payload?.email : payload?.id)!)}`,
+      `/audiences/${encodeURIComponent(payload.audienceId)}/contacts/${encodeURIComponent(payload.email ?? payload.id ?? '')}`,
     );
   }
 }

--- a/src/contacts/segments/contact-segments.ts
+++ b/src/contacts/segments/contact-segments.ts
@@ -34,11 +34,11 @@ export class ContactSegments {
       };
     }
 
-    const identifier = options.email ? options.email : options.contactId;
+    const identifier = options.email ?? options.contactId ?? '';
     const queryString = buildPaginationQuery(options);
     const url = queryString
-      ? `/contacts/${encodeURIComponent(identifier!)}/segments?${queryString}`
-      : `/contacts/${encodeURIComponent(identifier!)}/segments`;
+      ? `/contacts/${encodeURIComponent(identifier)}/segments?${queryString}`
+      : `/contacts/${encodeURIComponent(identifier)}/segments`;
 
     const data = await this.resend.get<ListContactSegmentsResponseSuccess>(url);
     return data;
@@ -59,9 +59,9 @@ export class ContactSegments {
       };
     }
 
-    const identifier = options.email ? options.email : options.contactId;
+    const identifier = options.email ?? options.contactId ?? '';
     return this.resend.post<AddContactSegmentResponseSuccess>(
-      `/contacts/${encodeURIComponent(identifier!)}/segments/${encodeURIComponent(options.segmentId)}`,
+      `/contacts/${encodeURIComponent(identifier)}/segments/${encodeURIComponent(options.segmentId)}`,
     );
   }
 
@@ -80,9 +80,9 @@ export class ContactSegments {
       };
     }
 
-    const identifier = options.email ? options.email : options.contactId;
+    const identifier = options.email ?? options.contactId ?? '';
     return this.resend.delete<RemoveContactSegmentResponseSuccess>(
-      `/contacts/${encodeURIComponent(identifier!)}/segments/${encodeURIComponent(options.segmentId)}`,
+      `/contacts/${encodeURIComponent(identifier)}/segments/${encodeURIComponent(options.segmentId)}`,
     );
   }
 }

--- a/src/contacts/segments/contact-segments.ts
+++ b/src/contacts/segments/contact-segments.ts
@@ -37,8 +37,8 @@ export class ContactSegments {
     const identifier = options.email ? options.email : options.contactId;
     const queryString = buildPaginationQuery(options);
     const url = queryString
-      ? `/contacts/${identifier}/segments?${queryString}`
-      : `/contacts/${identifier}/segments`;
+      ? `/contacts/${encodeURIComponent(identifier!)}/segments?${queryString}`
+      : `/contacts/${encodeURIComponent(identifier!)}/segments`;
 
     const data = await this.resend.get<ListContactSegmentsResponseSuccess>(url);
     return data;
@@ -61,7 +61,7 @@ export class ContactSegments {
 
     const identifier = options.email ? options.email : options.contactId;
     return this.resend.post<AddContactSegmentResponseSuccess>(
-      `/contacts/${identifier}/segments/${options.segmentId}`,
+      `/contacts/${encodeURIComponent(identifier!)}/segments/${encodeURIComponent(options.segmentId)}`,
     );
   }
 
@@ -82,7 +82,7 @@ export class ContactSegments {
 
     const identifier = options.email ? options.email : options.contactId;
     return this.resend.delete<RemoveContactSegmentResponseSuccess>(
-      `/contacts/${identifier}/segments/${options.segmentId}`,
+      `/contacts/${encodeURIComponent(identifier!)}/segments/${encodeURIComponent(options.segmentId)}`,
     );
   }
 }

--- a/src/contacts/topics/contact-topics.ts
+++ b/src/contacts/topics/contact-topics.ts
@@ -29,9 +29,9 @@ export class ContactTopics {
       };
     }
 
-    const identifier = payload.email ? payload.email : payload.id;
+    const identifier = payload.email ?? payload.id ?? '';
     return this.resend.patch<UpdateContactTopicsResponseSuccess>(
-      `/contacts/${encodeURIComponent(identifier!)}/topics`,
+      `/contacts/${encodeURIComponent(identifier)}/topics`,
       payload.topics,
     );
   }
@@ -51,11 +51,11 @@ export class ContactTopics {
       };
     }
 
-    const identifier = options.email ? options.email : options.id;
+    const identifier = options.email ?? options.id ?? '';
     const queryString = buildPaginationQuery(options);
     const url = queryString
-      ? `/contacts/${encodeURIComponent(identifier!)}/topics?${queryString}`
-      : `/contacts/${encodeURIComponent(identifier!)}/topics`;
+      ? `/contacts/${encodeURIComponent(identifier)}/topics?${queryString}`
+      : `/contacts/${encodeURIComponent(identifier)}/topics`;
 
     return this.resend.get<ListContactTopicsResponseSuccess>(url);
   }

--- a/src/contacts/topics/contact-topics.ts
+++ b/src/contacts/topics/contact-topics.ts
@@ -31,7 +31,7 @@ export class ContactTopics {
 
     const identifier = payload.email ? payload.email : payload.id;
     return this.resend.patch<UpdateContactTopicsResponseSuccess>(
-      `/contacts/${identifier}/topics`,
+      `/contacts/${encodeURIComponent(identifier!)}/topics`,
       payload.topics,
     );
   }
@@ -54,8 +54,8 @@ export class ContactTopics {
     const identifier = options.email ? options.email : options.id;
     const queryString = buildPaginationQuery(options);
     const url = queryString
-      ? `/contacts/${identifier}/topics?${queryString}`
-      : `/contacts/${identifier}/topics`;
+      ? `/contacts/${encodeURIComponent(identifier!)}/topics?${queryString}`
+      : `/contacts/${encodeURIComponent(identifier!)}/topics`;
 
     return this.resend.get<ListContactTopicsResponseSuccess>(url);
   }

--- a/src/domains/domains.ts
+++ b/src/domains/domains.ts
@@ -55,7 +55,7 @@ export class Domains {
 
   async get(id: string): Promise<GetDomainResponse> {
     const data = await this.resend.get<GetDomainResponseSuccess>(
-      `/domains/${id}`,
+      `/domains/${encodeURIComponent(id)}`,
     );
 
     return data;
@@ -63,7 +63,7 @@ export class Domains {
 
   async update(payload: UpdateDomainsOptions): Promise<UpdateDomainsResponse> {
     const data = await this.resend.patch<UpdateDomainsResponseSuccess>(
-      `/domains/${payload.id}`,
+      `/domains/${encodeURIComponent(payload.id)}`,
       {
         click_tracking: payload.clickTracking,
         open_tracking: payload.openTracking,
@@ -76,14 +76,14 @@ export class Domains {
 
   async remove(id: string): Promise<RemoveDomainsResponse> {
     const data = await this.resend.delete<RemoveDomainsResponseSuccess>(
-      `/domains/${id}`,
+      `/domains/${encodeURIComponent(id)}`,
     );
     return data;
   }
 
   async verify(id: string): Promise<VerifyDomainsResponse> {
     const data = await this.resend.post<VerifyDomainsResponseSuccess>(
-      `/domains/${id}/verify`,
+      `/domains/${encodeURIComponent(id)}/verify`,
     );
     return data;
   }

--- a/src/emails/attachments/attachments.ts
+++ b/src/emails/attachments/attachments.ts
@@ -16,7 +16,7 @@ export class Attachments {
     const { emailId, id } = options;
 
     const data = await this.resend.get<GetAttachmentResponseSuccess>(
-      `/emails/${emailId}/attachments/${id}`,
+      `/emails/${encodeURIComponent(emailId)}/attachments/${encodeURIComponent(id)}`,
     );
 
     return data;
@@ -29,8 +29,8 @@ export class Attachments {
 
     const queryString = buildPaginationQuery(options);
     const url = queryString
-      ? `/emails/${emailId}/attachments?${queryString}`
-      : `/emails/${emailId}/attachments`;
+      ? `/emails/${encodeURIComponent(emailId)}/attachments?${queryString}`
+      : `/emails/${encodeURIComponent(emailId)}/attachments`;
 
     const data = await this.resend.get<ListAttachmentsResponseSuccess>(url);
 

--- a/src/emails/emails.ts
+++ b/src/emails/emails.ts
@@ -65,7 +65,7 @@ export class Emails {
 
   async get(id: string): Promise<GetEmailResponse> {
     const data = await this.resend.get<GetEmailResponseSuccess>(
-      `/emails/${id}`,
+      `/emails/${encodeURIComponent(id)}`,
     );
 
     return data;
@@ -82,7 +82,7 @@ export class Emails {
 
   async update(payload: UpdateEmailOptions): Promise<UpdateEmailResponse> {
     const data = await this.resend.patch<UpdateEmailResponseSuccess>(
-      `/emails/${payload.id}`,
+      `/emails/${encodeURIComponent(payload.id)}`,
       {
         scheduled_at: payload.scheduledAt,
       },
@@ -92,7 +92,7 @@ export class Emails {
 
   async cancel(id: string): Promise<CancelEmailResponse> {
     const data = await this.resend.post<CancelEmailResponseSuccess>(
-      `/emails/${id}/cancel`,
+      `/emails/${encodeURIComponent(id)}/cancel`,
     );
     return data;
   }

--- a/src/emails/receiving/attachments/attachments.ts
+++ b/src/emails/receiving/attachments/attachments.ts
@@ -16,7 +16,7 @@ export class Attachments {
     const { emailId, id } = options;
 
     const data = await this.resend.get<GetAttachmentResponseSuccess>(
-      `/emails/receiving/${emailId}/attachments/${id}`,
+      `/emails/receiving/${encodeURIComponent(emailId)}/attachments/${encodeURIComponent(id)}`,
     );
 
     return data;
@@ -29,8 +29,8 @@ export class Attachments {
 
     const queryString = buildPaginationQuery(options);
     const url = queryString
-      ? `/emails/receiving/${emailId}/attachments?${queryString}`
-      : `/emails/receiving/${emailId}/attachments`;
+      ? `/emails/receiving/${encodeURIComponent(emailId)}/attachments?${queryString}`
+      : `/emails/receiving/${encodeURIComponent(emailId)}/attachments`;
 
     const data = await this.resend.get<ListAttachmentsResponseSuccess>(url);
 

--- a/src/emails/receiving/receiving.ts
+++ b/src/emails/receiving/receiving.ts
@@ -26,7 +26,7 @@ export class Receiving {
 
   async get(id: string): Promise<GetReceivingEmailResponse> {
     const data = await this.resend.get<GetReceivingEmailResponseSuccess>(
-      `/emails/receiving/${id}`,
+      `/emails/receiving/${encodeURIComponent(id)}`,
     );
 
     return data;

--- a/src/logs/logs.ts
+++ b/src/logs/logs.ts
@@ -21,7 +21,7 @@ export class Logs {
   }
 
   async get(id: string): Promise<GetLogResponse> {
-    const data = await this.resend.get<GetLogResponseSuccess>(`/logs/${id}`);
+    const data = await this.resend.get<GetLogResponseSuccess>(`/logs/${encodeURIComponent(id)}`);
     return data;
   }
 }

--- a/src/logs/logs.ts
+++ b/src/logs/logs.ts
@@ -21,7 +21,9 @@ export class Logs {
   }
 
   async get(id: string): Promise<GetLogResponse> {
-    const data = await this.resend.get<GetLogResponseSuccess>(`/logs/${encodeURIComponent(id)}`);
+    const data = await this.resend.get<GetLogResponseSuccess>(
+      `/logs/${encodeURIComponent(id)}`,
+    );
     return data;
   }
 }

--- a/src/segments/segments.ts
+++ b/src/segments/segments.ts
@@ -45,14 +45,14 @@ export class Segments {
 
   async get(id: string): Promise<GetSegmentResponse> {
     const data = await this.resend.get<GetSegmentResponseSuccess>(
-      `/segments/${id}`,
+      `/segments/${encodeURIComponent(id)}`,
     );
     return data;
   }
 
   async remove(id: string): Promise<RemoveSegmentResponse> {
     const data = await this.resend.delete<RemoveSegmentResponseSuccess>(
-      `/segments/${id}`,
+      `/segments/${encodeURIComponent(id)}`,
     );
     return data;
   }

--- a/src/templates/templates.ts
+++ b/src/templates/templates.ts
@@ -76,14 +76,14 @@ export class Templates {
 
   async remove(identifier: string): Promise<RemoveTemplateResponse> {
     const data = await this.resend.delete<RemoveTemplateResponseSuccess>(
-      `/templates/${identifier}`,
+      `/templates/${encodeURIComponent(identifier)}`,
     );
     return data;
   }
 
   async get(identifier: string): Promise<GetTemplateResponse> {
     const data = await this.resend.get<GetTemplateResponseSuccess>(
-      `/templates/${identifier}`,
+      `/templates/${encodeURIComponent(identifier)}`,
     );
     return data;
   }
@@ -98,7 +98,7 @@ export class Templates {
     identifier: string,
   ): ChainableTemplateResult<DuplicateTemplateResponse> {
     const promiseDuplicate = this.resend.post<DuplicateTemplateResponseSuccess>(
-      `/templates/${identifier}/duplicate`,
+      `/templates/${encodeURIComponent(identifier)}/duplicate`,
     );
     return new ChainableTemplateResult(
       promiseDuplicate,
@@ -108,7 +108,7 @@ export class Templates {
 
   async publish(identifier: string): Promise<PublishTemplateResponse> {
     const data = await this.resend.post<PublishTemplateResponseSuccess>(
-      `/templates/${identifier}/publish`,
+      `/templates/${encodeURIComponent(identifier)}/publish`,
     );
     return data;
   }
@@ -118,7 +118,7 @@ export class Templates {
     payload: UpdateTemplateOptions,
   ): Promise<UpdateTemplateResponse> {
     const data = await this.resend.patch<UpdateTemplateResponseSuccess>(
-      `/templates/${identifier}`,
+      `/templates/${encodeURIComponent(identifier)}`,
       parseTemplateToApiOptions(payload),
     );
     return data;

--- a/src/topics/topics.ts
+++ b/src/topics/topics.ts
@@ -55,7 +55,7 @@ export class Topics {
       };
     }
     const data = await this.resend.get<GetTopicResponseSuccess>(
-      `/topics/${id}`,
+      `/topics/${encodeURIComponent(id)}`,
     );
 
     return data;
@@ -75,7 +75,7 @@ export class Topics {
     }
 
     const data = await this.resend.patch<UpdateTopicResponseSuccess>(
-      `/topics/${payload.id}`,
+      `/topics/${encodeURIComponent(payload.id)}`,
       payload,
     );
 
@@ -96,7 +96,7 @@ export class Topics {
     }
 
     const data = await this.resend.delete<RemoveTopicResponseSuccess>(
-      `/topics/${id}`,
+      `/topics/${encodeURIComponent(id)}`,
     );
 
     return data;

--- a/src/webhooks/webhooks.ts
+++ b/src/webhooks/webhooks.ts
@@ -56,7 +56,7 @@ export class Webhooks {
 
   async get(id: string): Promise<GetWebhookResponse> {
     const data = await this.resend.get<GetWebhookResponseSuccess>(
-      `/webhooks/${id}`,
+      `/webhooks/${encodeURIComponent(id)}`,
     );
 
     return data;
@@ -75,7 +75,7 @@ export class Webhooks {
     payload: UpdateWebhookOptions,
   ): Promise<UpdateWebhookResponse> {
     const data = await this.resend.patch<UpdateWebhookResponseSuccess>(
-      `/webhooks/${id}`,
+      `/webhooks/${encodeURIComponent(id)}`,
       payload,
     );
     return data;
@@ -83,7 +83,7 @@ export class Webhooks {
 
   async remove(id: string): Promise<RemoveWebhookResponse> {
     const data = await this.resend.delete<RemoveWebhookResponseSuccess>(
-      `/webhooks/${id}`,
+      `/webhooks/${encodeURIComponent(id)}`,
     );
     return data;
   }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
URL-encode all endpoint path parameters to prevent broken requests when IDs or emails include special characters like "@". This fixes 404s and routing issues across the SDK.

- **Bug Fixes**
  - Applied `encodeURIComponent` to path params across the SDK, including contacts, contact properties, segments/topics, automations/runs, broadcasts, domains, emails (sending/receiving), attachments, templates, logs, webhooks, and API keys.
  - Updated integration HAR recordings and a spec to expect encoded paths.

<sup>Written for commit 951d8c66dbc4df176672e5847c162f1a3fe1875c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

