### PR TITLE
feat: release v6.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.15.0-canary.0",
+  "version": "6.15.0",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Promotes `resend` v6.15.0 from canary to stable for general availability.
Bumps `package.json` version from 6.15.0-canary.0 to 6.15.0 for publishing.

<sup>Written for commit 2e277eff928e71baaf8b8bc23b6a03bbffb936f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

