### PR TITLE
feat(domains): add Domain Claim API methods

### DIFF
--- a/src/domains/claims/domain-claims.spec.ts
+++ b/src/domains/claims/domain-claims.spec.ts
@@ -1,0 +1,132 @@
+import createFetchMock from 'vitest-fetch-mock';
+import { Resend } from '../../resend';
+import { mockSuccessResponse } from '../../test-utils/mock-fetch';
+import type {
+  ClaimDomainOptions,
+  ClaimDomainResponseSuccess,
+} from './interfaces/claim-domain-options.interface';
+
+const fetchMocker = createFetchMock(vi);
+fetchMocker.enableMocks();
+
+const API_KEY = 're_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop';
+
+const domainClaim: ClaimDomainResponseSuccess = {
+  object: 'domain_claim',
+  id: 'dacf4072-4119-4d88-932f-6c6126d3a9d1',
+  name: 'example.com',
+  status: 'pending',
+  domain_id: 'd91cd9bd-1176-453e-8fc1-35364d380206',
+  region: 'us-east-1',
+  record: {
+    type: 'TXT',
+    name: 'example.com',
+    value: 'resend-domain-verification=3f8a1c2d4e5b6a7f8091a2b3c4d5e6f7',
+    ttl: 'Auto',
+  },
+  blocked_reason: null,
+  failure_reason: null,
+  created_at: '2026-06-16T17:12:02.059593+00:00',
+  expires_at: '2026-06-23T17:12:02.059593+00:00',
+};
+
+describe('DomainClaims', () => {
+  afterEach(() => fetchMock.resetMocks());
+  afterAll(() => fetchMocker.disableMocks());
+
+  describe('create', () => {
+    it('starts a domain claim and maps options to a snake_case body', async () => {
+      mockSuccessResponse(domainClaim, { headers: {} });
+
+      const payload: ClaimDomainOptions = {
+        name: 'example.com',
+        region: 'us-east-1',
+        customReturnPath: 'send',
+        openTracking: true,
+        clickTracking: false,
+        trackingSubdomain: 'links',
+      };
+
+      const resend = new Resend(API_KEY);
+      const result = await resend.domains.claims.create(payload);
+
+      expect(result).toEqual({
+        data: domainClaim,
+        error: null,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://api.resend.com/domains/claim',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            name: 'example.com',
+            region: 'us-east-1',
+            custom_return_path: 'send',
+            open_tracking: true,
+            click_tracking: false,
+            tracking_subdomain: 'links',
+          }),
+          headers: expect.any(Headers),
+        }),
+      );
+    });
+  });
+
+  describe('get', () => {
+    it('retrieves the latest claim for a domain', async () => {
+      mockSuccessResponse(domainClaim, { headers: {} });
+
+      const resend = new Resend(API_KEY);
+      const result = await resend.domains.claims.get(
+        'd91cd9bd-1176-453e-8fc1-35364d380206',
+      );
+
+      expect(result).toEqual({
+        data: domainClaim,
+        error: null,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://api.resend.com/domains/d91cd9bd-1176-453e-8fc1-35364d380206/claim',
+        expect.objectContaining({
+          method: 'GET',
+          headers: expect.any(Headers),
+        }),
+      );
+    });
+  });
+
+  describe('verify', () => {
+    it('triggers verification for a domain claim', async () => {
+      mockSuccessResponse(domainClaim, { headers: {} });
+
+      const resend = new Resend(API_KEY);
+      const result = await resend.domains.claims.verify(
+        'd91cd9bd-1176-453e-8fc1-35364d380206',
+      );
+
+      expect(result).toEqual({
+        data: domainClaim,
+        error: null,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://api.resend.com/domains/d91cd9bd-1176-453e-8fc1-35364d380206/claim/verify',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.any(Headers),
+        }),
+      );
+    });
+  });
+});

