### PR TITLE
Add bounce info type to email retrieval response

### DIFF
--- a/src/emails/interfaces/get-email-options.interface.ts
+++ b/src/emails/interfaces/get-email-options.interface.ts
@@ -1,7 +1,23 @@
 import type { Response } from '../../interfaces';
 
+export interface GetEmailResponseBounce {
+  message: string | null;
+  type: 'Undetermined' | 'Transient' | 'Permanent' | null;
+  subType:
+    | 'Undetermined'
+    | 'General'
+    | 'NoEmail'
+    | 'MailboxFull'
+    | 'MessageTooLarge'
+    | 'ContentRejected'
+    | 'AttachmentRejected'
+    | null;
+  diagnosticCode?: string[];
+}
+
 export interface GetEmailResponseSuccess {
   bcc: string[] | null;
+  bounce?: GetEmailResponseBounce;
   cc: string[] | null;
   created_at: string;
   from: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds the `bounce` field to `GetEmailResponseSuccess`, matching the OpenAPI schema for `GET /emails/:id`.

- New `GetEmailResponseBounce` interface with `message`, `type`, `subType`, and `diagnosticCode`.
- `bounce?: GetEmailResponseBounce` added to `GetEmailResponseSuccess`, present only when `last_event` is `bounced`.

Type-only change, no runtime behavior affected.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dfc0b2df-17aa-415f-8073-1eca4ba412ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dfc0b2df-17aa-415f-8073-1eca4ba412ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add bounce details to the email retrieval response, matching the OpenAPI for GET /emails/:id. Type-only change; enables clients to read bounce reason info when an email is bounced.

- New Features
  - Added GetEmailResponseBounce with message, type, subType, and optional diagnosticCode.
  - Added optional bounce to GetEmailResponseSuccess (present when last_event is "bounced").

<sup>Written for commit 48bdd3ac98c913a3e4f4d2136d90da0f206334a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

