### PR TITLE
feat: add base methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.16.0",
+  "version": "6.17.0-suppression-list.0",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export type { ErrorResponse, Response } from './interfaces';
 export * from './logs/interfaces';
 export { Resend, type ResendOptions } from './resend';
 export * from './segments/interfaces';
+export * from './suppressions/interfaces';
 export * from './templates/interfaces';
 export * from './topics/interfaces';
 export * from './webhooks/interfaces';

--- a/src/resend.ts
+++ b/src/resend.ts
@@ -19,6 +19,7 @@ import { Events } from './events/events';
 import type { ErrorResponse, Response } from './interfaces';
 import { Logs } from './logs/logs';
 import { Segments } from './segments/segments';
+import { Suppressions } from './suppressions/suppressions';
 import { Templates } from './templates/templates';
 import { Topics } from './topics/topics';
 import { Webhooks } from './webhooks/webhooks';
@@ -63,6 +64,7 @@ export class Resend {
   readonly emails = new Emails(this);
   readonly events = new Events(this);
   readonly logs = new Logs(this);
+  readonly suppressions = new Suppressions(this);
   readonly templates = new Templates(this);
   readonly topics = new Topics(this);
   readonly webhooks = new Webhooks(this);

--- a/src/suppressions/interfaces/add-suppression.interface.ts
+++ b/src/suppressions/interfaces/add-suppression.interface.ts
@@ -1,0 +1,12 @@
+import type { Response } from '../../interfaces';
+
+export interface AddSuppressionOptions {
+  email: string;
+}
+
+export interface AddSuppressionResponseSuccess {
+  object: 'suppression';
+  id: string;
+}
+
+export type AddSuppressionResponse = Response<AddSuppressionResponseSuccess>;

--- a/src/suppressions/interfaces/get-suppression.interface.ts
+++ b/src/suppressions/interfaces/get-suppression.interface.ts
@@ -1,0 +1,6 @@
+import type { Response } from '../../interfaces';
+import type { SuppressionListEntry } from './suppression-list-entry';
+
+export type GetSuppressionResponseSuccess = SuppressionListEntry;
+
+export type GetSuppressionResponse = Response<GetSuppressionResponseSuccess>;

--- a/src/suppressions/interfaces/index.ts
+++ b/src/suppressions/interfaces/index.ts
@@ -1,0 +1,5 @@
+export * from './add-suppression.interface';
+export * from './get-suppression.interface';
+export * from './list-suppressions.interface';
+export * from './remove-suppression.interface';
+export * from './suppression-list-entry';

--- a/src/suppressions/interfaces/list-suppressions.interface.ts
+++ b/src/suppressions/interfaces/list-suppressions.interface.ts
@@ -1,0 +1,20 @@
+import type {
+  PaginatedData,
+  PaginationOptions,
+} from '../../common/interfaces/pagination-options.interface';
+import type { Response } from '../../interfaces';
+import type {
+  SuppressionListEntry,
+  SuppressionReason,
+} from './suppression-list-entry';
+
+export type ListSuppressionsOptions = PaginationOptions & {
+  reason?: SuppressionReason;
+};
+
+export type ListSuppressionsResponseSuccess = PaginatedData<
+  SuppressionListEntry[]
+>;
+
+export type ListSuppressionsResponse =
+  Response<ListSuppressionsResponseSuccess>;

--- a/src/suppressions/interfaces/remove-suppression.interface.ts
+++ b/src/suppressions/interfaces/remove-suppression.interface.ts
@@ -1,0 +1,10 @@
+import type { Response } from '../../interfaces';
+
+export interface RemoveSuppressionResponseSuccess {
+  object: 'suppression';
+  id: string;
+  deleted: true;
+}
+
+export type RemoveSuppressionResponse =
+  Response<RemoveSuppressionResponseSuccess>;

--- a/src/suppressions/interfaces/remove-suppression.interface.ts
+++ b/src/suppressions/interfaces/remove-suppression.interface.ts
@@ -3,7 +3,7 @@ import type { Response } from '../../interfaces';
 export interface RemoveSuppressionResponseSuccess {
   object: 'suppression';
   id: string;
-  deleted: true;
+  deleted: boolean;
 }
 
 export type RemoveSuppressionResponse =

--- a/src/suppressions/interfaces/suppression-list-entry.ts
+++ b/src/suppressions/interfaces/suppression-list-entry.ts
@@ -1,0 +1,11 @@
+export type SuppressionReason = 'bounce' | 'complaint' | 'manual';
+
+export interface SuppressionListEntry {
+  object: 'suppression';
+  id: string;
+  email: string;
+  reason: SuppressionReason;
+  source_id: string | null;
+  created_at: string;
+  expires_at: string | null;
+}

--- a/src/suppressions/suppressions.spec.ts
+++ b/src/suppressions/suppressions.spec.ts
@@ -1,0 +1,195 @@
+import createFetchMock from 'vitest-fetch-mock';
+import { Resend } from '../resend';
+import {
+  mockSuccessResponse,
+  mockSuccessWithStatusCode,
+} from '../test-utils/mock-fetch';
+import type { AddSuppressionResponseSuccess } from './interfaces/add-suppression.interface';
+import type { GetSuppressionResponseSuccess } from './interfaces/get-suppression.interface';
+import type { ListSuppressionsResponseSuccess } from './interfaces/list-suppressions.interface';
+import type { RemoveSuppressionResponseSuccess } from './interfaces/remove-suppression.interface';
+
+const fetchMocker = createFetchMock(vi);
+fetchMocker.enableMocks();
+
+const API_KEY = 're_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop';
+
+describe('Suppressions', () => {
+  afterEach(() => fetchMock.resetMocks());
+  afterAll(() => fetchMocker.disableMocks());
+
+  describe('add', () => {
+    it('adds a suppression', async () => {
+      const response: AddSuppressionResponseSuccess = {
+        object: 'suppression',
+        id: '3deaccfb-f47f-440a-8875-ea14b1716b43',
+      };
+      mockSuccessWithStatusCode(response, 201, {});
+
+      const resend = new Resend(API_KEY);
+      await expect(
+        resend.suppressions.add({ email: 'blocked@example.com' }),
+      ).resolves.toMatchInlineSnapshot(`
+        {
+          "data": {
+            "id": "3deaccfb-f47f-440a-8875-ea14b1716b43",
+            "object": "suppression",
+          },
+          "error": null,
+          "headers": {
+            "content-type": "application/json",
+          },
+        }
+      `);
+
+      const [url, options] = fetchMock.mock.calls[0];
+      expect(url).toContain('/suppressions');
+      expect(options?.method).toBe('POST');
+      expect(JSON.parse(options?.body as string)).toEqual({
+        email: 'blocked@example.com',
+      });
+    });
+  });
+
+  describe('get', () => {
+    it('gets a suppression by id or email', async () => {
+      const response: GetSuppressionResponseSuccess = {
+        object: 'suppression',
+        id: 'fd61172c-cafc-40f5-b049-b45947779a29',
+        email: 'blocked@example.com',
+        reason: 'bounce',
+        source_id: null,
+        created_at: '2024-01-16T18:12:26.514Z',
+        expires_at: null,
+      };
+      mockSuccessResponse(response, {});
+
+      const resend = new Resend(API_KEY);
+      await expect(
+        resend.suppressions.get('blocked@example.com'),
+      ).resolves.toMatchInlineSnapshot(`
+        {
+          "data": {
+            "created_at": "2024-01-16T18:12:26.514Z",
+            "email": "blocked@example.com",
+            "expires_at": null,
+            "id": "fd61172c-cafc-40f5-b049-b45947779a29",
+            "object": "suppression",
+            "reason": "bounce",
+            "source_id": null,
+          },
+          "error": null,
+          "headers": {
+            "content-type": "application/json",
+          },
+        }
+      `);
+    });
+
+    it('returns error when missing identifier', async () => {
+      const resend = new Resend(API_KEY);
+      await expect(resend.suppressions.get('')).resolves.toMatchInlineSnapshot(`
+        {
+          "data": null,
+          "error": {
+            "message": "Missing \`id\` field.",
+            "name": "missing_required_field",
+            "statusCode": null,
+          },
+          "headers": null,
+        }
+      `);
+      expect(fetchMock.mock.calls.length).toBe(0);
+    });
+  });
+
+  describe('remove', () => {
+    it('removes a suppression', async () => {
+      const response: RemoveSuppressionResponseSuccess = {
+        object: 'suppression',
+        id: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223',
+        deleted: true,
+      };
+      mockSuccessResponse(response, {});
+
+      const resend = new Resend(API_KEY);
+      await expect(
+        resend.suppressions.remove('blocked@example.com'),
+      ).resolves.toMatchInlineSnapshot(`
+        {
+          "data": {
+            "deleted": true,
+            "id": "3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223",
+            "object": "suppression",
+          },
+          "error": null,
+          "headers": {
+            "content-type": "application/json",
+          },
+        }
+      `);
+
+      const [, options] = fetchMock.mock.calls[0];
+      expect(options?.method).toBe('DELETE');
+    });
+
+    it('returns error when missing identifier', async () => {
+      const resend = new Resend(API_KEY);
+      await expect(
+        resend.suppressions.remove(''),
+      ).resolves.toMatchInlineSnapshot(`
+        {
+          "data": null,
+          "error": {
+            "message": "Missing \`id\` field.",
+            "name": "missing_required_field",
+            "statusCode": null,
+          },
+          "headers": null,
+        }
+      `);
+      expect(fetchMock.mock.calls.length).toBe(0);
+    });
+  });
+
+  describe('list', () => {
+    const listResponse: ListSuppressionsResponseSuccess = {
+      object: 'list',
+      has_more: false,
+      data: [
+        {
+          object: 'suppression',
+          id: 'b6d24b8e-af0b-4c3c-be0c-359bbd97381e',
+          email: 'blocked@example.com',
+          reason: 'complaint',
+          source_id: null,
+          created_at: '2023-04-07T23:13:52.669661+00:00',
+          expires_at: null,
+        },
+      ],
+    };
+
+    it('lists suppressions without options', async () => {
+      mockSuccessResponse(listResponse, {});
+
+      const resend = new Resend(API_KEY);
+      const result = await resend.suppressions.list();
+      expect(result.data).toEqual(listResponse);
+
+      const [url] = fetchMock.mock.calls[0];
+      expect(url).toContain('/suppressions');
+      expect(url).not.toContain('?');
+    });
+
+    it('appends reason and pagination to the query', async () => {
+      mockSuccessResponse(listResponse, {});
+
+      const resend = new Resend(API_KEY);
+      await resend.suppressions.list({ reason: 'bounce', limit: 50 });
+
+      const [url] = fetchMock.mock.calls[0];
+      expect(url).toContain('reason=bounce');
+      expect(url).toContain('limit=50');
+    });
+  });
+});

--- a/src/suppressions/suppressions.spec.ts
+++ b/src/suppressions/suppressions.spec.ts
@@ -86,6 +86,16 @@ describe('Suppressions', () => {
       `);
     });
 
+    it('encodes the identifier in the path', async () => {
+      mockSuccessResponse({}, {});
+
+      const resend = new Resend(API_KEY);
+      await resend.suppressions.get('user+tag@example.com');
+
+      const [url] = fetchMock.mock.calls[0];
+      expect(url).toContain('/suppressions/user%2Btag%40example.com');
+    });
+
     it('returns error when missing identifier', async () => {
       const resend = new Resend(API_KEY);
       await expect(resend.suppressions.get('')).resolves.toMatchInlineSnapshot(`
@@ -129,7 +139,8 @@ describe('Suppressions', () => {
         }
       `);
 
-      const [, options] = fetchMock.mock.calls[0];
+      const [url, options] = fetchMock.mock.calls[0];
+      expect(url).toContain('/suppressions/blocked%40example.com');
       expect(options?.method).toBe('DELETE');
     });
 

--- a/src/suppressions/suppressions.ts
+++ b/src/suppressions/suppressions.ts
@@ -54,7 +54,7 @@ export class Suppressions {
     }
 
     return this.resend.get<GetSuppressionResponseSuccess>(
-      `/suppressions/${idOrEmail}`,
+      `/suppressions/${encodeURIComponent(idOrEmail)}`,
     );
   }
 
@@ -64,7 +64,7 @@ export class Suppressions {
     }
 
     return this.resend.delete<RemoveSuppressionResponseSuccess>(
-      `/suppressions/${idOrEmail}`,
+      `/suppressions/${encodeURIComponent(idOrEmail)}`,
     );
   }
 }

--- a/src/suppressions/suppressions.ts
+++ b/src/suppressions/suppressions.ts
@@ -1,0 +1,81 @@
+import { buildPaginationQuery } from '../common/utils/build-pagination-query';
+import type { Resend } from '../resend';
+import type {
+  AddSuppressionOptions,
+  AddSuppressionResponse,
+  AddSuppressionResponseSuccess,
+} from './interfaces/add-suppression.interface';
+import type {
+  GetSuppressionResponse,
+  GetSuppressionResponseSuccess,
+} from './interfaces/get-suppression.interface';
+import type {
+  ListSuppressionsOptions,
+  ListSuppressionsResponse,
+  ListSuppressionsResponseSuccess,
+} from './interfaces/list-suppressions.interface';
+import type {
+  RemoveSuppressionResponse,
+  RemoveSuppressionResponseSuccess,
+} from './interfaces/remove-suppression.interface';
+
+const missingIdentifierError = {
+  data: null,
+  headers: null,
+  error: {
+    message: 'Missing `id` field.',
+    statusCode: null,
+    name: 'missing_required_field' as const,
+  },
+};
+
+export class Suppressions {
+  constructor(private readonly resend: Resend) {}
+
+  async add(options: AddSuppressionOptions): Promise<AddSuppressionResponse> {
+    return this.resend.post<AddSuppressionResponseSuccess>(
+      '/suppressions',
+      options,
+    );
+  }
+
+  async list(
+    options: ListSuppressionsOptions = {},
+  ): Promise<ListSuppressionsResponse> {
+    const queryString = buildSuppressionsQuery(options);
+    const url = queryString ? `/suppressions?${queryString}` : '/suppressions';
+
+    return this.resend.get<ListSuppressionsResponseSuccess>(url);
+  }
+
+  async get(idOrEmail: string): Promise<GetSuppressionResponse> {
+    if (!idOrEmail) {
+      return missingIdentifierError;
+    }
+
+    return this.resend.get<GetSuppressionResponseSuccess>(
+      `/suppressions/${idOrEmail}`,
+    );
+  }
+
+  async remove(idOrEmail: string): Promise<RemoveSuppressionResponse> {
+    if (!idOrEmail) {
+      return missingIdentifierError;
+    }
+
+    return this.resend.delete<RemoveSuppressionResponseSuccess>(
+      `/suppressions/${idOrEmail}`,
+    );
+  }
+}
+
+function buildSuppressionsQuery(options: ListSuppressionsOptions): string {
+  const { reason, ...pagination } = options;
+  const searchParams = new URLSearchParams(buildPaginationQuery(pagination));
+
+  if (reason) {
+    searchParams.set('reason', reason);
+  }
+
+  return searchParams.toString();
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds suppression list support to the Node SDK so you can add, get, list, and remove suppressions via `resend.suppressions`. Completes WORKSPA-2479.

- **New Features**
  - `resend.suppressions.{add,get,list,remove}`.
  - `list` supports pagination and optional `reason` filter.
  - `get` and `remove` accept a suppression `id` or `email` and validate missing identifiers.

- **Bug Fixes**
  - URL-encode the suppression identifier in `get` and `remove` paths.

<sup>Written for commit e7e2c23fe1a25ffd24e62adb5b4847b4def5f6e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

