### PR TITLE
feat: add received_for to inbound email and received webhook types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.14.0",
+  "version": "6.15.0-canary.0",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/src/emails/emails.spec.ts
+++ b/src/emails/emails.spec.ts
@@ -672,6 +672,7 @@ describe('Emails', () => {
         const response: GetEmailResponseSuccess = {
           object: 'email',
           id: '67d9bcdb-5a02-42d7-8da9-0d6feea18cff',
+          message_id: '<lc2vu8.gpa9o4@email.example.com>',
           to: ['zeno@resend.com'],
           from: 'bu@resend.com',
           created_at: '2023-04-07T23:13:52.669661+00:00',
@@ -704,6 +705,7 @@ describe('Emails', () => {
               "html": "<p>hello hello</p>",
               "id": "67d9bcdb-5a02-42d7-8da9-0d6feea18cff",
               "last_event": "delivered",
+              "message_id": "<lc2vu8.gpa9o4@email.example.com>",
               "object": "email",
               "reply_to": null,
               "scheduled_at": null,
@@ -725,6 +727,7 @@ describe('Emails', () => {
         const response: GetEmailResponseSuccess = {
           object: 'email',
           id: '67d9bcdb-5a02-42d7-8da9-0d6feea18cff',
+          message_id: '<lc2vu8.gpa9o4@email.example.com>',
           to: ['zeno@resend.com'],
           from: 'bu@resend.com',
           created_at: '2023-04-07T23:13:52.669661+00:00',
@@ -760,6 +763,7 @@ describe('Emails', () => {
               "html": "<p>hello hello</p>",
               "id": "67d9bcdb-5a02-42d7-8da9-0d6feea18cff",
               "last_event": "delivered",
+              "message_id": "<lc2vu8.gpa9o4@email.example.com>",
               "object": "email",
               "reply_to": null,
               "scheduled_at": null,
@@ -786,6 +790,7 @@ describe('Emails', () => {
       data: [
         {
           id: '67d9bcdb-5a02-42d7-8da9-0d6feea18cff',
+          message_id: '<lc2vu8.gpa9o4@email.example.com>',
           to: ['zeno@resend.com'],
           from: 'bu@resend.com',
           created_at: '2023-04-07T23:13:52.669661+00:00',

--- a/src/emails/interfaces/get-email-options.interface.ts
+++ b/src/emails/interfaces/get-email-options.interface.ts
@@ -7,6 +7,7 @@ export interface GetEmailResponseSuccess {
   from: string;
   html: string | null;
   id: string;
+  message_id: string;
   last_event:
     | 'bounced'
     | 'canceled'

--- a/src/emails/receiving/interfaces/get-receiving-email.interface.ts
+++ b/src/emails/receiving/interfaces/get-receiving-email.interface.ts
@@ -27,6 +27,7 @@ export interface GetReceivingEmailResponseSuccess {
   bcc: string[] | null;
   cc: string[] | null;
   reply_to: string[] | null;
+  received_for: string[];
   html: string | null;
   text: string | null;
   headers: Record<string, string> | null;

--- a/src/emails/receiving/receiving.spec.ts
+++ b/src/emails/receiving/receiving.spec.ts
@@ -65,6 +65,7 @@ describe('Receiving', () => {
           bcc: null,
           cc: ['cc@example.com'],
           reply_to: ['reply@example.com'],
+          received_for: [],
           headers: {
             example: 'value',
           },
@@ -127,6 +128,7 @@ describe('Receiving', () => {
                 "download_url": "https://example.com/emails/raw/abc123?signature=xyz789",
                 "expires_at": "2023-04-08T00:13:52.669661+00:00",
               },
+              "received_for": [],
               "reply_to": [
                 "reply@example.com",
               ],
@@ -157,6 +159,7 @@ describe('Receiving', () => {
           bcc: null,
           cc: null,
           reply_to: null,
+          received_for: [],
           headers: {},
           raw: null,
           attachments: [],
@@ -188,6 +191,7 @@ describe('Receiving', () => {
               "message_id": "msg_456",
               "object": "email",
               "raw": null,
+              "received_for": [],
               "reply_to": null,
               "subject": "Test inbound email",
               "text": "hello world",
@@ -218,6 +222,7 @@ describe('Receiving', () => {
           bcc: null,
           cc: null,
           reply_to: null,
+          received_for: [],
           headers: {},
           raw: null,
           attachments: [],
@@ -254,6 +259,7 @@ describe('Receiving', () => {
           bcc: null,
           cc: null,
           reply_to: null,
+          received_for: [],
           headers: {},
           raw: null,
           attachments: [],
@@ -549,6 +555,7 @@ describe('Receiving', () => {
           bcc: null,
           cc: null,
           reply_to: null,
+          received_for: [],
           headers: {},
           raw: null,
           attachments: [],
@@ -587,6 +594,7 @@ describe('Receiving', () => {
           bcc: null,
           cc: null,
           reply_to: null,
+          received_for: [],
           headers: {},
           raw: {
             download_url: 'https://example.com/raw-email-download',
@@ -635,6 +643,7 @@ describe('Receiving', () => {
           bcc: null,
           cc: null,
           reply_to: null,
+          received_for: [],
           headers: {},
           raw: {
             download_url: 'https://example.com/raw-email-download',
@@ -723,6 +732,7 @@ Content-Type: text/html; charset="UTF-8"
           bcc: null,
           cc: null,
           reply_to: null,
+          received_for: [],
           headers: {},
           raw: {
             download_url: 'https://example.com/raw-email-download',
@@ -816,6 +826,7 @@ ${attachmentContent}
           bcc: null,
           cc: null,
           reply_to: null,
+          received_for: [],
           headers: {},
           raw: {
             download_url: 'https://example.com/raw-email-download',
@@ -903,6 +914,7 @@ ${imageContent}
           bcc: null,
           cc: null,
           reply_to: null,
+          received_for: [],
           headers: {},
           raw: {
             download_url: 'https://example.com/raw-email-download',
@@ -964,6 +976,7 @@ hello world`;
           bcc: null,
           cc: null,
           reply_to: null,
+          received_for: [],
           headers: {},
           raw: {
             download_url: 'https://example.com/raw-email-download',
@@ -1048,6 +1061,7 @@ hello world`;
           bcc: null,
           cc: null,
           reply_to: null,
+          received_for: [],
           headers: {},
           raw: {
             download_url: 'https://example.com/raw-email-download',

--- a/src/webhooks/interfaces/webhook-event.interface.ts
+++ b/src/webhooks/interfaces/webhook-event.interface.ts
@@ -65,6 +65,7 @@ interface ReceivedEmailEventData {
   to: string[];
   bcc: string[];
   cc: string[];
+  received_for: string[];
   message_id: string;
   subject: string;
   attachments: ReceivedEmailAttachment[];


### PR DESCRIPTION
## Context

[Slack thread](https://resend.slack.com/archives/C0AJSRCBLT1/p1782424744720579)

**Opened on behalf of:** @lucasfcosta

## What

Adds the new `received_for` field (merged in resend-monorepo #4637) to the SDK types.

- `GetReceivingEmailResponseSuccess` (`src/emails/receiving/interfaces/get-receiving-email.interface.ts`) — the `emails.receiving.get` response now includes `received_for: string[]`.
- `ReceivedEmailEventData` (`src/webhooks/interfaces/webhook-event.interface.ts`) — the `email.received` webhook payload now includes `received_for: string[]`.

## Why

The field is already returned by the GET `/emails/receiving/:id` route and the `email.received` webhook; the SDK types were missing it.

## How

Typed fixtures in `receiving.spec.ts` updated to include the now-required field; inline snapshots regenerated. `pnpm typecheck` and `pnpm lint` clean (pre-existing `tsconfig` `moduleResolution=node10` deprecation is unrelated).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add received_for to inbound email responses and email.received webhooks so the SDK matches the API. Also expose message_id on get/list email responses.

- **New Features**
  - `GetReceivingEmailResponseSuccess`: adds `received_for: string[]`.
  - `ReceivedEmailEventData` (email.received webhook): adds `received_for: string[]`.
  - `GetEmailResponseSuccess`: adds `message_id`.
  - Updated tests and snapshots to include the new fields.

<sup>Written for commit da86148ff95ab00195343ec63745776f1a7622e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

