### PR TITLE
fix: remove object field from suppression list entry type

### DIFF
--- a/src/suppressions/interfaces/get-suppression.interface.ts
+++ b/src/suppressions/interfaces/get-suppression.interface.ts
@@ -1,6 +1,6 @@
 import type { Response } from '../../interfaces';
-import type { SuppressionListEntry } from './suppression-list-entry';
+import type { Suppression } from './suppression-list-entry';
 
-export type GetSuppressionResponseSuccess = SuppressionListEntry;
+export type GetSuppressionResponseSuccess = Suppression;
 
 export type GetSuppressionResponse = Response<GetSuppressionResponseSuccess>;

--- a/src/suppressions/interfaces/suppression-list-entry.ts
+++ b/src/suppressions/interfaces/suppression-list-entry.ts
@@ -1,6 +1,6 @@
 export type SuppressionOrigin = 'bounce' | 'complaint' | 'manual';
 
-export interface SuppressionListEntry {
+export interface Suppression {
   object: 'suppression';
   id: string;
   email: string;
@@ -8,3 +8,5 @@ export interface SuppressionListEntry {
   source_id: string | null;
   created_at: string;
 }
+
+export type SuppressionListEntry = Omit<Suppression, 'object'>;

--- a/src/suppressions/suppressions.spec.ts
+++ b/src/suppressions/suppressions.spec.ts
@@ -167,7 +167,6 @@ describe('Suppressions', () => {
       has_more: false,
       data: [
         {
-          object: 'suppression',
           id: 'b6d24b8e-af0b-4c3c-be0c-359bbd97381e',
           email: 'blocked@example.com',
           origin: 'complaint',


### PR DESCRIPTION
## Problem

`SuppressionListEntry` declares an `object: 'suppression'` field that the list endpoint never returns, and the same type was aliased as the `get` response type:

```ts
// get-suppression.interface.ts (before)
export type GetSuppressionResponseSuccess = SuppressionListEntry;
```

The two endpoints return shapes that differ by exactly one field:

- `GET /suppressions` → `{object: "list", has_more, data: [{id, email, origin, source_id, created_at}]}` — entries have **five** fields, no `object`
- `GET /suppressions/{id-or-email}` → those five **plus** `object: "suppression"`

So this compiles but throws at runtime:

```ts
const { data } = await resend.suppressions.list();
data.data[0].object.toUpperCase(); // Cannot read properties of undefined
```

TypeScript can't catch it, since the declaration is simply believed.

## Verification

Confirmed against the API implementation — `apps/public-api/src/routes/suppressions/list.ts` selects exactly those five columns and adds nothing, while `get.ts` returns `{ object: 'suppression' as const, ...data }` — and then against the live API. Real list entry:

```json
{"id":"019f856f-…","email":"…@example.com","origin":"manual",
 "source_id":null,"created_at":"2026-07-21 16:08:06.045503+00"}
```

The OpenAPI spec already models this correctly (its list-item schema omits `object`); this type and the `list-suppressions` docs example are the two artifacts that drifted. The docs fix is owned separately by the API team.

## Change

Splits the shapes, following the precedent already used elsewhere in this repo for list-item-vs-full-object pairs (`ListEmail = Omit<GetEmailResponseSuccess, … | 'object'>` in `list-emails-options.interface.ts`, and `ListReceivingEmail` likewise):

```ts
export interface Suppression { object: 'suppression'; id; email; origin; source_id; created_at }
export type SuppressionListEntry = Omit<Suppression, 'object'>;
```

`GetSuppressionResponseSuccess = Suppression`. `SuppressionListEntry` keeps its name and now matches what that name says. `SuppressionOrigin` is unchanged, and `Suppression` is newly exported.

## Breaking change

Consumers reading `object` off a list entry will now get a compile error. That is the point — the code was already broken at runtime, and the type was hiding it. Worth calling out in release notes. No version bump here, since this repo releases via `scripts/tegami.mts` rather than changesets.

## Tests

The existing `list` test already covers the shape via `expect(result.data).toEqual(listResponse)`; the fixture is what needed correcting, and because it is annotated `ListSuppressionsResponseSuccess`, re-adding `object` to either the type or the fixture fails to compile. The `get` test's inline snapshot pins `"object": "suppression"` on that side.

```
biome check src                      -> exit 0, 223 files, no fixes applied
vitest run --dir src --exclude e2e   -> 36 files passed, 385 passed | 4 todo
```

Two notes for reproducing locally, neither related to this change:

- `pnpm lint` at the repo root currently fails on my machine because stale worktrees under `.claude/worktrees/` contain their own `biome.jsonc`, which biome rejects as nested root configs. Scoping to `src` avoids it; CI is unaffected since that directory isn't committed.
- `pnpm typecheck` already fails on `canary` with pre-existing errors in `src/batch/batch.ts`, `src/resend.ts`, `src/emails/receiving/receiving.spec.ts` and `e2e/esbuild/index.ts`, plus a `tsconfig` `moduleResolution=node10` deprecation under TypeScript 6.0.3. None are in suppression files, and CI does not run `typecheck` (it runs build, lint, test, test:e2e).
