### PR TITLE
chore: set minimum release age for renovate to 1 day

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"]
+  "extends": ["config:recommended"],
+  "minimumReleaseAge": "1 day"
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Configure Renovate to wait 1 day after a release before opening update PRs by setting `minimumReleaseAge: "1 day"` in `renovate.json`. This reduces churn and avoids adopting just-published versions immediately.

<sup>Written for commit adce33442cb769fd2f68579896aa536297cdc60f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

