### PR TITLE
feat(webhooks): event endpoints

### DIFF
--- a/src/broadcasts/broadcasts.ts
+++ b/src/broadcasts/broadcasts.ts
@@ -1,4 +1,7 @@
-import { buildPaginationUrl } from '../common/utils/build-pagination-query';
+import {
+  buildPaginationQuery,
+  buildPaginationUrl,
+} from '../common/utils/build-pagination-query';
 import { render } from '../render';
 import type { Resend } from '../resend';
 import type {

--- a/src/webhooks/events/attempts/attempts.ts
+++ b/src/webhooks/events/attempts/attempts.ts
@@ -1,0 +1,26 @@
+import { buildPaginationQuery } from '../../../common/utils/build-pagination-query';
+import type { Resend } from '../../../resend';
+import type {
+  ListWebhookEventAttemptsOptions,
+  ListWebhookEventAttemptsResponse,
+  ListWebhookEventAttemptsResponseSuccess,
+} from '../../interfaces/list-webhook-event-attempts.interface';
+
+export class Attempts {
+  constructor(private readonly resend: Resend) {}
+
+  async list(
+    options: ListWebhookEventAttemptsOptions,
+  ): Promise<ListWebhookEventAttemptsResponse> {
+    const { webhookId, eventId } = options;
+
+    const queryString = buildPaginationQuery(options);
+    const url = queryString
+      ? `/webhooks/${webhookId}/events/${eventId}/attempts?${queryString}`
+      : `/webhooks/${webhookId}/events/${eventId}/attempts`;
+
+    const data =
+      await this.resend.get<ListWebhookEventAttemptsResponseSuccess>(url);
+    return data;
+  }
+}

--- a/src/webhooks/events/attempts/attempts.ts
+++ b/src/webhooks/events/attempts/attempts.ts
@@ -1,4 +1,4 @@
-import { buildPaginationQuery } from '../../../common/utils/build-pagination-query';
+import { buildPaginationUrl } from '../../../common/utils/build-pagination-query';
 import type { Resend } from '../../../resend';
 import type {
   ListWebhookEventAttemptsOptions,
@@ -14,10 +14,10 @@ export class Attempts {
   ): Promise<ListWebhookEventAttemptsResponse> {
     const { webhookId, eventId } = options;
 
-    const queryString = buildPaginationQuery(options);
-    const url = queryString
-      ? `/webhooks/${webhookId}/events/${eventId}/attempts?${queryString}`
-      : `/webhooks/${webhookId}/events/${eventId}/attempts`;
+    const url = buildPaginationUrl(
+      `/webhooks/${webhookId}/events/${eventId}/attempts`,
+      options,
+    );
 
     const data =
       await this.resend.get<ListWebhookEventAttemptsResponseSuccess>(url);

--- a/src/webhooks/events/events.ts
+++ b/src/webhooks/events/events.ts
@@ -1,0 +1,44 @@
+import { buildPaginationQuery } from '../../common/utils/build-pagination-query';
+import type { Resend } from '../../resend';
+import type {
+  GetWebhookEventOptions,
+  GetWebhookEventResponse,
+  GetWebhookEventResponseSuccess,
+} from '../interfaces/get-webhook-event.interface';
+import type {
+  ListWebhookEventsOptions,
+  ListWebhookEventsResponse,
+  ListWebhookEventsResponseSuccess,
+} from '../interfaces/list-webhook-events.interface';
+import { Attempts } from './attempts/attempts';
+
+export class Events {
+  readonly attempts: Attempts;
+
+  constructor(private readonly resend: Resend) {
+    this.attempts = new Attempts(resend);
+  }
+
+  async list(
+    options: ListWebhookEventsOptions,
+  ): Promise<ListWebhookEventsResponse> {
+    const { webhookId } = options;
+
+    const queryString = buildPaginationQuery(options);
+    const url = queryString
+      ? `/webhooks/${webhookId}/events?${queryString}`
+      : `/webhooks/${webhookId}/events`;
+
+    const data = await this.resend.get<ListWebhookEventsResponseSuccess>(url);
+    return data;
+  }
+
+  async get(options: GetWebhookEventOptions): Promise<GetWebhookEventResponse> {
+    const { webhookId, eventId } = options;
+
+    const data = await this.resend.get<GetWebhookEventResponseSuccess>(
+      `/webhooks/${webhookId}/events/${eventId}`,
+    );
+    return data;
+  }
+}

--- a/src/webhooks/events/events.ts
+++ b/src/webhooks/events/events.ts
@@ -1,4 +1,4 @@
-import { buildPaginationQuery } from '../../common/utils/build-pagination-query';
+import { buildPaginationUrl } from '../../common/utils/build-pagination-query';
 import type { Resend } from '../../resend';
 import type {
   GetWebhookEventOptions,
@@ -24,10 +24,7 @@ export class Events {
   ): Promise<ListWebhookEventsResponse> {
     const { webhookId } = options;
 
-    const queryString = buildPaginationQuery(options);
-    const url = queryString
-      ? `/webhooks/${webhookId}/events?${queryString}`
-      : `/webhooks/${webhookId}/events`;
+    const url = buildPaginationUrl(`/webhooks/${webhookId}/events`, options);
 
     const data = await this.resend.get<ListWebhookEventsResponseSuccess>(url);
     return data;

--- a/src/webhooks/interfaces/get-webhook-event.interface.ts
+++ b/src/webhooks/interfaces/get-webhook-event.interface.ts
@@ -1,5 +1,9 @@
 import type { Response } from '../../interfaces';
 import type { WebhookEventLogStatus } from './list-webhook-events.interface';
+import type {
+  WebhookEvent,
+  WebhookEventPayload,
+} from './webhook-event.interface';
 
 export interface GetWebhookEventOptions {
   webhookId: string;
@@ -9,11 +13,11 @@ export interface GetWebhookEventOptions {
 export interface GetWebhookEventResponseSuccess {
   object: 'webhook_event';
   id: string;
-  type: string;
+  type: WebhookEvent;
   created_at: string;
   status: WebhookEventLogStatus;
   next_attempt_at: string | null;
-  payload: unknown;
+  payload: WebhookEventPayload;
 }
 
 export type GetWebhookEventResponse = Response<GetWebhookEventResponseSuccess>;

--- a/src/webhooks/interfaces/get-webhook-event.interface.ts
+++ b/src/webhooks/interfaces/get-webhook-event.interface.ts
@@ -1,0 +1,19 @@
+import type { Response } from '../../interfaces';
+import type { WebhookEventLogStatus } from './list-webhook-events.interface';
+
+export interface GetWebhookEventOptions {
+  webhookId: string;
+  eventId: string;
+}
+
+export interface GetWebhookEventResponseSuccess {
+  object: 'webhook_event';
+  id: string;
+  type: string;
+  created_at: string;
+  status: WebhookEventLogStatus;
+  next_attempt_at: string | null;
+  payload: unknown;
+}
+
+export type GetWebhookEventResponse = Response<GetWebhookEventResponseSuccess>;

--- a/src/webhooks/interfaces/index.ts
+++ b/src/webhooks/interfaces/index.ts
@@ -9,6 +9,24 @@ export type {
   GetWebhookResponseSuccess,
 } from './get-webhook.interface';
 export type {
+  GetWebhookEventOptions,
+  GetWebhookEventResponse,
+  GetWebhookEventResponseSuccess,
+} from './get-webhook-event.interface';
+export type {
+  ListWebhookEventAttemptsOptions,
+  ListWebhookEventAttemptsResponse,
+  ListWebhookEventAttemptsResponseSuccess,
+  WebhookEventAttempt,
+} from './list-webhook-event-attempts.interface';
+export type {
+  ListWebhookEventsOptions,
+  ListWebhookEventsResponse,
+  ListWebhookEventsResponseSuccess,
+  WebhookEventLog,
+  WebhookEventLogStatus,
+} from './list-webhook-events.interface';
+export type {
   ListWebhooksOptions,
   ListWebhooksResponse,
   ListWebhooksResponseSuccess,

--- a/src/webhooks/interfaces/list-webhook-event-attempts.interface.ts
+++ b/src/webhooks/interfaces/list-webhook-event-attempts.interface.ts
@@ -1,0 +1,24 @@
+import type { Response } from '../../interfaces';
+
+export interface WebhookEventAttempt {
+  id: string;
+  http_status_code: number;
+  response: string;
+  sent_at: string;
+}
+
+export type ListWebhookEventAttemptsOptions = {
+  webhookId: string;
+  eventId: string;
+  limit?: number;
+  after?: string;
+};
+
+export type ListWebhookEventAttemptsResponseSuccess = {
+  object: 'list';
+  has_more: boolean;
+  data: WebhookEventAttempt[];
+};
+
+export type ListWebhookEventAttemptsResponse =
+  Response<ListWebhookEventAttemptsResponseSuccess>;

--- a/src/webhooks/interfaces/list-webhook-events.interface.ts
+++ b/src/webhooks/interfaces/list-webhook-events.interface.ts
@@ -1,0 +1,29 @@
+import type { Response } from '../../interfaces';
+
+export type WebhookEventLogStatus =
+  | 'success'
+  | 'pending'
+  | 'failed'
+  | 'attempting';
+
+export interface WebhookEventLog {
+  id: string;
+  type: string;
+  created_at: string;
+  status: WebhookEventLogStatus;
+}
+
+export type ListWebhookEventsOptions = {
+  webhookId: string;
+  limit?: number;
+  after?: string;
+};
+
+export type ListWebhookEventsResponseSuccess = {
+  object: 'list';
+  has_more: boolean;
+  data: WebhookEventLog[];
+};
+
+export type ListWebhookEventsResponse =
+  Response<ListWebhookEventsResponseSuccess>;

--- a/src/webhooks/webhooks.spec.ts
+++ b/src/webhooks/webhooks.spec.ts
@@ -9,6 +9,9 @@ import type {
   CreateWebhookResponseSuccess,
 } from './interfaces/create-webhook-options.interface';
 import type { GetWebhookResponseSuccess } from './interfaces/get-webhook.interface';
+import type { GetWebhookEventResponseSuccess } from './interfaces/get-webhook-event.interface';
+import type { ListWebhookEventAttemptsResponseSuccess } from './interfaces/list-webhook-event-attempts.interface';
+import type { ListWebhookEventsResponseSuccess } from './interfaces/list-webhook-events.interface';
 import type { ListWebhooksResponseSuccess } from './interfaces/list-webhooks.interface';
 import type { RemoveWebhookResponseSuccess } from './interfaces/remove-webhook.interface';
 import type {
@@ -213,6 +216,221 @@ describe('Webhooks', () => {
 
         expect(fetchMock).toHaveBeenCalledWith(
           'https://api.resend.com/webhooks?limit=10',
+          expect.objectContaining({
+            method: 'GET',
+            headers: expect.any(Headers),
+          }),
+        );
+      });
+    });
+  });
+
+  describe('events.list', () => {
+    const webhookId = '430eed87-632a-4ea6-90db-0aace67ec228';
+    const response: ListWebhookEventsResponseSuccess = {
+      has_more: false,
+      object: 'list',
+      data: [
+        {
+          id: 'msg_1srOrx2ZWZBpBUvZwXKQmoEYga2',
+          type: 'email.sent',
+          created_at: '2026-08-22T15:28:00.000Z',
+          status: 'success',
+        },
+      ],
+    };
+
+    describe('when no pagination options are provided', () => {
+      it('lists events', async () => {
+        mockSuccessResponse(response, {
+          headers: {},
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+        const result = await resend.webhooks.events.list({ webhookId });
+        expect(result).toEqual({
+          data: response,
+          error: null,
+          headers: {
+            'content-type': 'application/json',
+          },
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          `https://api.resend.com/webhooks/${webhookId}/events`,
+          expect.objectContaining({
+            method: 'GET',
+            headers: expect.any(Headers),
+          }),
+        );
+      });
+    });
+
+    describe('when pagination options are provided', () => {
+      it('passes limit and after params', async () => {
+        mockSuccessResponse(response, {
+          headers: {},
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+        await resend.webhooks.events.list({
+          webhookId,
+          limit: 10,
+          after: 'msg_1srOrx2ZWZBpBUvZwXKQmoEYga2',
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          `https://api.resend.com/webhooks/${webhookId}/events?limit=10&after=msg_1srOrx2ZWZBpBUvZwXKQmoEYga2`,
+          expect.objectContaining({
+            method: 'GET',
+            headers: expect.any(Headers),
+          }),
+        );
+      });
+    });
+  });
+
+  describe('events.get', () => {
+    const webhookId = '430eed87-632a-4ea6-90db-0aace67ec228';
+    const eventId = 'msg_1srOrx2ZWZBpBUvZwXKQmoEYga2';
+
+    it('gets an event', async () => {
+      const response: GetWebhookEventResponseSuccess = {
+        object: 'webhook_event',
+        id: eventId,
+        type: 'email.sent',
+        created_at: '2026-08-22T15:28:00.000Z',
+        status: 'success',
+        next_attempt_at: null,
+        payload: { type: 'email.sent', data: { email_id: 'abc' } },
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      const result = await resend.webhooks.events.get({ webhookId, eventId });
+      expect(result).toEqual({
+        data: response,
+        error: null,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        `https://api.resend.com/webhooks/${webhookId}/events/${eventId}`,
+        expect.objectContaining({
+          method: 'GET',
+          headers: expect.any(Headers),
+        }),
+      );
+    });
+
+    describe('when event not found', () => {
+      it('returns error', async () => {
+        const response: ErrorResponse = {
+          name: 'not_found',
+          message: 'Webhook event not found',
+          statusCode: 404,
+        };
+
+        fetchMock.mockOnce(JSON.stringify(response), {
+          status: 404,
+          headers: {
+            'content-type': 'application/json',
+          },
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+        const result = resend.webhooks.events.get({ webhookId, eventId });
+
+        await expect(result).resolves.toEqual({
+          data: null,
+          error: {
+            message: 'Webhook event not found',
+            name: 'not_found',
+            statusCode: 404,
+          },
+          headers: {
+            'content-type': 'application/json',
+          },
+        });
+      });
+    });
+  });
+
+  describe('events.attempts.list', () => {
+    const webhookId = '430eed87-632a-4ea6-90db-0aace67ec228';
+    const eventId = 'msg_1srOrx2ZWZBpBUvZwXKQmoEYga2';
+    const response: ListWebhookEventAttemptsResponseSuccess = {
+      has_more: false,
+      object: 'list',
+      data: [
+        {
+          id: 'atmpt_2ZbUCwvGmIT4mLIN6d3Yz0Ainbd',
+          http_status_code: 200,
+          response: '{"ok":true}',
+          sent_at: '2026-08-22T15:28:05.000Z',
+        },
+      ],
+    };
+
+    describe('when no pagination options are provided', () => {
+      it('lists attempts', async () => {
+        mockSuccessResponse(response, {
+          headers: {},
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+        const result = await resend.webhooks.events.attempts.list({
+          webhookId,
+          eventId,
+        });
+        expect(result).toEqual({
+          data: response,
+          error: null,
+          headers: {
+            'content-type': 'application/json',
+          },
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          `https://api.resend.com/webhooks/${webhookId}/events/${eventId}/attempts`,
+          expect.objectContaining({
+            method: 'GET',
+            headers: expect.any(Headers),
+          }),
+        );
+      });
+    });
+
+    describe('when pagination options are provided', () => {
+      it('passes limit and after params', async () => {
+        mockSuccessResponse(response, {
+          headers: {},
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+        await resend.webhooks.events.attempts.list({
+          webhookId,
+          eventId,
+          limit: 10,
+          after: 'atmpt_2ZbUCwvGmIT4mLIN6d3Yz0Ainbd',
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          `https://api.resend.com/webhooks/${webhookId}/events/${eventId}/attempts?limit=10&after=atmpt_2ZbUCwvGmIT4mLIN6d3Yz0Ainbd`,
           expect.objectContaining({
             method: 'GET',
             headers: expect.any(Headers),

--- a/src/webhooks/webhooks.spec.ts
+++ b/src/webhooks/webhooks.spec.ts
@@ -304,7 +304,18 @@ describe('Webhooks', () => {
         created_at: '2026-08-22T15:28:00.000Z',
         status: 'success',
         next_attempt_at: null,
-        payload: { type: 'email.sent', data: { email_id: 'abc' } },
+        payload: {
+          type: 'email.sent',
+          created_at: '2026-08-22T15:28:00.000Z',
+          data: {
+            created_at: '2026-08-22T15:28:00.000Z',
+            email_id: 'abc',
+            message_id: '<abc@resend.dev>',
+            from: 'bu@resend.com',
+            to: ['zeno@resend.com'],
+            subject: 'Hello World',
+          },
+        },
       };
 
       fetchMock.mockOnce(JSON.stringify(response), {

--- a/src/webhooks/webhooks.ts
+++ b/src/webhooks/webhooks.ts
@@ -1,6 +1,7 @@
 import { Webhook } from 'standardwebhooks';
 import { buildPaginationUrl } from '../common/utils/build-pagination-query';
 import type { Resend } from '../resend';
+import { Events } from './events/events';
 import type {
   CreateWebhookOptions,
   CreateWebhookRequestOptions,
@@ -40,7 +41,11 @@ interface VerifyWebhookOptions {
 }
 
 export class Webhooks {
-  constructor(private readonly resend: Resend) {}
+  readonly events: Events;
+
+  constructor(private readonly resend: Resend) {
+    this.events = new Events(resend);
+  }
 
   async create(
     payload: CreateWebhookOptions,


### PR DESCRIPTION
```ts
resend.webhooks.events.list({
  webhookId: string,
  limit?: number,
  after?: string,
});

resend.webhooks.events.get({
  webhookId: string,
  eventId: string,
});

resend.webhooks.events.attempts.list({
  webhookId: string,
  eventId: string,
  limit?: number,
  after?: string,
});
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds webhook event endpoints to the `resend` SDK to list events, fetch a single event, and view delivery attempts with pagination. Exposes `resend.webhooks.events` with nested `events.attempts`; event detail payloads now use explicit types and include `next_attempt_at`.

- **New Features**
  - `resend.webhooks.events.list({ webhookId, limit?, after? })`
  - `resend.webhooks.events.get({ webhookId, eventId })`
  - `resend.webhooks.events.attempts.list({ webhookId, eventId, limit?, after? })`

- **Refactors**
  - Typed models for events and attempts: `WebhookEvent`, `WebhookEventPayload`, `WebhookEventLog`, `WebhookEventAttempt`, `WebhookEventLogStatus`.
  - Use shared `buildPaginationUrl` for `limit`/`after` across listing endpoints.
  - Tests for listing, pagination, fetching, attempts, and 404 errors.

<sup>Written for commit 8d97abe9e76972eb002488bb2c8e228c12827061. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1051?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

