### PR TITLE
feat: add message_id to email webhook event types

### DIFF
--- a/src/webhooks/interfaces/webhook-event.interface.ts
+++ b/src/webhooks/interfaces/webhook-event.interface.ts
@@ -23,6 +23,7 @@ interface BaseEmailEventData {
   broadcast_id?: string;
   created_at: string;
   email_id: string;
+  message_id: string;
   from: string;
   to: string[];
   subject: string;


### PR DESCRIPTION
## Summary

The documented payloads for all email webhook events include the RFC `message_id`, but `BaseEmailEventData` does not type it, so TypeScript users of `webhooks.verify()` cannot access `event.data.message_id` on `email.sent`, `email.delivered`, `email.bounced`, etc. without casting.

The docs list `message_id` ("RFC Message-ID header value for the email") for every one of these events:

- [email.sent](https://resend.com/docs/webhooks/emails/sent)
- [email.scheduled](https://resend.com/docs/webhooks/emails/scheduled)
- [email.delivered](https://resend.com/docs/webhooks/emails/delivered)
- and the other `email.*` events sharing the same base payload

`ReceivedEmailEventData` (for `email.received`) already types `message_id`; this brings the outbound event types in line, following up on #702 (inbound email response) and #988 (get/list responses).

A concrete use case: capturing `message_id` from `email.sent` to set `In-Reply-To`/`References` on follow-up emails, per the [threading guide](https://resend.com/docs/dashboard/receiving/reply-to-emails), without polling `emails.get()` (which can 404 right after the send).

## Change

Add `message_id: string` to `BaseEmailEventData`, matching the documented payloads and the field's position in the docs examples.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `message_id` to `BaseEmailEventData` so TypeScript users of `webhooks.verify()` can access `event.data.message_id` on outbound email webhook events without casting. Aligns types with the documented payloads for `email.sent`, `email.scheduled`, `email.delivered`, `email.bounced`, and others.

<sup>Written for commit d5b2c7b6aa689fc0f3fbcfcc53c79aa040a343db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

