### PR TITLE
fix: response types for removing an api key, and removing a contact from a segment

### DIFF
--- a/.tegami/2026-07-08-mrcal1b4.md
+++ b/.tegami/2026-07-08-mrcal1b4.md
@@ -1,0 +1,6 @@
+---
+packages:
+  npm:resend: patch
+---
+
+## fix reponse types for removing contacts out of segments and removing api keys

--- a/.tegami/2026-07-08-mrcal1b4.md
+++ b/.tegami/2026-07-08-mrcal1b4.md
@@ -3,4 +3,4 @@ packages:
   npm:resend: patch
 ---
 
-## fix reponse types for removing contacts out of segments and removing api keys
+## fix response types for removing contacts out of segments and removing api keys

--- a/src/api-keys/api-keys.spec.ts
+++ b/src/api-keys/api-keys.spec.ts
@@ -402,7 +402,11 @@ describe('API Keys', () => {
 
   describe('remove', () => {
     const id = '5262504e-8ed7-4fac-bd16-0d4be94bc9f2';
-    const response: RemoveApiKeyResponseSuccess = {};
+    const response: RemoveApiKeyResponseSuccess = {
+      object: 'api_key',
+      id,
+      deleted: true,
+    };
 
     it('removes an api key', async () => {
       fetchMock.mockOnce(JSON.stringify(response), {
@@ -416,7 +420,11 @@ describe('API Keys', () => {
 
       await expect(resend.apiKeys.remove(id)).resolves.toMatchInlineSnapshot(`
         {
-          "data": {},
+          "data": {
+            "deleted": true,
+            "id": "5262504e-8ed7-4fac-bd16-0d4be94bc9f2",
+            "object": "api_key",
+          },
           "error": null,
           "headers": {
             "content-type": "application/json",

--- a/src/api-keys/interfaces/remove-api-keys.interface.ts
+++ b/src/api-keys/interfaces/remove-api-keys.interface.ts
@@ -1,6 +1,9 @@
 import type { Response } from '../../interfaces';
+import type { ApiKey } from './api-key';
 
-// biome-ignore lint/complexity/noBannedTypes: allow empty types
-export type RemoveApiKeyResponseSuccess = {};
+export type RemoveApiKeyResponseSuccess = Pick<ApiKey, 'id'> & {
+  object: 'api_key';
+  deleted: boolean;
+};
 
 export type RemoveApiKeyResponse = Response<RemoveApiKeyResponseSuccess>;

--- a/src/contacts/segments/contact-segments.spec.ts
+++ b/src/contacts/segments/contact-segments.spec.ts
@@ -227,6 +227,7 @@ describe('ContactSegments', () => {
 
       const response: RemoveContactSegmentResponseSuccess = {
         id: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223',
+        audienceId: 'c7e1e488-ae2c-4255-a40c-a4db3af7ed0b',
         deleted: true,
       };
 
@@ -238,6 +239,7 @@ describe('ContactSegments', () => {
       ).resolves.toMatchInlineSnapshot(`
         {
           "data": {
+            "audienceId": "c7e1e488-ae2c-4255-a40c-a4db3af7ed0b",
             "deleted": true,
             "id": "3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223",
           },
@@ -257,6 +259,7 @@ describe('ContactSegments', () => {
 
       const response: RemoveContactSegmentResponseSuccess = {
         id: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223',
+        audienceId: 'c7e1e488-ae2c-4255-a40c-a4db3af7ed0b',
         deleted: true,
       };
 
@@ -268,6 +271,7 @@ describe('ContactSegments', () => {
       ).resolves.toMatchInlineSnapshot(`
         {
           "data": {
+            "audienceId": "c7e1e488-ae2c-4255-a40c-a4db3af7ed0b",
             "deleted": true,
             "id": "3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223",
           },

--- a/src/contacts/segments/interfaces/remove-contact-segment.interface.ts
+++ b/src/contacts/segments/interfaces/remove-contact-segment.interface.ts
@@ -7,6 +7,7 @@ export type RemoveContactSegmentOptions = ContactSegmentsBaseOptions & {
 
 export interface RemoveContactSegmentResponseSuccess {
   id: string;
+  audienceId: string;
   deleted: boolean;
 }
 


### PR DESCRIPTION
Signed-off-by: gabriel miranda <gabrielmfern@outlook.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes remove response types for API keys and contact segments so the SDK returns the correct fields. API key removal now returns `object`, `id`, and `deleted`; contact-segment removal now includes `audienceId`.

<sup>Written for commit ad28daf895251d6dc24b6a933b1a70e189d64d61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

