### PR TITLE
chore(ci): ensure that the tags don't have a `resend@` prefix

### DIFF
--- a/scripts/tegami.mts
+++ b/scripts/tegami.mts
@@ -50,6 +50,20 @@ const paper = tegami({
         },
       },
     }),
+    {
+      name: 'git-tag-format',
+      // The github plugin's git tags default to `resend@6.17.0`. This repo
+      // only ever publishes the one package, so drop that prefix and tag
+      // `v6.17.0` instead, matching this repo's pre-Tegami tags. Runs after
+      // the (enforce: "pre") git plugin's own `initPublishPlan`, which is
+      // what sets `git.tag` in the first place.
+      initPublishPlan({ plan }) {
+        for (const [id, packagePlan] of plan.packages) {
+          const version = this.graph.get(id)?.version;
+          if (version) packagePlan.git = { ...packagePlan.git, tag: `v${version}` };
+        }
+      },
+    },
   ],
 });
 void createCli(paper).parseAsync();

--- a/scripts/tegami.mts
+++ b/scripts/tegami.mts
@@ -22,6 +22,14 @@ const paper = tegami({
   plugins: [
     github({
       repo: 'resend/resend-node',
+      release: {
+        // Default title is `formatPackageVersion(name, version, distTag)`
+        // (e.g. "resend@6.17.0"), independent of the `git.tag` override
+        // below. Reuse `tag` so the release title and its tag/URL match.
+        create({ tag }) {
+          return { title: tag };
+        },
+      },
       versionPr: {
         // Versioning happens on canary (version.yml): the Version Packages PR
         // targets canary with the bumped versions and the publish lock.

--- a/scripts/tegami.mts
+++ b/scripts/tegami.mts
@@ -68,7 +68,8 @@ const paper = tegami({
       initPublishPlan({ plan }) {
         for (const [id, packagePlan] of plan.packages) {
           const version = this.graph.get(id)?.version;
-          if (version) packagePlan.git = { ...packagePlan.git, tag: `v${version}` };
+          if (version)
+            packagePlan.git = { ...packagePlan.git, tag: `v${version}` };
         }
       },
     },


### PR DESCRIPTION
Signed-off-by: gabriel miranda <gabrielmfern@outlook.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes release tags to `v<version>` (e.g., `v6.17.0`) and updates GitHub release titles to match, removing the `resend@` prefix. This keeps tags consistent with prior tags and avoids accidental mentions in releases.

- **Bug Fixes**
  - Added a Tegami plugin that rewrites `git.tag` to `v<version>` for all packages.
  - Set GitHub release title to the tag so the title and release URL match and never use `resend@<version>`.

<sup>Written for commit 775cc70f744375ef9eca2a95ad6229617e5c676e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

