### PR TITLE
feat: segments.metrics() for account-level segment metrics

### DIFF
--- a/src/segments/interfaces/get-metrics.interface.ts
+++ b/src/segments/interfaces/get-metrics.interface.ts
@@ -4,6 +4,10 @@ export type SegmentMetric = 'all_contacts' | 'subscribers' | 'unsubscribers';
 
 export type SegmentMetricsDimension = 'segment';
 
+export type SegmentMetricsSortBy = 'date';
+
+export type SegmentMetricsSortOrder = 'asc' | 'desc';
+
 export type GetSegmentsMetricsOptions = {
   /**
    * The metrics to include in the response. Defaults to all metrics.
@@ -25,6 +29,19 @@ export type GetSegmentsMetricsOptions = {
      */
     segmentId?: string[];
   };
+
+  /**
+   * What to sort the segment breakdown by. `date` is currently the only
+   * supported value. Only applies to `data` (when `dimensions` includes
+   * `segment`) — `totals` ignores sort params. Defaults to `date`.
+   */
+  sortBy?: SegmentMetricsSortBy;
+
+  /**
+   * The sort direction for `sortBy`, applied to each segment's creation
+   * date. Defaults to `desc`.
+   */
+  sortOrder?: SegmentMetricsSortOrder;
 };
 
 export type SegmentMetricsTotals = Partial<Record<SegmentMetric, number>>;
@@ -38,6 +55,8 @@ export interface GetSegmentsMetricsResponseSuccess {
   object: 'segments_metrics';
   metrics: SegmentMetric[];
   dimensions: SegmentMetricsDimension[];
+  sort_by: SegmentMetricsSortBy;
+  sort_order: SegmentMetricsSortOrder;
   totals: SegmentMetricsTotals;
   data?: SegmentMetricsDataRow[];
 }

--- a/src/segments/interfaces/get-metrics.interface.ts
+++ b/src/segments/interfaces/get-metrics.interface.ts
@@ -1,0 +1,46 @@
+import type { Response } from '../../interfaces';
+
+export type SegmentMetric = 'all_contacts' | 'subscribers' | 'unsubscribers';
+
+export type SegmentMetricsDimension = 'segment';
+
+export type GetSegmentsMetricsOptions = {
+  /**
+   * The metrics to include in the response. Defaults to all metrics.
+   *
+   * @link https://resend.com/docs/api-reference/segments/get-segment-metrics#query-parameters
+   */
+  metrics?: SegmentMetric[];
+
+  /**
+   * The dimensions to break `data` down by. Defaults to `[]`, which returns
+   * only `totals` with no `data`.
+   */
+  dimensions?: SegmentMetricsDimension[];
+
+  filter?: {
+    /**
+     * Restrict `totals` (and `data`, when requested) to these segment IDs,
+     * without double-counting contacts that belong to more than one.
+     */
+    segmentId?: string[];
+  };
+};
+
+export type SegmentMetricsTotals = Partial<Record<SegmentMetric, number>>;
+
+export type SegmentMetricsDataRow = SegmentMetricsTotals & {
+  segment_id: string;
+  segment_name: string;
+};
+
+export interface GetSegmentsMetricsResponseSuccess {
+  object: 'segments_metrics';
+  metrics: SegmentMetric[];
+  dimensions: SegmentMetricsDimension[];
+  totals: SegmentMetricsTotals;
+  data?: SegmentMetricsDataRow[];
+}
+
+export type GetSegmentsMetricsResponse =
+  Response<GetSegmentsMetricsResponseSuccess>;

--- a/src/segments/interfaces/index.ts
+++ b/src/segments/interfaces/index.ts
@@ -1,4 +1,5 @@
 export * from './create-segment-options.interface';
+export * from './get-metrics.interface';
 export * from './get-segment.interface';
 export * from './list-segments.interface';
 export * from './remove-segment.interface';

--- a/src/segments/segments.spec.ts
+++ b/src/segments/segments.spec.ts
@@ -6,6 +6,7 @@ import type {
   CreateSegmentOptions,
   CreateSegmentResponseSuccess,
 } from './interfaces/create-segment-options.interface';
+import type { GetSegmentsMetricsResponseSuccess } from './interfaces/get-metrics.interface';
 import type { GetSegmentResponseSuccess } from './interfaces/get-segment.interface';
 import type { ListSegmentsResponseSuccess } from './interfaces/list-segments.interface';
 import type { RemoveSegmentResponseSuccess } from './interfaces/remove-segment.interface';
@@ -209,6 +210,122 @@ describe('Segments', () => {
           }),
         );
       });
