### PR TITLE
feat: emails.metrics() for account-level email metrics

### DIFF
--- a/src/emails/emails.spec.ts
+++ b/src/emails/emails.spec.ts
@@ -936,6 +936,8 @@ describe('Emails', () => {
       const result = await resend.emails.metrics({
         startDate: '2026-07-01',
         endDate: '2026-07-08',
+        timezone: 'America/New_York',
+        granularity: 'daily',
         metrics: ['sent', 'delivered', 'open_rate'],
         dimensions: ['period', 'domain'],
         filter: { domainId: ['d91cd9bd-1176-4f47-2a4b-fce2d5399cbf'] },
@@ -949,7 +951,7 @@ describe('Emails', () => {
         },
       });
       expect(fetchMock.mock.calls[0][0]).toBe(
-        'https://api.resend.com/emails/metrics?start_date=2026-07-01&end_date=2026-07-08&metrics=sent%2Cdelivered%2Copen_rate&dimensions=period%2Cdomain&filter%5Bdomain_id%5D=d91cd9bd-1176-4f47-2a4b-fce2d5399cbf',
+        'https://api.resend.com/emails/metrics?start_date=2026-07-01&end_date=2026-07-08&timezone=America%2FNew_York&granularity=daily&metrics=sent%2Cdelivered%2Copen_rate&dimensions=period%2Cdomain&filter%5Bdomain_id%5D=d91cd9bd-1176-4f47-2a4b-fce2d5399cbf',
       );
     });
 

--- a/src/emails/emails.spec.ts
+++ b/src/emails/emails.spec.ts
@@ -1143,6 +1143,89 @@ describe('Emails', () => {
       );
     });
 
