### PR TITLE
feat: add usage resource

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,4 +24,5 @@ export * from './suppressions/batch/interfaces';
 export * from './suppressions/interfaces';
 export * from './templates/interfaces';
 export * from './topics/interfaces';
+export * from './usage/interfaces';
 export * from './webhooks/interfaces';

--- a/src/resend.ts
+++ b/src/resend.ts
@@ -23,6 +23,7 @@ import { Segments } from './segments/segments';
 import { Suppressions } from './suppressions/suppressions';
 import { Templates } from './templates/templates';
 import { Topics } from './topics/topics';
+import { Usage } from './usage/usage';
 import { Webhooks } from './webhooks/webhooks';
 
 const defaultBaseUrl = 'https://api.resend.com';
@@ -69,6 +70,7 @@ export class Resend {
   readonly suppressions = new Suppressions(this);
   readonly templates = new Templates(this);
   readonly topics = new Topics(this);
+  readonly usage = new Usage(this);
   readonly webhooks = new Webhooks(this);
 
   constructor(

--- a/src/usage/interfaces/get-usage.interface.ts
+++ b/src/usage/interfaces/get-usage.interface.ts
@@ -1,0 +1,54 @@
+import type { Response } from '../../interfaces';
+
+export type GetUsageResponseSuccess = {
+  object: 'usage';
+  generated_at: string;
+  emails: {
+    daily: {
+      used: number;
+      limit: number | null;
+      sent: number;
+      received: number;
+      resets_at: string;
+    };
+    monthly: {
+      used: number;
+      limit: number;
+      sent: number;
+      received: number;
+      resets_at: string;
+    };
+  };
+  contacts: {
+    used: number;
+    limit: number;
+  };
+  segments: {
+    used: number;
+    limit: number | null;
+  };
+  broadcasts: {
+    used: number;
+    limit: null;
+  };
+  ai_credits: {
+    used: number;
+    limit: number;
+    next_increase_at: string | null;
+  };
+  automation_runs: {
+    used: number;
+    limit: number;
+    resets_at: string;
+  };
+  domains: {
+    used: number;
+    limit: number | null;
+  };
+  rate_limit: {
+    limit: number;
+    duration: string;
+  };
+};
+
+export type GetUsageResponse = Response<GetUsageResponseSuccess>;

--- a/src/usage/interfaces/index.ts
+++ b/src/usage/interfaces/index.ts
@@ -1,0 +1,1 @@
+export * from './get-usage.interface';

--- a/src/usage/usage.spec.ts
+++ b/src/usage/usage.spec.ts
@@ -1,0 +1,71 @@
+import createFetchMock from 'vitest-fetch-mock';
+import { Resend } from '../resend';
+import { mockSuccessResponse } from '../test-utils/mock-fetch';
+import type { GetUsageResponseSuccess } from './interfaces';
+
+const fetchMocker = createFetchMock(vi);
+fetchMocker.enableMocks();
+
+describe('Usage', () => {
+  afterEach(() => fetchMock.resetMocks());
+  afterAll(() => fetchMocker.disableMocks());
+
+  describe('get', () => {
+    it('gets usage', async () => {
+      const response: GetUsageResponseSuccess = {
+        object: 'usage',
+        generated_at: '2024-11-01T18:10:00.000Z',
+        emails: {
+          daily: {
+            used: 10,
+            limit: 100,
+            sent: 8,
+            received: 2,
+            resets_at: '2024-11-02T00:00:00.000Z',
+          },
+          monthly: {
+            used: 100,
+            limit: 3000,
+            sent: 80,
+            received: 20,
+            resets_at: '2024-12-01T00:00:00.000Z',
+          },
+        },
+        contacts: { used: 10, limit: 3000 },
+        segments: { used: 1, limit: 3 },
+        broadcasts: { used: 2, limit: null },
+        ai_credits: { used: 5, limit: 100, next_increase_at: null },
+        automation_runs: {
+          used: 3,
+          limit: 10000,
+          resets_at: '2024-12-01T00:00:00.000Z',
+        },
+        domains: { used: 1, limit: 1 },
+        rate_limit: { limit: 1000, duration: '1000ms' },
+      };
+
+      mockSuccessResponse(response, {
+        headers: {},
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      const result = await resend.usage.get();
+      expect(result).toEqual({
+        data: response,
+        error: null,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://api.resend.com/usage',
+        expect.objectContaining({
+          method: 'GET',
+          headers: expect.any(Headers),
+        }),
+      );
+    });
+  });
+});

--- a/src/usage/usage.ts
+++ b/src/usage/usage.ts
@@ -1,0 +1,11 @@
+import type { Resend } from '../resend';
+import type { GetUsageResponse, GetUsageResponseSuccess } from './interfaces';
+
+export class Usage {
+  constructor(private readonly resend: Resend) {}
+
+  async get(): Promise<GetUsageResponse> {
+    const data = await this.resend.get<GetUsageResponseSuccess>('/usage');
+    return data;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `resend.usage.get()` matching the new `GET /usage` endpoint in the public API, returning email/contacts/segments/broadcasts/ai_credits/automation_runs/domains usage and rate limit info.

## Test plan
- [x] `usage.spec.ts` covers a successful `get()` call
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `resend.usage.get()` for the new `GET /usage` API to fetch account usage and rate limit data. Wires `usage` onto the `Resend` client and exports typed interfaces; returns usage for emails (daily/monthly), contacts, segments, broadcasts, ai credits, automation runs, domains, and rate limit details.

<sup>Written for commit b224dc6fe8fb323cc16ab3128adee63e78412e09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

