### PR TITLE
chore: bump version to 6.19.0-preview-headless-dashboard.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.18.1",
+  "version": "6.19.0-preview-headless-dashboard.0",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## Summary
- Bumps the version to a preview release covering the changes merged into `preview-headless-dashboard` so far:
  - `broadcasts.metrics()`/`broadcasts.recipients()` (#1037)
  - `resend.usage.get()` (#1039)
- Tagged as a preview since both features are still in private beta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `resend` to 6.19.0-preview-headless-dashboard.0 to expose new private-beta APIs: `broadcasts.metrics()`, `broadcasts.recipients()`, and `resend.usage.get()`. This is a preview release.

<sup>Written for commit d15481fc087f3a3d6cfe3ebcb0e56695152cbed1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1044?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