+    it('calls endpoint passing an engagement metric sortBy for a domain breakdown', async () => {
+      const response: GetEmailsMetricsResponseSuccess = {
+        object: 'metrics',
+        start_date: '2026-07-01T00:00:00.000Z',
+        end_date: '2026-07-08T00:00:00.000Z',
+        metrics: ['unique_opened'],
+        dimensions: ['domain'],
+        granularity: 'daily',
+        sort_by: 'unique_opened',
+        sort_order: 'desc',
+        totals: {
+          unique_opened: 512,
+        },
+        data: [
+          {
+            domain_id: 'd91cd9bd-1176-4f47-2a4b-fce2d5399cbf',
+            domain_name: 'example.com',
+            unique_opened: 128,
+          },
+        ],
+      };
+
+      mockSuccessResponse(response);
+
+      const result = await resend.emails.metrics({
+        dimensions: ['domain'],
+        metrics: ['unique_opened'],
+        sortBy: 'unique_opened',
+      });
+
+      expect(result).toEqual({
+        data: response,
+        error: null,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'https://api.resend.com/emails/metrics?metrics=unique_opened&dimensions=domain&sort_by=unique_opened',
+      );
+    });
+
+    it('calls endpoint passing a rate metric sortBy for an email breakdown', async () => {
+      const response: GetEmailsMetricsResponseSuccess = {
+        object: 'metrics',
+        start_date: '2026-07-01T00:00:00.000Z',
+        end_date: '2026-07-08T00:00:00.000Z',
+        metrics: ['open_rate'],
+        dimensions: ['email'],
+        granularity: 'daily',
+        sort_by: 'open_rate',
+        sort_order: 'desc',
+        totals: {
+          open_rate: 42.5,
+        },
+        data: [
+          {
+            email_id: '3c9a1e0a-2b7d-4e0a-9e0a-2b7d4e0a9e0a',
+            open_rate: 63.4,
+          },
+        ],
+      };
+
+      mockSuccessResponse(response);
+
+      const result = await resend.emails.metrics({
+        dimensions: ['email'],
+        metrics: ['open_rate'],
+        sortBy: 'open_rate',
+      });
+
+      expect(result).toEqual({
+        data: response,
+        error: null,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'https://api.resend.com/emails/metrics?metrics=open_rate&dimensions=email&sort_by=open_rate',
+      );
+    });
+
     it('returns error when request fails', async () => {
       const response: ErrorResponse = {
         name: 'validation_error',

--- a/src/emails/emails.spec.ts
+++ b/src/emails/emails.spec.ts
@@ -7,6 +7,7 @@ import type {
   CreateEmailResponseSuccess,
 } from './interfaces/create-email-options.interface';
 import type { GetEmailResponseSuccess } from './interfaces/get-email-options.interface';
+import type { GetEmailsMetricsResponseSuccess } from './interfaces/get-metrics.interface';
 import type { ListEmailsResponseSuccess } from './interfaces/list-emails-options.interface';
 
 const fetchMocker = createFetchMock(vi);
@@ -870,6 +871,117 @@ describe('Emails', () => {
           'https://api.resend.com/emails?before=cursor123',
         );
       });
+    });
+  });
+
+  describe('metrics', () => {
+    it('calls endpoint with no options and returns the response', async () => {
+      const response: GetEmailsMetricsResponseSuccess = {
+        object: 'metrics',
+        start_date: '2026-07-01T00:00:00.000Z',
+        end_date: '2026-07-08T00:00:00.000Z',
+        metrics: ['sent', 'delivered', 'open_rate'],
+        dimensions: [],
+        granularity: 'daily',
+        totals: {
+          sent: 1204,
+          delivered: 1180,
+          open_rate: 50.0,
+        },
+      };
+
+      mockSuccessResponse(response);
+
+      const result = await resend.emails.metrics();
+
+      expect(result).toEqual({
+        data: response,
+        error: null,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'https://api.resend.com/emails/metrics',
+      );
+    });
+
+    it('calls endpoint passing date range, metrics, dimensions and filters', async () => {
+      const response: GetEmailsMetricsResponseSuccess = {
+        object: 'metrics',
+        start_date: '2026-07-01T00:00:00.000Z',
+        end_date: '2026-07-08T00:00:00.000Z',
+        metrics: ['sent', 'delivered', 'open_rate'],
+        dimensions: ['period', 'domain'],
+        granularity: 'daily',
+        totals: {
+          sent: 1204,
+          delivered: 1180,
+          open_rate: 50.0,
+        },
+        data: [
+          {
+            period: '2026-07-01',
+            domain_id: 'd91cd9bd-1176-4f47-2a4b-fce2d5399cbf',
+            domain_name: 'example.com',
+            sent: 172,
+            delivered: 169,
+            open_rate: 49.7,
+          },
+        ],
+      };
+
+      mockSuccessResponse(response);
+
+      const result = await resend.emails.metrics({
+        startDate: '2026-07-01',
+        endDate: '2026-07-08',
+        metrics: ['sent', 'delivered', 'open_rate'],
+        dimensions: ['period', 'domain'],
+        filter: { domainId: ['d91cd9bd-1176-4f47-2a4b-fce2d5399cbf'] },
+      });
+
+      expect(result).toEqual({
+        data: response,
+        error: null,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'https://api.resend.com/emails/metrics?start_date=2026-07-01&end_date=2026-07-08&metrics=sent%2Cdelivered%2Copen_rate&dimensions=period%2Cdomain&filter%5Bdomain_id%5D=d91cd9bd-1176-4f47-2a4b-fce2d5399cbf',
+      );
+    });
+
+    it('returns error when request fails', async () => {
+      const response: ErrorResponse = {
+        name: 'validation_error',
+        message: 'Invalid `start_date`.',
+        statusCode: 422,
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 422,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      const result = await resend.emails.metrics({ startDate: 'not-a-date' });
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "data": null,
+          "error": {
+            "message": "Invalid \`start_date\`.",
+            "name": "validation_error",
+            "statusCode": 422,
+          },
+          "headers": {
+            "content-type": "application/json",
+          },
+        }
+      `);
     });
   });
 });

--- a/src/emails/emails.spec.ts
+++ b/src/emails/emails.spec.ts
@@ -883,6 +883,8 @@ describe('Emails', () => {
         metrics: ['sent', 'delivered', 'open_rate'],
         dimensions: [],
         granularity: 'daily',
+        sort_by: 'sent',
+        sort_order: 'desc',
         totals: {
           sent: 1204,
           delivered: 1180,
@@ -914,6 +916,8 @@ describe('Emails', () => {
         metrics: ['sent', 'delivered', 'open_rate'],
         dimensions: ['period', 'domain'],
         granularity: 'daily',
+        sort_by: 'date',
+        sort_order: 'asc',
         totals: {
           sent: 1204,
           delivered: 1180,
@@ -963,6 +967,8 @@ describe('Emails', () => {
         metrics: ['sent', 'delivered', 'open_rate'],
         dimensions: ['period', 'email'],
         granularity: 'daily',
+        sort_by: 'date',
+        sort_order: 'asc',
         totals: {
           sent: 1204,
           delivered: 1180,
@@ -1000,6 +1006,90 @@ describe('Emails', () => {
       });
       expect(fetchMock.mock.calls[0][0]).toBe(
         'https://api.resend.com/emails/metrics?start_date=2026-07-01&end_date=2026-07-08&timezone=America%2FNew_York&granularity=daily&metrics=sent%2Cdelivered%2Copen_rate&dimensions=period%2Cemail&filter%5Bemail_id%5D=4dd369bc-aa82-4ff3-97de-514ae3000ee0',
+      );
+    });
+
+    it('calls endpoint passing sortBy=date and sortOrder for a period breakdown', async () => {
+      const response: GetEmailsMetricsResponseSuccess = {
+        object: 'metrics',
+        start_date: '2026-07-01T00:00:00.000Z',
+        end_date: '2026-07-08T00:00:00.000Z',
+        metrics: ['sent'],
+        dimensions: ['period'],
+        granularity: 'daily',
+        sort_by: 'date',
+        sort_order: 'desc',
+        totals: {
+          sent: 1204,
+        },
+        data: [
+          { period: '2026-07-08', sent: 200 },
+          { period: '2026-07-01', sent: 150 },
+        ],
+      };
+
+      mockSuccessResponse(response);
+
+      const result = await resend.emails.metrics({
+        startDate: '2026-07-01',
+        endDate: '2026-07-08',
+        metrics: ['sent'],
+        dimensions: ['period'],
+        sortBy: 'date',
+        sortOrder: 'desc',
+      });
+
+      expect(result).toEqual({
+        data: response,
+        error: null,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'https://api.resend.com/emails/metrics?start_date=2026-07-01&end_date=2026-07-08&metrics=sent&dimensions=period&sort_by=date&sort_order=desc',
+      );
+    });
+
+    it('calls endpoint passing a metric sortBy for a domain breakdown', async () => {
+      const response: GetEmailsMetricsResponseSuccess = {
+        object: 'metrics',
+        start_date: '2026-07-01T00:00:00.000Z',
+        end_date: '2026-07-08T00:00:00.000Z',
+        metrics: ['sent'],
+        dimensions: ['domain'],
+        granularity: 'daily',
+        sort_by: 'sent',
+        sort_order: 'asc',
+        totals: {
+          sent: 1204,
+        },
+        data: [
+          {
+            domain_id: 'd91cd9bd-1176-4f47-2a4b-fce2d5399cbf',
+            domain_name: 'example.com',
+            sent: 172,
+          },
+        ],
+      };
+
+      mockSuccessResponse(response);
+
+      const result = await resend.emails.metrics({
+        dimensions: ['domain'],
+        sortBy: 'sent',
+        sortOrder: 'asc',
+      });
+
+      expect(result).toEqual({
+        data: response,
+        error: null,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'https://api.resend.com/emails/metrics?dimensions=domain&sort_by=sent&sort_order=asc',
       );
     });
 

--- a/src/emails/emails.spec.ts
+++ b/src/emails/emails.spec.ts
@@ -1051,6 +1051,56 @@ describe('Emails', () => {
       );
     });
 
+    it('calls endpoint passing sortBy=date for a period+domain breakdown', async () => {
+      const response: GetEmailsMetricsResponseSuccess = {
+        object: 'metrics',
+        start_date: '2026-07-01T00:00:00.000Z',
+        end_date: '2026-07-08T00:00:00.000Z',
+        metrics: ['sent'],
+        dimensions: ['period', 'domain'],
+        granularity: 'daily',
+        sort_by: 'date',
+        sort_order: 'asc',
+        totals: {
+          sent: 1204,
+        },
+        data: [
+          {
+            period: '2026-07-01',
+            domain_id: 'd91cd9bd-1176-4f47-2a4b-fce2d5399cbf',
+            domain_name: 'example.com',
+            sent: 172,
+          },
+          {
+            period: '2026-07-08',
+            domain_id: 'd91cd9bd-1176-4f47-2a4b-fce2d5399cbf',
+            domain_name: 'example.com',
+            sent: 200,
+          },
+        ],
+      };
+
+      mockSuccessResponse(response);
+
+      const result = await resend.emails.metrics({
+        metrics: ['sent'],
+        dimensions: ['period', 'domain'],
+        sortBy: 'date',
+        sortOrder: 'asc',
+      });
+
+      expect(result).toEqual({
+        data: response,
+        error: null,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'https://api.resend.com/emails/metrics?metrics=sent&dimensions=period%2Cdomain&sort_by=date&sort_order=asc',
+      );
+    });
+
     it('calls endpoint passing a metric sortBy for a domain breakdown', async () => {
       const response: GetEmailsMetricsResponseSuccess = {
         object: 'metrics',

--- a/src/emails/emails.spec.ts
+++ b/src/emails/emails.spec.ts
@@ -955,6 +955,54 @@ describe('Emails', () => {
       );
     });
 
+    it('calls endpoint passing the email dimension and filter[email_id]', async () => {
+      const response: GetEmailsMetricsResponseSuccess = {
+        object: 'metrics',
+        start_date: '2026-07-01T00:00:00.000Z',
+        end_date: '2026-07-08T00:00:00.000Z',
+        metrics: ['sent', 'delivered', 'open_rate'],
+        dimensions: ['period', 'email'],
+        granularity: 'daily',
+        totals: {
+          sent: 1204,
+          delivered: 1180,
+          open_rate: 50.0,
+        },
+        data: [
+          {
+            period: '2026-07-01',
+            email_id: '4dd369bc-aa82-4ff3-97de-514ae3000ee0',
+            sent: 172,
+            delivered: 169,
+            open_rate: 49.7,
+          },
+        ],
+      };
+
+      mockSuccessResponse(response);
+
+      const result = await resend.emails.metrics({
+        startDate: '2026-07-01',
+        endDate: '2026-07-08',
+        timezone: 'America/New_York',
+        granularity: 'daily',
+        metrics: ['sent', 'delivered', 'open_rate'],
+        dimensions: ['period', 'email'],
+        filter: { emailId: ['4dd369bc-aa82-4ff3-97de-514ae3000ee0'] },
+      });
+
+      expect(result).toEqual({
+        data: response,
+        error: null,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'https://api.resend.com/emails/metrics?start_date=2026-07-01&end_date=2026-07-08&timezone=America%2FNew_York&granularity=daily&metrics=sent%2Cdelivered%2Copen_rate&dimensions=period%2Cemail&filter%5Bemail_id%5D=4dd369bc-aa82-4ff3-97de-514ae3000ee0',
+      );
+    });
+
     it('returns error when request fails', async () => {
       const response: ErrorResponse = {
         name: 'validation_error',

--- a/src/emails/emails.ts
+++ b/src/emails/emails.ts
@@ -18,6 +18,11 @@ import type {
   GetEmailResponseSuccess,
 } from './interfaces/get-email-options.interface';
 import type {
+  GetEmailsMetricsOptions,
+  GetEmailsMetricsResponse,
+  GetEmailsMetricsResponseSuccess,
+} from './interfaces/get-metrics.interface';
+import type {
   ListEmailsOptions,
   ListEmailsResponse,
   ListEmailsResponseSuccess,
@@ -97,4 +102,59 @@ export class Emails {
     );
     return data;
   }
+
+  async metrics(
+    options: GetEmailsMetricsOptions = {},
+  ): Promise<GetEmailsMetricsResponse> {
+    const queryString = buildMetricsQuery(options);
+    const url = queryString
+      ? `/emails/metrics?${queryString}`
+      : '/emails/metrics';
+
+    const data = await this.resend.get<GetEmailsMetricsResponseSuccess>(url);
+    return data;
+  }
+}
+
+function buildMetricsQuery(options: GetEmailsMetricsOptions) {
+  const {
+    startDate,
+    endDate,
+    timezone,
+    granularity,
+    metrics,
+    dimensions,
+    filter,
+  } = options;
+  const searchParams = new URLSearchParams();
+
+  if (startDate !== undefined) {
+    searchParams.set('start_date', startDate);
+  }
+
+  if (endDate !== undefined) {
+    searchParams.set('end_date', endDate);
+  }
+
+  if (timezone !== undefined) {
+    searchParams.set('timezone', timezone);
+  }
+
+  if (granularity !== undefined) {
+    searchParams.set('granularity', granularity);
+  }
+
+  if (metrics !== undefined) {
+    searchParams.set('metrics', metrics.join(','));
+  }
+
+  if (dimensions !== undefined) {
+    searchParams.set('dimensions', dimensions.join(','));
+  }
+
+  if (filter?.domainId !== undefined) {
+    searchParams.set('filter[domain_id]', filter.domainId.join(','));
+  }
+
+  return searchParams.toString();
 }

--- a/src/emails/emails.ts
+++ b/src/emails/emails.ts
@@ -125,6 +125,7 @@ function buildMetricsQuery(options: GetEmailsMetricsOptions) {
     metrics: options.metrics?.join(','),
     dimensions: options.dimensions?.join(','),
     'filter[domain_id]': options.filter?.domainId?.join(','),
+    'filter[email_id]': options.filter?.emailId?.join(','),
   };
 
   const searchParams = new URLSearchParams();

--- a/src/emails/emails.ts
+++ b/src/emails/emails.ts
@@ -117,43 +117,21 @@ export class Emails {
 }
 
 function buildMetricsQuery(options: GetEmailsMetricsOptions) {
-  const {
-    startDate,
-    endDate,
-    timezone,
-    granularity,
-    metrics,
-    dimensions,
-    filter,
-  } = options;
+  const params: Record<string, string | undefined> = {
+    start_date: options.startDate,
+    end_date: options.endDate,
+    timezone: options.timezone,
+    granularity: options.granularity,
+    metrics: options.metrics?.join(','),
+    dimensions: options.dimensions?.join(','),
+    'filter[domain_id]': options.filter?.domainId?.join(','),
+  };
+
   const searchParams = new URLSearchParams();
-
-  if (startDate !== undefined) {
-    searchParams.set('start_date', startDate);
-  }
-
-  if (endDate !== undefined) {
-    searchParams.set('end_date', endDate);
-  }
-
-  if (timezone !== undefined) {
-    searchParams.set('timezone', timezone);
-  }
-
-  if (granularity !== undefined) {
-    searchParams.set('granularity', granularity);
-  }
-
-  if (metrics !== undefined) {
-    searchParams.set('metrics', metrics.join(','));
-  }
-
-  if (dimensions !== undefined) {
-    searchParams.set('dimensions', dimensions.join(','));
-  }
-
-  if (filter?.domainId !== undefined) {
-    searchParams.set('filter[domain_id]', filter.domainId.join(','));
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined) {
+      searchParams.set(key, value);
+    }
   }
 
   return searchParams.toString();

--- a/src/emails/emails.ts
+++ b/src/emails/emails.ts
@@ -126,11 +126,13 @@ function buildMetricsQuery(options: GetEmailsMetricsOptions) {
     dimensions: options.dimensions?.join(','),
     'filter[domain_id]': options.filter?.domainId?.join(','),
     'filter[email_id]': options.filter?.emailId?.join(','),
+    sort_by: options.sortBy,
+    sort_order: options.sortOrder,
   };
 
   const searchParams = new URLSearchParams();
   for (const [key, value] of Object.entries(params)) {
-    if (value !== undefined) {
+    if (value !== undefined && value !== '') {
       searchParams.set(key, value);
     }
   }

--- a/src/emails/interfaces/get-metrics.interface.ts
+++ b/src/emails/interfaces/get-metrics.interface.ts
@@ -102,19 +102,20 @@ export type GetEmailsMetricsOptions = {
   };
 
   /**
-   * What to sort `data` by. Defaults to `date` when `dimensions` is exactly
+   * What to sort `data` by. Defaults to `date` when `dimensions` includes
    * `period`, or `sent` when `dimensions` is exactly `domain` or exactly
    * `email`.
    *
-   * `sortBy: 'date'` requires `dimensions` to be exactly `period`. A metric
-   * `sortBy` requires `dimensions` to be exactly one non-time dimension
-   * (`domain` or `email`).
+   * `sortBy: 'date'` requires `dimensions` to include `period` — this also
+   * works when `period` is combined with `domain` or `email`. A metric
+   * `sortBy` requires `dimensions` to be exactly one dimension other than
+   * `period` (`domain` or `email`).
    */
   sortBy?: EmailMetricsSortBy;
 
   /**
-   * The sort direction for `sortBy`. Defaults to `asc` for a `period`
-   * breakdown, `desc` otherwise.
+   * The sort direction for `sortBy`. Defaults to `asc` when `dimensions`
+   * includes `period`, `desc` otherwise.
    */
   sortOrder?: EmailMetricsSortOrder;
 };

--- a/src/emails/interfaces/get-metrics.interface.ts
+++ b/src/emails/interfaces/get-metrics.interface.ts
@@ -28,6 +28,26 @@ export type EmailMetricsDimension = 'period' | 'domain' | 'email';
 
 export type EmailMetricsGranularity = 'hourly' | 'daily' | 'weekly';
 
+export type SortableEmailMetric =
+  | 'received'
+  | 'delivered'
+  | 'complained'
+  | 'suppressed'
+  | 'bounced'
+  | 'bounced_transient'
+  | 'bounced_permanent'
+  | 'bounced_undetermined'
+  | 'opened'
+  | 'clicked'
+  | 'unsubscribed'
+  | 'delivery_delayed'
+  | 'failed'
+  | 'sent';
+
+export type EmailMetricsSortBy = 'date' | SortableEmailMetric;
+
+export type EmailMetricsSortOrder = 'asc' | 'desc';
+
 export type GetEmailsMetricsOptions = {
   /**
    * The start of the date range, as an ISO 8601 date or datetime.
@@ -80,6 +100,23 @@ export type GetEmailsMetricsOptions = {
      */
     emailId?: string[];
   };
+
+  /**
+   * What to sort `data` by. Defaults to `date` when `dimensions` is exactly
+   * `period`, or `sent` when `dimensions` is exactly `domain` or exactly
+   * `email`.
+   *
+   * `sortBy: 'date'` requires `dimensions` to be exactly `period`. A metric
+   * `sortBy` requires `dimensions` to be exactly one non-time dimension
+   * (`domain` or `email`).
+   */
+  sortBy?: EmailMetricsSortBy;
+
+  /**
+   * The sort direction for `sortBy`. Defaults to `asc` for a `period`
+   * breakdown, `desc` otherwise.
+   */
+  sortOrder?: EmailMetricsSortOrder;
 };
 
 export type EmailMetricsTotals = Partial<Record<EmailMetric, number>>;
@@ -98,6 +135,8 @@ export interface GetEmailsMetricsResponseSuccess {
   metrics: EmailMetric[];
   dimensions: EmailMetricsDimension[];
   granularity: EmailMetricsGranularity;
+  sort_by: EmailMetricsSortBy;
+  sort_order: EmailMetricsSortOrder;
   totals: EmailMetricsTotals;
   data?: EmailMetricsDataRow[];
 }

--- a/src/emails/interfaces/get-metrics.interface.ts
+++ b/src/emails/interfaces/get-metrics.interface.ts
@@ -1,0 +1,99 @@
+import type { Response } from '../../interfaces';
+
+export type EmailMetric =
+  | 'received'
+  | 'delivered'
+  | 'complained'
+  | 'suppressed'
+  | 'bounced'
+  | 'bounced_transient'
+  | 'bounced_permanent'
+  | 'bounced_undetermined'
+  | 'opened'
+  | 'clicked'
+  | 'unsubscribed'
+  | 'delivery_delayed'
+  | 'failed'
+  | 'sent'
+  | 'unique_opened'
+  | 'unique_clicked'
+  | 'delivery_rate'
+  | 'open_rate'
+  | 'click_rate'
+  | 'bounce_rate'
+  | 'complaint_rate'
+  | 'unsubscribe_rate';
+
+export type EmailMetricsDimension = 'period' | 'domain';
+
+export type EmailMetricsGranularity = 'hourly' | 'daily' | 'weekly';
+
+export type GetEmailsMetricsOptions = {
+  /**
+   * The start of the date range, as an ISO 8601 date or datetime.
+   * Defaults to 6 days before `endDate`.
+   *
+   * @link https://resend.com/docs/api-reference/emails/get-metrics#query-parameters
+   */
+  startDate?: string;
+
+  /**
+   * The end of the date range, as an ISO 8601 date or datetime.
+   * Defaults to now.
+   *
+   * @link https://resend.com/docs/api-reference/emails/get-metrics#query-parameters
+   */
+  endDate?: string;
+
+  /**
+   * The IANA timezone used to bucket periods when `period` is in `dimensions`.
+   * Defaults to `UTC`.
+   */
+  timezone?: string;
+
+  /**
+   * The bucket size used when `period` is in `dimensions`.
+   * Defaults to `daily`.
+   */
+  granularity?: EmailMetricsGranularity;
+
+  /**
+   * The metrics to include in the response. Defaults to all metrics.
+   */
+  metrics?: EmailMetric[];
+
+  /**
+   * The dimensions to break the response down by. Defaults to `[]`, which
+   * returns a single `totals` row for the whole range, with no `data`.
+   */
+  dimensions?: EmailMetricsDimension[];
+
+  filter?: {
+    /**
+     * Restrict the response to these sending domain IDs.
+     */
+    domainId?: string[];
+  };
+};
+
+export type EmailMetricsTotals = Partial<Record<EmailMetric, number>>;
+
+export type EmailMetricsDataRow = EmailMetricsTotals & {
+  period?: string;
+  domain_id?: string;
+  domain_name?: string;
+};
+
+export interface GetEmailsMetricsResponseSuccess {
+  object: 'metrics';
+  start_date: string;
+  end_date: string;
+  metrics: EmailMetric[];
+  dimensions: EmailMetricsDimension[];
+  granularity: EmailMetricsGranularity;
+  totals: EmailMetricsTotals;
+  data?: EmailMetricsDataRow[];
+}
+
+export type GetEmailsMetricsResponse =
+  Response<GetEmailsMetricsResponseSuccess>;

--- a/src/emails/interfaces/get-metrics.interface.ts
+++ b/src/emails/interfaces/get-metrics.interface.ts
@@ -24,7 +24,7 @@ export type EmailMetric =
   | 'complaint_rate'
   | 'unsubscribe_rate';
 
-export type EmailMetricsDimension = 'period' | 'domain';
+export type EmailMetricsDimension = 'period' | 'domain' | 'email';
 
 export type EmailMetricsGranularity = 'hourly' | 'daily' | 'weekly';
 
@@ -73,6 +73,12 @@ export type GetEmailsMetricsOptions = {
      * Restrict the response to these sending domain IDs.
      */
     domainId?: string[];
+
+    /**
+     * Restrict the response to these email IDs. Cannot be combined with the
+     * `domain` dimension.
+     */
+    emailId?: string[];
   };
 };
 
@@ -82,6 +88,7 @@ export type EmailMetricsDataRow = EmailMetricsTotals & {
   period?: string;
   domain_id?: string;
   domain_name?: string;
+  email_id?: string;
 };
 
 export interface GetEmailsMetricsResponseSuccess {

--- a/src/emails/interfaces/get-metrics.interface.ts
+++ b/src/emails/interfaces/get-metrics.interface.ts
@@ -28,23 +28,7 @@ export type EmailMetricsDimension = 'period' | 'domain' | 'email';
 
 export type EmailMetricsGranularity = 'hourly' | 'daily' | 'weekly';
 
-export type SortableEmailMetric =
-  | 'received'
-  | 'delivered'
-  | 'complained'
-  | 'suppressed'
-  | 'bounced'
-  | 'bounced_transient'
-  | 'bounced_permanent'
-  | 'bounced_undetermined'
-  | 'opened'
-  | 'clicked'
-  | 'unsubscribed'
-  | 'delivery_delayed'
-  | 'failed'
-  | 'sent';
-
-export type EmailMetricsSortBy = 'date' | SortableEmailMetric;
+export type EmailMetricsSortBy = 'date' | EmailMetric;
 
 export type EmailMetricsSortOrder = 'asc' | 'desc';
 
@@ -103,13 +87,9 @@ export type GetEmailsMetricsOptions = {
 
   /**
    * What to sort `data` by. Defaults to `date` when `dimensions` includes
-   * `period`, or `sent` when `dimensions` is exactly `domain` or exactly
-   * `email`.
+   * `period`, or `sent` otherwise.
    *
-   * `sortBy: 'date'` requires `dimensions` to include `period` — this also
-   * works when `period` is combined with `domain` or `email`. A metric
-   * `sortBy` requires `dimensions` to be exactly one dimension other than
-   * `period` (`domain` or `email`).
+   * @link https://resend.com/docs/api-reference/emails/get-metrics#query-parameters
    */
   sortBy?: EmailMetricsSortBy;
 

--- a/src/emails/interfaces/index.ts
+++ b/src/emails/interfaces/index.ts
@@ -1,5 +1,6 @@
 export * from './cancel-email-options.interface';
 export * from './create-email-options.interface';
 export * from './get-email-options.interface';
+export * from './get-metrics.interface';
 export * from './list-emails-options.interface';
 export * from './update-email-options.interface';


### PR DESCRIPTION
## Summary
- Adds `emails.metrics()` to retrieve account-level email metrics: counts and rates for `sent`, `delivered`, `opened`, `clicked`, `bounced`, etc., optionally broken down by `period` and/or `domain`.
- Supports `startDate`/`endDate` range, `timezone`, `granularity` (`hourly`/`daily`/`weekly`), a `metrics` allowlist, `dimensions` breakdown, and `filter.domainId`.
- `totals` and each `data` row are typed as a partial record over the possible metric keys, since the set of metrics present depends on what was requested.

Based on [resend-docs#1686](https://github.com/resend/resend-docs/pull/1686).

## Test plan
- [x] `emails.spec.ts` covers `metrics()` with no options, with date range/metrics/dimensions/filter, and an error response
- [x] Full `emails.spec.ts` suite passes (27 tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `resend.emails.metrics()` to fetch account-level email metrics with date range, timezone, granularity, breakdowns, filters, and flexible sorting (by date or any metric). Returns typed totals and optional rows; response echoes resolved `sort_by`/`sort_order`.

- **New Features**
  - New `resend.emails.metrics(options?)` for `/emails/metrics`.
  - Options: `startDate`/`endDate`, `timezone`, `granularity` (`hourly`|`daily`|`weekly`), `metrics`, `dimensions` (`period`|`domain`|`email`), `filter.domainId`, `filter.emailId`, `sortBy` (`date` or any metric, including engagement and rate), `sortOrder` (`asc`|`desc`).

- **Bug Fixes**
  - `sortBy: 'date'` works when `dimensions` includes `period` (alone or with `domain`/`email`).
  - Query builder omits empty `metrics`/`dimensions`, serializes `timezone`/`granularity`, and is simplified; `get-metrics` types exported from `emails/interfaces`.

<sup>Written for commit 5873b0e3fd10fa09ee0ecda57cf1923d758c27d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

