### PR TITLE
chore: add typecheck CI check

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,30 @@
+name: Typecheck
+on:
+  push:
+    branches:
+      - main
+      - canary
+  pull_request:
+permissions: 
+  contents: read
+  pull-requests: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  typecheck:
+    runs-on: depot-ubuntu-22.04-2
+    timeout-minutes: 10
+    container:
+      image: node:24-slim
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - name: pnpm setup
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320
+      - name: Install packages
+        run: pnpm install
+      - name: Run Typecheck
+        run: pnpm typecheck
+        env:
+          SKIP_ENV_VALIDATION: true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `Typecheck` CI workflow that runs the existing `pnpm typecheck` script (`tsc --noEmit`) on pushes to `main`/`canary` and on pull requests, mirroring the setup of the existing `Lint` and `Tests` workflows (same pinned actions, runner class, and container image).

## Note

`pnpm typecheck` currently fails on `canary`: TypeScript 6 reports a `moduleResolution: node10` deprecation error in `tsconfig.json`, and behind it there are pre-existing type errors in `src/resend.ts`, `src/batch/batch.ts`, `src/topics/topics.spec.ts`, `src/emails/receiving/receiving.spec.ts`, and `e2e/esbuild/index.ts`. A contributor PR fixing those is already in flight, so this check will turn green once that lands and this branch is rebased.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://resend.slack.com/archives/C0AG3A0TP7W/p1786021340584569?thread_ts=1786021340.584569&cid=C0AG3A0TP7W)

<div><a href="https://cursor.com/agents/bc-af759998-cb7b-5b3a-9ff6-a0eb15739fd5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af759998-cb7b-5b3a-9ff6-a0eb15739fd5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Typecheck CI workflow that runs `pnpm typecheck` (`tsc --noEmit`) on pushes to `main`/`canary` and on all PRs to catch TypeScript errors early.

- **New Features**
  - Triggers on push to `main` and `canary`, and on PRs.
  - Runs in a Node 24 slim container on `depot-ubuntu-22.04-2` with a 10-minute timeout and per-ref concurrency cancelation.
  - Installs with `pnpm` and runs `pnpm typecheck` with `SKIP_ENV_VALIDATION=true`.

- **Migration**
  - Heads-up: this currently fails on `canary` (TS 6 deprecation and pre-existing type errors). It will pass once the fix lands; rebase afterward.

<sup>Written for commit 5c8b7d2941765df0885955e5031d3e95428334b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