--- a/src/domains/claims/domain-claims.ts
+++ b/src/domains/claims/domain-claims.ts
@@ -1,0 +1,52 @@
+import type { Resend } from '../../resend';
+import type {
+  ClaimDomainOptions,
+  ClaimDomainRequestOptions,
+  ClaimDomainResponse,
+  ClaimDomainResponseSuccess,
+} from './interfaces/claim-domain-options.interface';
+import type {
+  GetDomainClaimResponse,
+  GetDomainClaimResponseSuccess,
+} from './interfaces/get-domain-claim.interface';
+import type {
+  VerifyDomainClaimResponse,
+  VerifyDomainClaimResponseSuccess,
+} from './interfaces/verify-domain-claim.interface';
+
+export class DomainClaims {
+  constructor(private readonly resend: Resend) {}
+
+  async create(
+    payload: ClaimDomainOptions,
+    options: ClaimDomainRequestOptions = {},
+  ): Promise<ClaimDomainResponse> {
+    const data = await this.resend.post<ClaimDomainResponseSuccess>(
+      '/domains/claim',
+      {
+        name: payload.name,
+        region: payload.region,
+        custom_return_path: payload.customReturnPath,
+        open_tracking: payload.openTracking,
+        click_tracking: payload.clickTracking,
+        tracking_subdomain: payload.trackingSubdomain,
+      },
+      options,
+    );
+    return data;
+  }
+
+  async get(domainId: string): Promise<GetDomainClaimResponse> {
+    const data = await this.resend.get<GetDomainClaimResponseSuccess>(
+      `/domains/${domainId}/claim`,
+    );
+    return data;
+  }
+
+  async verify(domainId: string): Promise<VerifyDomainClaimResponse> {
+    const data = await this.resend.post<VerifyDomainClaimResponseSuccess>(
+      `/domains/${domainId}/claim/verify`,
+    );
+    return data;
+  }
+}

--- a/src/domains/claims/interfaces/claim-domain-options.interface.ts
+++ b/src/domains/claims/interfaces/claim-domain-options.interface.ts
@@ -1,0 +1,21 @@
+import type { PostOptions } from '../../../common/interfaces/post-option.interface';
+import type { Response } from '../../../interfaces';
+import type { DomainRegion } from '../../interfaces/domain';
+import type { DomainClaim } from './domain-claim';
+
+export interface ClaimDomainOptions {
+  name: string;
+  region?: DomainRegion;
+  customReturnPath?: string;
+  openTracking?: boolean;
+  clickTracking?: boolean;
+  trackingSubdomain?: string;
+}
+
+export interface ClaimDomainRequestOptions extends PostOptions {}
+
+export interface ClaimDomainResponseSuccess extends DomainClaim {
+  object: 'domain_claim';
+}
+
+export type ClaimDomainResponse = Response<ClaimDomainResponseSuccess>;

--- a/src/domains/claims/interfaces/domain-claim.ts
+++ b/src/domains/claims/interfaces/domain-claim.ts
@@ -1,0 +1,36 @@
+import type { DomainRegion } from '../../interfaces/domain';
+
+export type DomainClaimStatus =
+  | 'pending'
+  | 'verified'
+  | 'completed'
+  | 'blocked'
+  | 'expired'
+  | 'superseded'
+  | 'canceled'
+  | 'failed';
+
+export type DomainClaimBlockedReason =
+  | 'grace_period'
+  | 'recent_owner_activity'
+  | 'pending_scheduled_emails';
+
+export interface DomainClaimRecord {
+  type: 'TXT';
+  name: string;
+  value: string;
+  ttl: 'Auto';
+}
+
+export interface DomainClaim {
+  id: string;
+  name: string;
+  status: DomainClaimStatus;
+  domain_id: string | null;
+  region: DomainRegion | null;
+  record: DomainClaimRecord;
+  blocked_reason: DomainClaimBlockedReason | null;
+  failure_reason: string | null;
+  created_at: string;
+  expires_at: string;
+}

--- a/src/domains/claims/interfaces/get-domain-claim.interface.ts
+++ b/src/domains/claims/interfaces/get-domain-claim.interface.ts
@@ -1,0 +1,8 @@
+import type { Response } from '../../../interfaces';
+import type { DomainClaim } from './domain-claim';
+
+export interface GetDomainClaimResponseSuccess extends DomainClaim {
+  object: 'domain_claim';
+}
+
+export type GetDomainClaimResponse = Response<GetDomainClaimResponseSuccess>;

