### PR TITLE
chore: bump version to 6.18.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.18.0",
+  "version": "6.18.1",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bump `resend` version to 6.18.1 for a patch release; no code or runtime changes.

<sup>Written for commit c9509b2fc2f062d7fdc62b9d592cf7608c641f1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

