### PR TITLE
feat: add batch email updates

### DIFF
--- a/.tegami/2026-07-10-batch-email-options.md
+++ b/.tegami/2026-07-10-batch-email-options.md
@@ -1,0 +1,6 @@
+---
+packages:
+  npm:resend: minor
+---
+
+## support attachments, scheduledAt, and tags in batch emails

--- a/src/batch/batch.spec.ts
+++ b/src/batch/batch.spec.ts
@@ -649,5 +649,34 @@ describe('Batch', () => {
         },
       ]);
     });
+
+    it('forwards attachments in a batch email', async () => {
+      const payload: CreateBatchOptions = [
+        {
+          from: 'bu@resend.com',
+          to: 'zeno@resend.com',
+          subject: 'Hello World',
+          html: '<h1>Hello world</h1>',
+          tags: [{ name: 'category', value: 'confirm_email' }],
+          attachments: [{ content: 'aGVsbG8gd29ybGQ=', filename: 'hello.txt' }],
+        },
+      ];
+
+      mockSuccessResponse(
+        { data: [{ id: 'batch-with-attachment-1' }] },
+        { headers: {} },
+      );
+
+      await resend.batch.send(payload);
+
+      const lastCall = fetchMock.mock.calls[0];
+      const requestBody = JSON.parse(lastCall[1]?.body as string);
+      expect(requestBody[0].attachments).toEqual([
+        { content: 'aGVsbG8gd29ybGQ=', filename: 'hello.txt' },
+      ]);
+      expect(requestBody[0].tags).toEqual([
+        { name: 'category', value: 'confirm_email' },
+      ]);
+    });
   });
 });

--- a/src/batch/batch.spec.ts
+++ b/src/batch/batch.spec.ts
@@ -650,7 +650,7 @@ describe('Batch', () => {
       ]);
     });
 
-    it('forwards attachments in a batch email', async () => {
+    it('forwards attachments and tags in a batch email', async () => {
       const payload: CreateBatchOptions = [
         {
           from: 'bu@resend.com',

--- a/src/batch/interfaces/create-batch-options.interface.ts
+++ b/src/batch/interfaces/create-batch-options.interface.ts
@@ -4,15 +4,10 @@ import type { CreateEmailOptions } from '../../emails/interfaces/create-email-op
 import type { Response } from '../../interfaces';
 
 /**
- * Email options for batch sending. Same as CreateEmailOptions but without attachments
- * and scheduledAt, as these are not supported in the batch API.
- *
- * @link https://resend.com/docs/dashboard/emails/batch-sending#limitations
+ * Email options for batch sending.
+ * @link https://resend.com/docs/dashboard/emails/batch-sending
  */
-export type CreateBatchEmailOptions = Omit<
-  CreateEmailOptions,
-  'attachments' | 'scheduledAt'
->;
+export type CreateBatchEmailOptions = CreateEmailOptions;
 
 export type CreateBatchOptions = CreateBatchEmailOptions[];
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds support for attachments, scheduledAt, and tags in batch emails. Batch options now match single email options so these fields are forwarded to the API.

- **New Features**
  - Use `CreateEmailOptions` for `CreateBatchEmailOptions` to enable `attachments`, `scheduledAt`, and `tags`.
  - Add a test to confirm attachments and tags are forwarded in batch requests.

<sup>Written for commit e07d30f2d7993d6eb61abe0e3a4680aaeb0826dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

