### PR TITLE
feat(webhooks): add suppression webhooks

### DIFF
--- a/src/webhooks/interfaces/index.ts
+++ b/src/webhooks/interfaces/index.ts
@@ -41,6 +41,8 @@ export type {
   EmailScheduledEvent,
   EmailSentEvent,
   EmailSuppressedEvent,
+  SuppressionAddedEvent,
+  SuppressionRemovedEvent,
   WebhookEvent,
   WebhookEventPayload,
 } from './webhook-event.interface';

--- a/src/webhooks/interfaces/webhook-event.interface.ts
+++ b/src/webhooks/interfaces/webhook-event.interface.ts
@@ -15,7 +15,9 @@ export type WebhookEvent =
   | 'contact.deleted'
   | 'domain.created'
   | 'domain.updated'
-  | 'domain.deleted';
+  | 'domain.deleted'
+  | 'suppression.added'
+  | 'suppression.removed';
 
 interface BaseEmailEventData {
   broadcast_id?: string;
@@ -100,6 +102,14 @@ interface DomainEventData {
   created_at: string;
   region: string;
   records: DomainRecord[];
+}
+
+interface SuppressionEventData {
+  id: string;
+  email: string;
+  origin: 'bounce' | 'complaint' | 'manual';
+  source_id: string | null;
+  created_at: string;
 }
 
 export interface EmailSentEvent {
@@ -212,6 +222,18 @@ export interface DomainDeletedEvent {
   data: DomainEventData;
 }
 
+export interface SuppressionAddedEvent {
+  type: 'suppression.added';
+  created_at: string;
+  data: SuppressionEventData;
+}
+
+export interface SuppressionRemovedEvent {
+  type: 'suppression.removed';
+  created_at: string;
+  data: SuppressionEventData;
+}
+
 export type WebhookEventPayload =
   | EmailSentEvent
   | EmailScheduledEvent
@@ -229,4 +251,6 @@ export type WebhookEventPayload =
   | ContactDeletedEvent
   | DomainCreatedEvent
   | DomainUpdatedEvent
-  | DomainDeletedEvent;
+  | DomainDeletedEvent
+  | SuppressionAddedEvent
+  | SuppressionRemovedEvent;


### PR DESCRIPTION
Added `suppression.added` and `suppression.removed` webhook types.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds suppression webhooks so clients are notified when an email is added to or removed from the suppression list. Includes typed payloads and exports for `suppression.added` and `suppression.removed`.

- **New Features**
  - Added `suppression.added` and `suppression.removed` to `WebhookEvent` and `WebhookEventPayload`.
  - Introduced `SuppressionEventData` with: `id`, `email`, `origin` ('bounce' | 'complaint' | 'manual'), `source_id` (nullable), `created_at`.
  - Exported `SuppressionAddedEvent` and `SuppressionRemovedEvent` from `webhook-event.interface`.

<sup>Written for commit e0e4ecfb9b0e8e749d9b45e3fd798fab4760ce7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1031?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

