### PR TITLE
chore: bump version to 6.19.0-preview-headless-dashboard.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.19.0-preview-headless-dashboard.0",
+  "version": "6.19.0-preview-headless-dashboard.1",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## Summary
Bumps the preview version following #1044's convention, now that `segments.metrics()` (#1045) and `emails.metrics()` (#1042) have landed on `preview-headless-dashboard`.

## Test plan
- [x] Version-only change, no code affected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `resend` preview version to 6.19.0-preview-headless-dashboard.1 to include `segments.metrics()` and `emails.metrics()` in the preview release. Version-only change; no code impact.

<sup>Written for commit 6fc99313e83a81f839c5c086b73e51d0e37dc2ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

