### PR TITLE
chore: exit canary release

### DIFF
--- a/scripts/tegami.mts
+++ b/scripts/tegami.mts
@@ -7,11 +7,6 @@ import { createCli } from 'tegami/cli';
 import { github } from 'tegami/plugins/github';
 
 const paper = tegami({
-  packages: {
-    resend: {
-      prerelease: 'canary',
-    },
-  },
   npm: {
     client: 'pnpm',
     // npm trusted publishing (OIDC) — no NPM_TOKEN secret needed. This only


### PR DESCRIPTION
Exits prerelease mode

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exit the canary prerelease and promote suppressions to stable. Removes the `prerelease: 'canary'` setting in `scripts/tegami.mts` so the workflow prepares 6.18.0 and publishes `resend@6.18.0` to `latest`.

<sup>Written for commit 73d246e800a2f819f4be4eb52feaa3ebaa2316c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1026?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

