### PR TITLE
feat: add monthly granularity to emails.metrics()

### DIFF
--- a/src/emails/interfaces/get-metrics.interface.ts
+++ b/src/emails/interfaces/get-metrics.interface.ts
@@ -26,7 +26,7 @@ export type EmailMetric =
 
 export type EmailMetricsDimension = 'period' | 'domain' | 'email';
 
-export type EmailMetricsGranularity = 'hourly' | 'daily' | 'weekly';
+export type EmailMetricsGranularity = 'hourly' | 'daily' | 'weekly' | 'monthly';
 
 export type EmailMetricsSortBy = 'date' | EmailMetric;
 


### PR DESCRIPTION
## Summary
- Adds `'monthly'` to `EmailMetricsGranularity`, matching the API's new `granularity=monthly` option on `GET /emails/metrics`.
- Straight passthrough (no client-side branching on this value), same as the existing `hourly`/`daily`/`weekly` options — no new test added, consistent with how those are covered.
- Depends on resend/resend-monorepo#7953 (and resend/resend-analytics#118) being live before `monthly` requests return correctly.
- Based on `preview-headless-dashboard` since that's the branch carrying `emails.metrics()`.

## Test plan
- [ ] `pnpm run lint` — passes
- [ ] `pnpm run typecheck` — pre-existing `moduleResolution=node10` deprecation warning unrelated to this change; no new errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds monthly granularity to `emails.metrics()` to match `GET /emails/metrics?granularity=monthly`. Passthrough change with no client-side branching.

- **Dependencies**
  - Requires backend support in `resend/resend-monorepo#7953` and `resend/resend-analytics#118` to be live for monthly results to return.

<sup>Written for commit 02d34a6515a00c1caeb8e45a558503b06c933859. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1050?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

