### PR TITLE
feat: release `6.14.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.14.0-canary.0",
+  "version": "6.14.0",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
Production release bumping the package version `6.14.0-canary.0` → `6.14.0`.

Promotes the canary (#986) to GA. Ships the **Domain Claim API** methods — `resend.domains.claims.create/get/verify` (#985).

After merge (manual, per the release runbook):
1. `git checkout canary && git pull`
2. Rebase `main` onto `canary`: `git checkout main && git pull && git rebase canary && git push`
3. `npm publish`
4. `git tag -a v6.14.0 && git push origin --tags`
5. Create the GitHub release for `v6.14.0` with the auto-generated changelog.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes `resend` from `6.14.0-canary.0` to `6.14.0`. Makes the Domain Claim API generally available for production.

- **New Features**
  - Domain Claim API (GA): `resend.domains.claims.create`, `resend.domains.claims.get`, `resend.domains.claims.verify` to start, check, and verify domain ownership.

<sup>Written for commit ac84709a41aaee1b7ff23a8c853fbb735b05b1c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