--- a/src/domains/claims/interfaces/index.ts
+++ b/src/domains/claims/interfaces/index.ts
@@ -1,0 +1,4 @@
+export * from './claim-domain-options.interface';
+export * from './domain-claim';
+export * from './get-domain-claim.interface';
+export * from './verify-domain-claim.interface';

--- a/src/domains/claims/interfaces/verify-domain-claim.interface.ts
+++ b/src/domains/claims/interfaces/verify-domain-claim.interface.ts
@@ -1,0 +1,9 @@
+import type { Response } from '../../../interfaces';
+import type { DomainClaim } from './domain-claim';
+
+export interface VerifyDomainClaimResponseSuccess extends DomainClaim {
+  object: 'domain_claim';
+}
+
+export type VerifyDomainClaimResponse =
+  Response<VerifyDomainClaimResponseSuccess>;

--- a/src/domains/domains.ts
+++ b/src/domains/domains.ts
@@ -1,6 +1,7 @@
 import { buildPaginationQuery } from '../common/utils/build-pagination-query';
 import { parseDomainToApiOptions } from '../common/utils/parse-domain-to-api-options';
 import type { Resend } from '../resend';
+import { DomainClaims } from './claims/domain-claims';
 import type {
   CreateDomainOptions,
   CreateDomainRequestOptions,
@@ -31,7 +32,11 @@ import type {
 } from './interfaces/verify-domain.interface';
 
 export class Domains {
-  constructor(private readonly resend: Resend) {}
+  readonly claims: DomainClaims;
+
+  constructor(private readonly resend: Resend) {
+    this.claims = new DomainClaims(this.resend);
+  }
 
   async create(
     payload: CreateDomainOptions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export * from './contact-properties/interfaces';
 export * from './contacts/interfaces';
 export * from './contacts/segments/interfaces';
 export * from './contacts/topics/interfaces';
+export * from './domains/claims/interfaces';
 export * from './domains/interfaces';
 export * from './emails/attachments/interfaces';
 export * from './emails/interfaces';


### PR DESCRIPTION
Adds Node SDK support for the Domain Claim API as a nested namespace under `domains`, mirroring the existing `contacts.segments` / `contacts.topics` sub-resource pattern.

| Method | Endpoint |
|---|---|
| `resend.domains.claims.create(payload)` | `POST /domains/claim` |
| `resend.domains.claims.get(domainId)` | `GET /domains/:domain_id/claim` |
| `resend.domains.claims.verify(domainId)` | `POST /domains/:domain_id/claim/verify` |

`create` accepts `name`, `region`, `customReturnPath`, `openTracking`, `clickTracking`, `trackingSubdomain` (camelCase), mapped to a snake_case body inline like `Domains.update`. All three return the `domain_claim` object (`object: 'domain_claim'`, `status`, `domain_id`, `record`, `blocked_reason`, etc.).

- New types under `src/domains/claims/interfaces/`, exported via `src/index.ts`.
- Tests in `src/domains/claims/domain-claims.spec.ts` (create body mapping + get/verify URL/method). Full suite: 360 passed; `build` + `lint` clean.

Wraps the Domain Claim API (public-api endpoints + docs). The cURL-only docs pages can now be backfilled with Node samples.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Domain Claim API support to the Node SDK under `resend.domains.claims`, so you can create, fetch, and verify domain claims in code. Matches the existing `domains` sub-resource pattern.

- **New Features**
  - Methods:
    - `resend.domains.claims.create(payload)` → `POST /domains/claim`
    - `resend.domains.claims.get(domainId)` → `GET /domains/:domain_id/claim`
    - `resend.domains.claims.verify(domainId)` → `POST /domains/:domain_id/claim/verify`
  - `create` maps camelCase options to snake_case body (`customReturnPath` → `custom_return_path`, etc.).
  - All methods return the `domain_claim` object.
  - New types exported via `src/index.ts`; tests cover body mapping and method URLs.

<sup>Written for commit 6d343ad292a891acd8acb66b08f0f2be301f6b74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/985?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

