### PR TITLE
feat: oauth grant management

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.16.0",
+  "version": "6.17.0",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export * from './emails/receiving/interfaces';
 export * from './events/interfaces';
 export type { ErrorResponse, Response } from './interfaces';
 export * from './logs/interfaces';
+export * from './oauth-grants/interfaces';
 export { Resend, type ResendOptions } from './resend';
 export * from './segments/interfaces';
 export * from './templates/interfaces';

--- a/src/oauth-grants/interfaces/index.ts
+++ b/src/oauth-grants/interfaces/index.ts
@@ -1,0 +1,10 @@
+export type {
+  ListOAuthGrantsOptions,
+  ListOAuthGrantsResponse,
+  ListOAuthGrantsResponseSuccess,
+} from './list-oauth-grants.interface';
+export type { OAuthGrant } from './oauth-grant';
+export type {
+  RevokeOAuthGrantResponse,
+  RevokeOAuthGrantResponseSuccess,
+} from './revoke-oauth-grant.interface';

--- a/src/oauth-grants/interfaces/list-oauth-grants.interface.ts
+++ b/src/oauth-grants/interfaces/list-oauth-grants.interface.ts
@@ -1,0 +1,13 @@
+import type { PaginationOptions } from '../../common/interfaces';
+import type { Response } from '../../interfaces';
+import type { OAuthGrant } from './oauth-grant';
+
+export type ListOAuthGrantsOptions = PaginationOptions;
+
+export type ListOAuthGrantsResponseSuccess = {
+  object: 'list';
+  has_more: boolean;
+  data: OAuthGrant[];
+};
+
+export type ListOAuthGrantsResponse = Response<ListOAuthGrantsResponseSuccess>;

--- a/src/oauth-grants/interfaces/oauth-grant.ts
+++ b/src/oauth-grants/interfaces/oauth-grant.ts
@@ -1,0 +1,13 @@
+export interface OAuthGrant {
+  id: string;
+  client_id: string;
+  scopes: string[];
+  resource: string | null;
+  created_at: string;
+  revoked_at: string | null;
+  revoked_reason: string | null;
+  client: {
+    name: string;
+    logo_uri: string | null;
+  };
+}

--- a/src/oauth-grants/interfaces/revoke-oauth-grant.interface.ts
+++ b/src/oauth-grants/interfaces/revoke-oauth-grant.interface.ts
@@ -1,0 +1,11 @@
+import type { Response } from '../../interfaces';
+
+export type RevokeOAuthGrantResponseSuccess = {
+  object: 'oauth_grant';
+  id: string;
+  revoked_at: string;
+  revoked_reason: string;
+};
+
+export type RevokeOAuthGrantResponse =
+  Response<RevokeOAuthGrantResponseSuccess>;

