### PR TITLE
chore(ci): add manual preview builds for preview-* branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,13 +2,17 @@ name: Release
 
 # Publishing half of the release flow (versioning runs on canary, see
 # version.yml). Publishes whatever the committed publish lock holds that
-# isn't on npm yet, then creates the git tag and GitHub release. Runs on both
-# branches, but each publishes a different channel:
+# isn't on npm yet, then creates the git tag and GitHub release. Each channel
+# publishes differently:
 #
-#   - canary: prerelease versions only (x.y.z-canary.N, npm dist-tag
+#   - canary (push): prerelease versions only (x.y.z-canary.N, npm dist-tag
 #     "canary"), so prereleases ship as soon as their version PR merges.
 #     Stable versions never publish from here — they wait for promotion.
-#   - main: everything, once canary is promoted.
+#   - main (push): everything, once canary is promoted.
+#   - preview-* (manual dispatch): snapshot builds for single-feature betas,
+#     published as x.y.z-preview-<feature>.N under the branch-name dist-tag
+#     by the "preview" job below — outside the tegami train, committing
+#     nothing. latest and canary are unaffected.
 #
 # Already-published versions are skipped, so re-runs, promotions with nothing
 # pending, and prereleases that already shipped from canary are safe no-ops.
@@ -31,6 +35,7 @@ jobs:
     # npm trusted publishing (OIDC) is only supported on GitHub-hosted runners,
     # so this job intentionally does not use the depot-* runners or a
     # container image like the rest of this repo's workflows.
+    if: github.ref_name == 'main' || github.ref_name == 'canary'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -64,3 +69,51 @@ jobs:
         run: pnpm tegami publish
         env:
           GITHUB_TOKEN: ${{ github.token }}
+
+  preview:
+    name: Publish preview build
+    # Manual snapshot builds for single-feature betas: run this workflow from
+    # a preview-* branch (Actions tab -> Release -> Run workflow). Publishes
+    # x.y.z-preview-<feature>.N under the branch-name npm dist-tag and commits
+    # nothing — the version base comes from the branch's pending changeset(s)
+    # and the .N counter from what's already on npm (see
+    # scripts/preview-version.mjs). Tegami is not involved; the same
+    # changesets produce the real release when the branch merges to canary.
+    # No git tag or GitHub release: preview builds are disposable.
+    if: github.event_name == 'workflow_dispatch' && startsWith(github.ref_name, 'preview-')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write # npm trusted publishing (OIDC)
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: pnpm setup
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install packages
+        run: pnpm install --frozen-lockfile
+
+      - name: Compute preview version
+        id: version
+        run: echo "version=$(node scripts/preview-version.mjs)" >> "$GITHUB_OUTPUT"
+
+      # `pnpm publish` runs `prepublishOnly` (`pnpm run build`), same as the
+      # tegami path above. The version edit stays in the runner — nothing is
+      # committed back to the branch.
+      - name: Publish
+        run: |
+          npm pkg set version="$VERSION"
+          pnpm publish --tag "$GITHUB_REF_NAME" --no-git-checks
+          echo "Published \`resend@$VERSION\` (npm dist-tag \`$GITHUB_REF_NAME\`)" >> "$GITHUB_STEP_SUMMARY"
+        env:
+          VERSION: ${{ steps.version.outputs.version }}

