### PR TITLE
chore: release 6.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.15.0",
+  "version": "6.16.0",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
Minor bump to release a new field support on inbound.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release `resend` 6.16.0 to ship support for the new inbound field. This PR only bumps the package version to publish the change.

<sup>Written for commit d4b448dbc0fa8e5c8b9d8f05fcac20cc751a0eb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