--- a/src/oauth-grants/oauth-grants.spec.ts
+++ b/src/oauth-grants/oauth-grants.spec.ts
@@ -1,0 +1,189 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import createFetchMock from 'vitest-fetch-mock';
+import type { ErrorResponse } from '../interfaces';
+import { Resend } from '../resend';
+import { mockSuccessResponse } from '../test-utils/mock-fetch';
+import type { ListOAuthGrantsResponseSuccess } from './interfaces/list-oauth-grants.interface';
+import type { RevokeOAuthGrantResponseSuccess } from './interfaces/revoke-oauth-grant.interface';
+
+const fetchMocker = createFetchMock(vi);
+fetchMocker.enableMocks();
+
+describe('OAuthGrants', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchMock.resetMocks();
+  });
+
+  afterAll(() => fetchMocker.disableMocks());
+
+  describe('list', () => {
+    const response: ListOAuthGrantsResponseSuccess = {
+      object: 'list',
+      has_more: false,
+      data: [
+        {
+          id: '650e8400-e29b-41d4-a716-446655440001',
+          client_id: '430eed87-632a-4ea6-90db-0aace67ec228',
+          scopes: ['emails:send'],
+          resource: null,
+          created_at: '2023-06-21T06:10:36.144Z',
+          revoked_at: null,
+          revoked_reason: null,
+          client: {
+            name: 'Resend CLI',
+            logo_uri: 'https://example.com/logo.png',
+          },
+        },
+        {
+          id: '650e8400-e29b-41d4-a716-446655440002',
+          client_id: '430eed87-632a-4ea6-90db-0aace67ec228',
+          scopes: ['emails:send', 'domains:read'],
+          resource: 'https://api.resend.com',
+          created_at: '2023-06-20T06:10:36.144Z',
+          revoked_at: '2023-06-22T06:10:36.144Z',
+          revoked_reason: 'revoked_from_api',
+          client: {
+            name: 'Resend CLI',
+            logo_uri: 'https://example.com/logo.png',
+          },
+        },
+      ],
+    };
+
+    describe('when no pagination options are provided', () => {
+      it('lists oauth grants', async () => {
+        mockSuccessResponse(response, {
+          headers: {},
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+        const result = await resend.oauthGrants.list();
+        expect(result).toEqual({
+          data: response,
+          error: null,
+          headers: {
+            'content-type': 'application/json',
+          },
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://api.resend.com/oauth/grants',
+          expect.objectContaining({
+            method: 'GET',
+            headers: expect.any(Headers),
+          }),
+        );
+      });
+    });
+
+    describe('when pagination options are provided', () => {
+      it('passes limit param and returns a response', async () => {
+        mockSuccessResponse(response, {
+          headers: {},
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+        const result = await resend.oauthGrants.list({ limit: 10 });
+        expect(result).toEqual({
+          data: response,
+          error: null,
+          headers: {
+            'content-type': 'application/json',
+          },
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://api.resend.com/oauth/grants?limit=10',
+          expect.objectContaining({
+            method: 'GET',
+            headers: expect.any(Headers),
+          }),
+        );
+      });
+    });
+  });
+
+  describe('revoke', () => {
+    it('revokes an oauth grant', async () => {
+      const id = '650e8400-e29b-41d4-a716-446655440001';
+      const response: RevokeOAuthGrantResponseSuccess = {
+        object: 'oauth_grant',
+        id,
+        revoked_at: '2023-06-22T06:10:36.144Z',
+        revoked_reason: 'revoked_from_api',
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      await expect(
+        resend.oauthGrants.revoke(id),
+      ).resolves.toMatchInlineSnapshot(`
+        {
+          "data": {
+            "id": "650e8400-e29b-41d4-a716-446655440001",
+            "object": "oauth_grant",
+            "revoked_at": "2023-06-22T06:10:36.144Z",
+            "revoked_reason": "revoked_from_api",
+          },
+          "error": null,
+          "headers": {
+            "content-type": "application/json",
+          },
+        }
+      `);
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        `https://api.resend.com/oauth/grants/${id}`,
+        expect.objectContaining({
+          method: 'DELETE',
+          headers: expect.any(Headers),
+        }),
+      );
+    });
+
+    describe('when oauth grant not found', () => {
+      it('returns error', async () => {
+        const response: ErrorResponse = {
+          name: 'not_found',
+          message: 'OAuth grant not found. Perhaps it was already revoked?',
+          statusCode: 404,
+        };
+
+        fetchMock.mockOnce(JSON.stringify(response), {
+          status: 404,
+          headers: {
+            'content-type': 'application/json',
+          },
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+        const result = resend.oauthGrants.revoke('1234');
+
+        await expect(result).resolves.toMatchInlineSnapshot(`
+          {
+            "data": null,
+            "error": {
+              "message": "OAuth grant not found. Perhaps it was already revoked?",
+              "name": "not_found",
+              "statusCode": 404,
+            },
+            "headers": {
+              "content-type": "application/json",
+            },
+          }
+        `);
+      });
+    });
+  });
+});

--- a/src/oauth-grants/oauth-grants.ts
+++ b/src/oauth-grants/oauth-grants.ts
@@ -1,0 +1,32 @@
+import { buildPaginationQuery } from '../common/utils/build-pagination-query';
+import type { Resend } from '../resend';
+import type {
+  ListOAuthGrantsOptions,
+  ListOAuthGrantsResponse,
+  ListOAuthGrantsResponseSuccess,
+} from './interfaces/list-oauth-grants.interface';
+import type {
+  RevokeOAuthGrantResponse,
+  RevokeOAuthGrantResponseSuccess,
+} from './interfaces/revoke-oauth-grant.interface';
+
+export class OAuthGrants {
+  constructor(private readonly resend: Resend) {}
+
+  async list(
+    options: ListOAuthGrantsOptions = {},
+  ): Promise<ListOAuthGrantsResponse> {
+    const queryString = buildPaginationQuery(options);
+    const url = queryString ? `/oauth/grants?${queryString}` : '/oauth/grants';
+
+    const data = await this.resend.get<ListOAuthGrantsResponseSuccess>(url);
+    return data;
+  }
+
+  async revoke(id: string): Promise<RevokeOAuthGrantResponse> {
+    const data = await this.resend.delete<RevokeOAuthGrantResponseSuccess>(
+      `/oauth/grants/${id}`,
+    );
+    return data;
+  }
+}

--- a/src/resend.ts
+++ b/src/resend.ts
@@ -18,6 +18,7 @@ import { Emails } from './emails/emails';
 import { Events } from './events/events';
 import type { ErrorResponse, Response } from './interfaces';
 import { Logs } from './logs/logs';
+import { OAuthGrants } from './oauth-grants/oauth-grants';
 import { Segments } from './segments/segments';
 import { Templates } from './templates/templates';
 import { Topics } from './topics/topics';
@@ -63,6 +64,7 @@ export class Resend {
   readonly emails = new Emails(this);
   readonly events = new Events(this);
   readonly logs = new Logs(this);
+  readonly oauthGrants = new OAuthGrants(this);
   readonly templates = new Templates(this);
   readonly topics = new Topics(this);
   readonly webhooks = new Webhooks(this);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds OAuth grant management to the SDK. You can now list existing grants with pagination and revoke a grant via `resend.oauthGrants`.

- **New Features**
  - `resend.oauthGrants.list(options?: { limit, before, after })` → GET `/oauth/grants`.
  - `resend.oauthGrants.revoke(id)` → DELETE `/oauth/grants/{id}`.
  - Exported types: `OAuthGrant`, `ListOAuthGrantsResponse`, `RevokeOAuthGrantResponse`.

<sup>Written for commit 2f787a33b606242a1d25d3a45d97c0e4b901f4a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

