### PR TITLE
feat: release `6.14.0-canary.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.13.0",
+  "version": "6.14.0-canary.0",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
Canary pre-release bumping the package version `6.13.0` → `6.14.0-canary.0`.

Minor bump for the new **Domain Claim API** methods (`resend.domains.claims.create/get/verify`, #985), which merged into `canary` after the `6.13.0` release.

After merge (manual, per the release runbook): `git checkout canary && git pull` then `npm publish --tag canary`. Production promotion (`6.14.0`) is a follow-up PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish canary pre-release of `resend` v6.14.0-canary.0 to ship the new Domain Claim API (`resend.domains.claims.create/get/verify`) for testing ahead of 6.14.0. Version bump from 6.13.0; no other changes.

<sup>Written for commit 5998458c2ac069a349a0479db6516327effddc77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/986?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

