### PR TITLE
feat: release new canary with `message_id`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.14.0",
+  "version": "6.15.0-canary.0",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Publish a canary build of `resend` (v6.15.0-canary.0) to enable early testing of the new `message_id` field.

<sup>Written for commit f74a42007f05ea2c13931a04f17b80d77a0466fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

