### PR TITLE
feat: add idempotencyKey support to emails.receiving.forward()

### DIFF
--- a/src/emails/receiving/interfaces/forward-receiving-email.interface.ts
+++ b/src/emails/receiving/interfaces/forward-receiving-email.interface.ts
@@ -1,3 +1,5 @@
+import type { PostOptions } from '../../../common/interfaces';
+import type { IdempotentRequest } from '../../../common/interfaces/idempotent-request.interface';
 import type { RequireAtLeastOne } from '../../../common/interfaces/require-at-least-one';
 import type { Response } from '../../../interfaces';
 
@@ -17,6 +19,10 @@ export type ForwardReceivingEmailOptions =
   | (ForwardReceivingEmailBaseOptions & {
       passthrough: false;
     } & RequireAtLeastOne<ForwardReceivingEmailBodyOptions>);
+
+export interface ForwardReceivingEmailRequestOptions
+  extends PostOptions,
+    IdempotentRequest {}
 
 export interface ForwardReceivingEmailResponseSuccess {
   id: string;

--- a/src/emails/receiving/receiving.spec.ts
+++ b/src/emails/receiving/receiving.spec.ts
@@ -1112,5 +1112,111 @@ hello world`;
         );
       });
     });
+
+    describe('request options', () => {
+      const getEmailResponse: GetReceivingEmailResponseSuccess = {
+        object: 'email' as const,
+        id: '67d9bcdb-5a02-42d7-8da9-0d6feea18cff',
+        to: ['received@example.com'],
+        from: 'original-sender@example.com',
+        created_at: '2023-04-07T23:13:52.669661+00:00',
+        subject: 'Original Subject',
+        html: '<p>hello world</p>',
+        text: 'hello world',
+        bcc: null,
+        cc: null,
+        reply_to: null,
+        received_for: [],
+        headers: {},
+        raw: {
+          download_url: 'https://example.com/raw-email-download',
+          expires_at: '2023-04-08T00:13:52.669661+00:00',
+        },
+        attachments: [],
+        message_id: 'msg_123',
+      };
+
+      const rawEmailContent =
+        'From: original-sender@example.com\r\nTo: received@example.com\r\nSubject: Original Subject\r\n\r\nhello world';
+
+      const forwardResponse: ForwardReceivingEmailResponseSuccess = {
+        id: 'new-email-id-123',
+      };
+
+      beforeEach(() => {
+        fetchMock.mockOnce(JSON.stringify(getEmailResponse), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+
+        fetchMock.mockOnce(rawEmailContent, {
+          status: 200,
+          headers: { 'content-type': 'message/rfc822' },
+        });
+
+        fetchMock.mockOnce(JSON.stringify(forwardResponse), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      });
+
+      it('sends the Idempotency-Key header when idempotencyKey is provided', async () => {
+        const idempotencyKey = 'forward:67d9bcdb-5a02-42d7-8da9-0d6feea18cff';
+
+        await resend.emails.receiving.forward(
+          {
+            emailId: '67d9bcdb-5a02-42d7-8da9-0d6feea18cff',
+            to: 'forward@example.com',
+            from: 'sender@verified-domain.com',
+          },
+          { idempotencyKey },
+        );
+
+        const sendEmailCall = fetchMock.mock.calls[2];
+        expect(sendEmailCall[0]).toBe('https://api.resend.com/emails');
+
+        const headers = new Headers(sendEmailCall[1]?.headers);
+        expect(headers.get('Idempotency-Key')).toBe(idempotencyKey);
+
+        const getEmailCall = fetchMock.mock.calls[0];
+        const getEmailHeaders = new Headers(getEmailCall[1]?.headers);
+        expect(getEmailHeaders.has('Idempotency-Key')).toBe(false);
+      });
+
+      it('sends the Idempotency-Key header in wrapped mode', async () => {
+        const idempotencyKey = 'forward:67d9bcdb-5a02-42d7-8da9-0d6feea18cff';
+
+        await resend.emails.receiving.forward(
+          {
+            emailId: '67d9bcdb-5a02-42d7-8da9-0d6feea18cff',
+            to: 'forward@example.com',
+            from: 'sender@verified-domain.com',
+            passthrough: false,
+            text: 'Forwarded email.',
+          },
+          { idempotencyKey },
+        );
+
+        const sendEmailCall = fetchMock.mock.calls[2];
+        expect(sendEmailCall[0]).toBe('https://api.resend.com/emails');
+
+        const headers = new Headers(sendEmailCall[1]?.headers);
+        expect(headers.get('Idempotency-Key')).toBe(idempotencyKey);
+      });
+
+      it('does not send the Idempotency-Key header when idempotencyKey is not provided', async () => {
+        await resend.emails.receiving.forward({
+          emailId: '67d9bcdb-5a02-42d7-8da9-0d6feea18cff',
+          to: 'forward@example.com',
+          from: 'sender@verified-domain.com',
+        });
+
+        const sendEmailCall = fetchMock.mock.calls[2];
+        expect(sendEmailCall[0]).toBe('https://api.resend.com/emails');
+
+        const headers = new Headers(sendEmailCall[1]?.headers);
+        expect(headers.has('Idempotency-Key')).toBe(false);
+      });
+    });
   });
 });

--- a/src/emails/receiving/receiving.ts
+++ b/src/emails/receiving/receiving.ts
@@ -4,6 +4,7 @@ import type { Resend } from '../../resend';
 import { Attachments } from './attachments/attachments';
 import type {
   ForwardReceivingEmailOptions,
+  ForwardReceivingEmailRequestOptions,
   ForwardReceivingEmailResponse,
   ForwardReceivingEmailResponseSuccess,
 } from './interfaces/forward-receiving-email.interface';
@@ -60,6 +61,7 @@ export class Receiving {
 
   async forward(
     options: ForwardReceivingEmailOptions,
+    requestOptions: ForwardReceivingEmailRequestOptions = {},
   ): Promise<ForwardReceivingEmailResponse> {
     const { emailId, to, from } = options;
     const passthrough = options.passthrough !== false;
@@ -79,29 +81,38 @@ export class Receiving {
     const originalSubject = email.subject || '(no subject)';
 
     if (passthrough) {
-      return this.forwardPassthrough(email, {
-        to,
-        from,
-        subject: originalSubject,
-      });
+      return this.forwardPassthrough(
+        email,
+        {
+          to,
+          from,
+          subject: originalSubject,
+        },
+        requestOptions,
+      );
     }
 
     const forwardSubject = originalSubject.startsWith('Fwd:')
       ? originalSubject
       : `Fwd: ${originalSubject}`;
 
-    return this.forwardWrapped(email, {
-      to,
-      from,
-      subject: forwardSubject,
-      text: 'text' in options ? options.text : undefined,
-      html: 'html' in options ? options.html : undefined,
-    });
+    return this.forwardWrapped(
+      email,
+      {
+        to,
+        from,
+        subject: forwardSubject,
+        text: 'text' in options ? options.text : undefined,
+        html: 'html' in options ? options.html : undefined,
+      },
+      requestOptions,
+    );
   }
 
   private async forwardPassthrough(
     email: GetReceivingEmailResponseSuccess,
     options: { to: string | string[]; from: string; subject: string },
+    requestOptions: ForwardReceivingEmailRequestOptions,
   ): Promise<ForwardReceivingEmailResponse> {
     const { to, from, subject } = options;
 
@@ -160,6 +171,7 @@ export class Receiving {
         html: parsed.html || undefined,
         attachments: attachments.length > 0 ? attachments : undefined,
       },
+      requestOptions,
     );
 
     return data;
@@ -174,6 +186,7 @@ export class Receiving {
       text?: string;
       html?: string;
     },
+    requestOptions: ForwardReceivingEmailRequestOptions,
   ): Promise<ForwardReceivingEmailResponse> {
     const { to, from, subject, text, html } = options;
 
@@ -221,6 +234,7 @@ export class Receiving {
           },
         ],
       },
+      requestOptions,
     );
 
     return data;


### PR DESCRIPTION
Accept a second request options argument, matching emails.send/create, and pass it to the internal POST /emails call so forwarded emails can be safely retried without duplicates.

Closes #967

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional request options to `emails.receiving.forward()` with `idempotencyKey` support, so forwards can be retried without duplicates. Aligns the method with `emails.send`/`emails.create` and closes #967.

- **New Features**
  - Adds a second argument `requestOptions` (`ForwardReceivingEmailRequestOptions`) with `idempotencyKey` and other `PostOptions`.
  - Applies options only to the internal `POST /emails` in both passthrough and wrapped modes; `Idempotency-Key` is not sent on the initial `GET`. Tests cover both cases.

<sup>Written for commit 93d1f8d59b63ca4f1f0fb4f20ba564daa46c2370. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/997?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

