### PR TITLE
feat(batch): support tags and scheduledAt in batch email options

### DIFF
--- a/.tegami/2026-07-15-batch-tags-scheduled-at.md
+++ b/.tegami/2026-07-15-batch-tags-scheduled-at.md
@@ -1,0 +1,6 @@
+---
+packages:
+  npm:resend: minor
+---
+
+## Support tags and scheduledAt in batch email options

--- a/src/batch/batch.spec.ts
+++ b/src/batch/batch.spec.ts
@@ -152,6 +152,79 @@ describe('Batch', () => {
       const usedIdempotencyKey = lastCall[1]?.headers.get('Idempotency-Key');
       expect(usedIdempotencyKey).toBe(idempotencyKey);
     });
+
+    it('sends emails with tags and scheduledAt', async () => {
+      const payload: CreateBatchOptions = [
+        {
+          from: 'admin@resend.com',
+          to: 'user1@resend.com',
+          subject: 'Scheduled Email 1',
+          html: '<h1>Hello</h1>',
+          tags: [{ name: 'category', value: 'welcome' }],
+          scheduledAt: 'in 1 hour',
+        },
+        {
+          from: 'admin@resend.com',
+          to: 'user2@resend.com',
+          subject: 'Scheduled Email 2',
+          html: '<h1>Hi</h1>',
+          tags: [
+            { name: 'category', value: 'newsletter' },
+            { name: 'campaign', value: 'summer-2026' },
+          ],
+          scheduledAt: '2026-07-16T10:00:00.000Z',
+        },
+      ];
+
+      mockSuccessResponse(
+        {
+          data: [{ id: 'scheduled-batch-1' }, { id: 'scheduled-batch-2' }],
+        },
+        {
+          headers: {},
+        },
+      );
+
+      await resend.batch.create(payload);
+
+      const lastCall = fetchMock.mock.calls[0];
+      const requestBody = JSON.parse(lastCall[1]?.body as string);
+      expect(requestBody).toEqual([
+        {
+          attachments: undefined,
+          bcc: undefined,
+          cc: undefined,
+          from: 'admin@resend.com',
+          headers: undefined,
+          html: '<h1>Hello</h1>',
+          reply_to: undefined,
+          scheduled_at: 'in 1 hour',
+          subject: 'Scheduled Email 1',
+          tags: [{ name: 'category', value: 'welcome' }],
+          text: undefined,
+          to: 'user1@resend.com',
+          template: undefined,
+        },
+        {
+          attachments: undefined,
+          bcc: undefined,
+          cc: undefined,
+          from: 'admin@resend.com',
+          headers: undefined,
+          html: '<h1>Hi</h1>',
+          reply_to: undefined,
+          scheduled_at: '2026-07-16T10:00:00.000Z',
+          subject: 'Scheduled Email 2',
+          tags: [
+            { name: 'category', value: 'newsletter' },
+            { name: 'campaign', value: 'summer-2026' },
+          ],
+          text: undefined,
+          to: 'user2@resend.com',
+          template: undefined,
+        },
+      ]);
+    });
   });
 
   describe('send', () => {
@@ -593,6 +666,7 @@ describe('Batch', () => {
           to: 'subscriber@example.com',
           replyTo: 'noreply@example.com',
           scheduledAt: 'in 1 hour',
+          tags: [{ name: 'type', value: 'newsletter' }],
         },
       ];
 
@@ -636,7 +710,7 @@ describe('Batch', () => {
           reply_to: 'noreply@example.com',
           scheduled_at: 'in 1 hour',
           subject: 'Custom Subject Override',
-          tags: undefined,
+          tags: [{ name: 'type', value: 'newsletter' }],
           text: undefined,
           to: 'subscriber@example.com',
           template: {

--- a/src/batch/interfaces/create-batch-options.interface.ts
+++ b/src/batch/interfaces/create-batch-options.interface.ts
@@ -4,15 +4,12 @@ import type { CreateEmailOptions } from '../../emails/interfaces/create-email-op
 import type { Response } from '../../interfaces';
 
 /**
- * Email options for batch sending. Same as CreateEmailOptions but without attachments
- * and scheduledAt, as these are not supported in the batch API.
+ * Email options for batch sending. Same as CreateEmailOptions but without attachments,
+ * as these are not supported in the batch API.
  *
  * @link https://resend.com/docs/dashboard/emails/batch-sending#limitations
  */
-export type CreateBatchEmailOptions = Omit<
-  CreateEmailOptions,
-  'attachments' | 'scheduledAt'
->;
+export type CreateBatchEmailOptions = Omit<CreateEmailOptions, 'attachments'>;
 
 export type CreateBatchOptions = CreateBatchEmailOptions[];
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The batch API now supports `tags` and `scheduled_at`. This PR updates the SDK types and tests to reflect that.

## Changes

- **`CreateBatchEmailOptions`**: Removed `scheduledAt` from the `Omit` list so batch emails can be scheduled. `tags` was already available via `CreateEmailOptions`.
- **Tests**: Added coverage for `tags` and `scheduledAt` serialization in batch requests, and extended the template email test to include tags.
- **Changelog**: Added a Tegami changelog entry for a minor version bump.

## Notes

Runtime serialization already worked through `parseEmailToApiOptions` — only the types and test coverage were out of date. Attachments remain unsupported in batch.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a6f158bf-309a-4915-b0e3-2d7573d0fcd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6f158bf-309a-4915-b0e3-2d7573d0fcd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `scheduledAt` and `tags` support to batch emails, enabling scheduled, tagged batch sends. Adds a Tegami changelog entry for a minor `resend` release; attachments remain unsupported.

- New Features
  - `CreateBatchEmailOptions` now includes `scheduledAt`.
  - Added tests for `tags` and `scheduledAt` serialization, including a template email case with tags.

<sup>Written for commit 883fe81c2bf17b8bc13b3bd4712c7188fc0f4633. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