--- a/scripts/preview-version.mjs
+++ b/scripts/preview-version.mjs
@@ -1,0 +1,74 @@
+// scripts/preview-version.mjs — compute the version for a preview build.
+//
+// Preview builds (see the "preview" job in .github/workflows/release.yml) are
+// published outside the tegami release train: nothing is committed, so the
+// version is derived entirely from what already exists:
+//
+//   <base>-<branch>.<N>   e.g. 6.19.0-preview-widgets.0
+//
+//   - base: the branch's package.json version bumped by the largest bump
+//     declared in the pending .tegami/*.md changesets — the same changesets
+//     that will produce the real release when the branch merges to canary.
+//   - N: one past the highest such build already on npm. The registry is the
+//     counter state; a stale read can't double-publish (npm rejects
+//     duplicate versions).
+//
+// Prints the version to stdout. Throws if there is no changeset: a preview
+// branch must declare its bump (and its eventual release notes) before
+// cutting builds.
+import { execFileSync } from 'node:child_process';
+import { readFileSync, readdirSync } from 'node:fs';
+
+const branch = process.env.GITHUB_REF_NAME;
+if (!branch?.startsWith('preview-')) {
+  throw new Error(`Preview builds only run on preview-* branches, got: ${branch}`);
+}
+
+const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
+
+const RANK = { patch: 1, minor: 2, major: 3 };
+let bump;
+for (const file of readdirSync('.tegami')) {
+  if (!file.endsWith('.md')) continue;
+  const text = readFileSync(`.tegami/${file}`, 'utf8');
+  const frontmatter = text.match(/^---\n([\s\S]*?)\n---/)?.[1] ?? '';
+  for (const [, found] of frontmatter.matchAll(/\b(patch|minor|major)\b/g)) {
+    if (!bump || RANK[found] > RANK[bump]) bump = found;
+  }
+}
+if (!bump) {
+  throw new Error(
+    'No changeset found — add a .tegami/*.md changeset declaring the bump before cutting a preview build.',
+  );
+}
+
+const [major, minor, patch] = pkg.version.split('-')[0].split('.').map(Number);
+const base =
+  bump === 'major'
+    ? `${major + 1}.0.0`
+    : bump === 'minor'
+      ? `${major}.${minor + 1}.0`
+      : `${major}.${minor}.${patch + 1}`;
+
+let published = [];
+try {
+  const out = execFileSync('npm', ['view', pkg.name, 'versions', '--json'], {
+    encoding: 'utf8',
+  });
+  published = JSON.parse(out);
+  if (!Array.isArray(published)) published = [published];
+} catch (error) {
+  // Unpublished package = no prior builds; anything else (network, auth) must
+  // surface rather than silently restart the counter at .0.
+  if (!`${error.stdout}${error.stderr}`.includes('E404')) throw error;
+}
+
+const prefix = `${base}-${branch}.`;
+const next =
+  published
+    .filter((v) => v.startsWith(prefix))
+    .map((v) => Number(v.slice(prefix.length)))
+    .filter(Number.isInteger)
+    .reduce((max, n) => Math.max(max, n), -1) + 1;
+
+console.log(`${prefix}${next}`);


### PR DESCRIPTION
Adds a snapshot-style preview channel for single-feature betas, **outside the tegami release train** — restoring the old per-feature preview process (`preview-topics`, `preview-batch`, …) without ever blocking `latest` or `canary`.

## Design

Preview branches carry **feature commits + the changeset for the eventual real release, and nothing else** — no version PRs, no lock/CHANGELOG bookkeeping, so graduation to canary is a plain, conflict-free merge and tegami takes over from there (the same changeset produces the real release).

Cutting a beta build is a manual dispatch: **Actions → Release → Run workflow from the `preview-*` branch.** The new `preview` job:

- computes `x.y.z-preview-<feature>.N` (`scripts/preview-version.mjs`): base = branch's `package.json` version bumped per the pending changeset(s); `.N` = one past the highest such build already on npm (the registry is the counter state — nothing committed, can't double-publish);
- fails loudly if the branch has no changeset (the graduation artifact must exist before builds are cut);
- publishes under the **branch-name dist-tag** via the existing npm trusted-publishing setup (`pnpm publish` in the runner; version edit never committed);
- no git tag / GitHub release — preview builds are disposable.

The existing `release` job is gated to main/canary so a preview dispatch doesn't run the tegami path.

## Testers install via

```
npm i resend@preview-<feature>        # dist-tag
npm i resend@6.19.0-preview-<feature>.0  # exact pin, e.g. for docs callouts
```

Verified locally: version computation (minor → 6.19.0-preview-widgets.0, patch → 6.18.1-preview-widgets.0, registry query, loud no-changeset failure). The trusted-publishing link from a dispatch run is the remaining unproven piece — shakedown plan: dispatch on a throwaway `preview-test` branch after merge.

Docs follow-up: rewrite the preview section of the "How to release Node libraries" Notion page around this flow.