+    });
+  });
+
+  describe('metrics', () => {
+    it('calls endpoint with no options and returns the response', async () => {
+      const response: GetSegmentsMetricsResponseSuccess = {
+        object: 'segments_metrics',
+        metrics: ['all_contacts', 'subscribers', 'unsubscribers'],
+        dimensions: [],
+        totals: {
+          all_contacts: 12450,
+          subscribers: 11800,
+          unsubscribers: 650,
+        },
+      };
+
+      mockSuccessResponse(response, {
+        headers: {},
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      const result = await resend.segments.metrics();
+
+      expect(result).toEqual({
+        data: response,
+        error: null,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://api.resend.com/segments/metrics',
+        expect.objectContaining({
+          method: 'GET',
+          headers: expect.any(Headers),
+        }),
+      );
+    });
+
+    it('calls endpoint passing metrics, dimensions and filter[segment_id]', async () => {
+      const response: GetSegmentsMetricsResponseSuccess = {
+        object: 'segments_metrics',
+        metrics: ['all_contacts'],
+        dimensions: ['segment'],
+        totals: {
+          all_contacts: 4300,
+        },
+        data: [
+          {
+            segment_id: '78261eea-8f8b-4381-83c6-79fa7120f1cf',
+            segment_name: 'Registered Users',
+            all_contacts: 4300,
+          },
+        ],
+      };
+
+      mockSuccessResponse(response, {
+        headers: {},
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      const result = await resend.segments.metrics({
+        metrics: ['all_contacts'],
+        dimensions: ['segment'],
+        filter: { segmentId: ['78261eea-8f8b-4381-83c6-79fa7120f1cf'] },
+      });
+
+      expect(result).toEqual({
+        data: response,
+        error: null,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://api.resend.com/segments/metrics?metrics=all_contacts&dimensions=segment&filter%5Bsegment_id%5D=78261eea-8f8b-4381-83c6-79fa7120f1cf',
+        expect.objectContaining({
+          method: 'GET',
+          headers: expect.any(Headers),
+        }),
+      );
+    });
+
+    it('returns error when request fails', async () => {
+      const response: ErrorResponse = {
+        name: 'validation_error',
+        message:
+          'Invalid `metrics` value. Allowed: all_contacts, subscribers, unsubscribers.',
+        statusCode: 422,
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 422,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      const result = resend.segments.metrics();
+
+      await expect(result).resolves.toMatchInlineSnapshot(`
+        {
+          "data": null,
+          "error": {
+            "message": "Invalid \`metrics\` value. Allowed: all_contacts, subscribers, unsubscribers.",
+            "name": "validation_error",
+            "statusCode": 422,
+          },
+          "headers": {
+            "content-type": "application/json",
+          },
+        }
+      `);
     });
   });
 

--- a/src/segments/segments.spec.ts
+++ b/src/segments/segments.spec.ts
@@ -219,6 +219,8 @@ describe('Segments', () => {
         object: 'segments_metrics',
         metrics: ['all_contacts', 'subscribers', 'unsubscribers'],
         dimensions: [],
+        sort_by: 'date',
+        sort_order: 'desc',
         totals: {
           all_contacts: 12450,
           subscribers: 11800,
@@ -255,6 +257,8 @@ describe('Segments', () => {
         object: 'segments_metrics',
         metrics: ['all_contacts', 'subscribers', 'unsubscribers'],
         dimensions: [],
+        sort_by: 'date',
+        sort_order: 'desc',
         totals: {
           all_contacts: 12450,
           subscribers: 11800,
@@ -287,6 +291,8 @@ describe('Segments', () => {
         object: 'segments_metrics',
         metrics: ['all_contacts'],
         dimensions: ['segment'],
+        sort_by: 'date',
+        sort_order: 'desc',
         totals: {
           all_contacts: 4300,
         },
@@ -320,6 +326,53 @@ describe('Segments', () => {
 
       expect(fetchMock).toHaveBeenCalledWith(
         'https://api.resend.com/segments/metrics?metrics=all_contacts&dimensions=segment&filter%5Bsegment_id%5D=78261eea-8f8b-4381-83c6-79fa7120f1cf',
+        expect.objectContaining({
+          method: 'GET',
+          headers: expect.any(Headers),
+        }),
+      );
+    });
+
+    it('calls endpoint passing sortBy and sortOrder', async () => {
+      const response: GetSegmentsMetricsResponseSuccess = {
+        object: 'segments_metrics',
+        metrics: ['all_contacts'],
+        dimensions: ['segment'],
+        sort_by: 'date',
+        sort_order: 'asc',
+        totals: {
+          all_contacts: 4300,
+        },
+        data: [
+          {
+            segment_id: '78261eea-8f8b-4381-83c6-79fa7120f1cf',
+            segment_name: 'Registered Users',
+            all_contacts: 4300,
+          },
+        ],
+      };
+
+      mockSuccessResponse(response, {
+        headers: {},
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      const result = await resend.segments.metrics({
+        dimensions: ['segment'],
+        sortBy: 'date',
+        sortOrder: 'asc',
+      });
+
+      expect(result).toEqual({
+        data: response,
+        error: null,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://api.resend.com/segments/metrics?dimensions=segment&sort_by=date&sort_order=asc',
         expect.objectContaining({
           method: 'GET',
           headers: expect.any(Headers),

--- a/src/segments/segments.spec.ts
+++ b/src/segments/segments.spec.ts
@@ -250,6 +250,38 @@ describe('Segments', () => {
       );
     });
 
+    it('omits query params when passed as empty arrays', async () => {
+      const response: GetSegmentsMetricsResponseSuccess = {
+        object: 'segments_metrics',
+        metrics: ['all_contacts', 'subscribers', 'unsubscribers'],
+        dimensions: [],
+        totals: {
+          all_contacts: 12450,
+          subscribers: 11800,
+          unsubscribers: 650,
+        },
+      };
+
+      mockSuccessResponse(response, {
+        headers: {},
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      await resend.segments.metrics({
+        metrics: [],
+        dimensions: [],
+        filter: { segmentId: [] },
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://api.resend.com/segments/metrics',
+        expect.objectContaining({
+          method: 'GET',
+          headers: expect.any(Headers),
+        }),
+      );
+    });
+
     it('calls endpoint passing metrics, dimensions and filter[segment_id]', async () => {
       const response: GetSegmentsMetricsResponseSuccess = {
         object: 'segments_metrics',

--- a/src/segments/segments.ts
+++ b/src/segments/segments.ts
@@ -84,7 +84,7 @@ function buildMetricsQuery(options: GetSegmentsMetricsOptions) {
 
   const searchParams = new URLSearchParams();
   for (const [key, value] of Object.entries(params)) {
-    if (value !== undefined) {
+    if (value !== undefined && value !== '') {
       searchParams.set(key, value);
     }
   }

--- a/src/segments/segments.ts
+++ b/src/segments/segments.ts
@@ -80,6 +80,8 @@ function buildMetricsQuery(options: GetSegmentsMetricsOptions) {
     metrics: options.metrics?.join(','),
     dimensions: options.dimensions?.join(','),
     'filter[segment_id]': options.filter?.segmentId?.join(','),
+    sort_by: options.sortBy,
+    sort_order: options.sortOrder,
   };
 
   const searchParams = new URLSearchParams();

--- a/src/segments/segments.ts
+++ b/src/segments/segments.ts
@@ -7,6 +7,11 @@ import type {
   CreateSegmentResponseSuccess,
 } from './interfaces/create-segment-options.interface';
 import type {
+  GetSegmentsMetricsOptions,
+  GetSegmentsMetricsResponse,
+  GetSegmentsMetricsResponseSuccess,
+} from './interfaces/get-metrics.interface';
+import type {
   GetSegmentResponse,
   GetSegmentResponseSuccess,
 } from './interfaces/get-segment.interface';
@@ -56,4 +61,33 @@ export class Segments {
     );
     return data;
   }
+
+  async metrics(
+    options: GetSegmentsMetricsOptions = {},
+  ): Promise<GetSegmentsMetricsResponse> {
+    const queryString = buildMetricsQuery(options);
+    const url = queryString
+      ? `/segments/metrics?${queryString}`
+      : '/segments/metrics';
+
+    const data = await this.resend.get<GetSegmentsMetricsResponseSuccess>(url);
+    return data;
+  }
+}
+
+function buildMetricsQuery(options: GetSegmentsMetricsOptions) {
+  const params: Record<string, string | undefined> = {
+    metrics: options.metrics?.join(','),
+    dimensions: options.dimensions?.join(','),
+    'filter[segment_id]': options.filter?.segmentId?.join(','),
+  };
+
+  const searchParams = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined) {
+      searchParams.set(key, value);
+    }
+  }
+
+  return searchParams.toString();
 }


### PR DESCRIPTION
## Summary
- Adds `segments.metrics()` to retrieve live account-level or per-segment contact counts: `all_contacts`, `subscribers`, `unsubscribers`, optionally broken down by `segment`.
- Supports a `metrics` allowlist, `dimensions` breakdown, and `filter.segmentId`.
- `totals` and each `data` row are typed as a partial record over the possible metric keys, since the set of metrics present depends on what was requested.

Based on resend-docs#1691.

## Test plan
- [x] `segments.spec.ts` covers `metrics()` with no options, with metrics/dimensions/filter, and an error response
- [x] Full `segments.spec.ts` suite passes (12 tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `segments.metrics()` to fetch live contact counts at the account level or by segment. Lets callers choose metrics, sort by date, and scope by segment IDs.

- **New Features**
  - Metrics supported: `all_contacts`, `subscribers`, `unsubscribers`.
  - Options: `dimensions=['segment']`, `filter.segmentId`, and sorting via `sortBy='date'` with `sortOrder='asc'|'desc'` (default `desc`).
  - Response includes `totals` and optional `data` rows; echoes `sort_by` and `sort_order`, and metric fields are typed based on requested metrics.

- **Bug Fixes**
  - Omits empty `metrics`, `dimensions`, and `filter.segmentId` from the query string to avoid invalid empty params and fall back to API defaults.

<sup>Written for commit 0e3a709d8dc84e5b9337dc84d39cfd06c18dc322. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1045?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

