### PR TITLE
chore: update sync_prs_to_linear action hash to a54e4298f0

### DIFF
--- a/.github/workflows/sync-prs-to-linear.yml
+++ b/.github/workflows/sync-prs-to-linear.yml
@@ -17,7 +17,7 @@ jobs:
       issues: write
 
     steps:
-      - uses: resend/public-shared-workflows/.github/actions/sync_prs_to_linear@9dd949340245057c074a4c0c96d9d7a7df22b655
+      - uses: resend/public-shared-workflows/.github/actions/sync_prs_to_linear@a54e4298f03be11600192b1004b021501545f4c5
         with:
           linear-api-key: ${{ secrets.LINEAR_API_KEY }}
           linear-team-id: ${{ secrets.LINEAR_TEAM_ID }}


### PR DESCRIPTION
Update `sync_prs_to_linear` action hash to `a54e4298f03be11600192b1004b021501545f4c5`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the `sync_prs_to_linear` workflow to use `resend/public-shared-workflows/.github/actions/sync_prs_to_linear@a54e4298f03be11600192b1004b021501545f4c5`. Pins the action to a newer commit to keep PR-to-Linear syncing stable and up to date.

<sup>Written for commit 7064ce9cbe3a6a56c898906d21f9057a0f880e66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

