### PR TITLE
feat: expose message_id on get and list responses

### DIFF
--- a/src/emails/emails.spec.ts
+++ b/src/emails/emails.spec.ts
@@ -672,6 +672,7 @@ describe('Emails', () => {
         const response: GetEmailResponseSuccess = {
           object: 'email',
           id: '67d9bcdb-5a02-42d7-8da9-0d6feea18cff',
+          message_id: '<lc2vu8.gpa9o4@email.example.com>',
           to: ['zeno@resend.com'],
           from: 'bu@resend.com',
           created_at: '2023-04-07T23:13:52.669661+00:00',
@@ -704,6 +705,7 @@ describe('Emails', () => {
               "html": "<p>hello hello</p>",
               "id": "67d9bcdb-5a02-42d7-8da9-0d6feea18cff",
               "last_event": "delivered",
+              "message_id": "<lc2vu8.gpa9o4@email.example.com>",
               "object": "email",
               "reply_to": null,
               "scheduled_at": null,
@@ -725,6 +727,7 @@ describe('Emails', () => {
         const response: GetEmailResponseSuccess = {
           object: 'email',
           id: '67d9bcdb-5a02-42d7-8da9-0d6feea18cff',
+          message_id: '<lc2vu8.gpa9o4@email.example.com>',
           to: ['zeno@resend.com'],
           from: 'bu@resend.com',
           created_at: '2023-04-07T23:13:52.669661+00:00',
@@ -760,6 +763,7 @@ describe('Emails', () => {
               "html": "<p>hello hello</p>",
               "id": "67d9bcdb-5a02-42d7-8da9-0d6feea18cff",
               "last_event": "delivered",
+              "message_id": "<lc2vu8.gpa9o4@email.example.com>",
               "object": "email",
               "reply_to": null,
               "scheduled_at": null,
@@ -786,6 +790,7 @@ describe('Emails', () => {
       data: [
         {
           id: '67d9bcdb-5a02-42d7-8da9-0d6feea18cff',
+          message_id: '<lc2vu8.gpa9o4@email.example.com>',
           to: ['zeno@resend.com'],
           from: 'bu@resend.com',
           created_at: '2023-04-07T23:13:52.669661+00:00',

--- a/src/emails/interfaces/get-email-options.interface.ts
+++ b/src/emails/interfaces/get-email-options.interface.ts
@@ -7,6 +7,7 @@ export interface GetEmailResponseSuccess {
   from: string;
   html: string | null;
   id: string;
+  message_id: string;
   last_event:
     | 'bounced'
     | 'canceled'


### PR DESCRIPTION
## Summary
- The `GET /emails` and `GET /emails/:id` endpoints now return an extra `message_id: string` key from the API.
- Add `message_id` to `GetEmailResponseSuccess` so it surfaces on email objects returned by `emails.get()`; `ListEmail` inherits it for `emails.list()`.
- Update the emails spec mocks/snapshots to include `message_id`.

This follows the SDK's existing snake_case passthrough convention (responses mirror the raw API shape, e.g. `created_at`, `reply_to`, `last_event`).

## Test plan
- [x] `vitest run src/emails/emails.spec.ts` (24/24 passing)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose `message_id` on the GET /emails and GET /emails/:id responses to surface it in the SDK. `emails.get()` and `emails.list()` now include `message_id`; types, mocks, and tests updated.

<sup>Written for commit c040e540392029c2d363e6323cfecb6e1c8b16bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/988?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

