### PR TITLE
chore: enter canary release

### DIFF
--- a/scripts/tegami.mts
+++ b/scripts/tegami.mts
@@ -7,6 +7,11 @@ import { createCli } from 'tegami/cli';
 import { github } from 'tegami/plugins/github';
 
 const paper = tegami({
+  packages: {
+    resend: {
+      prerelease: 'canary',
+    },
+  },
   npm: {
     client: 'pnpm',
     // npm trusted publishing (OIDC) — no NPM_TOKEN secret needed. This only


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Configured Tegami to treat the `resend` package as canary-only. This suppresses stable releases for `resend` by setting `packages.resend.prerelease` to `canary` in `scripts/tegami.mts`.

<sup>Written for commit 0a28f39b16b174a62948b54a0d93164677c80682. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

