### PR TITLE
fix(emails): flatten metrics filter query params

### DIFF
--- a/src/emails/emails.spec.ts
+++ b/src/emails/emails.spec.ts
@@ -955,11 +955,11 @@ describe('Emails', () => {
         },
       });
       expect(fetchMock.mock.calls[0][0]).toBe(
-        'https://api.resend.com/emails/metrics?start_date=2026-07-01&end_date=2026-07-08&timezone=America%2FNew_York&granularity=daily&metrics=sent%2Cdelivered%2Copen_rate&dimensions=period%2Cdomain&filter%5Bdomain_id%5D=d91cd9bd-1176-4f47-2a4b-fce2d5399cbf',
+        'https://api.resend.com/emails/metrics?start_date=2026-07-01&end_date=2026-07-08&timezone=America%2FNew_York&granularity=daily&metrics=sent%2Cdelivered%2Copen_rate&dimensions=period%2Cdomain&domain_id=d91cd9bd-1176-4f47-2a4b-fce2d5399cbf',
       );
     });
 
-    it('calls endpoint passing the email dimension and filter[email_id]', async () => {
+    it('calls endpoint passing the email dimension and email_id', async () => {
       const response: GetEmailsMetricsResponseSuccess = {
         object: 'metrics',
         start_date: '2026-07-01T00:00:00.000Z',
@@ -1005,7 +1005,7 @@ describe('Emails', () => {
         },
       });
       expect(fetchMock.mock.calls[0][0]).toBe(
-        'https://api.resend.com/emails/metrics?start_date=2026-07-01&end_date=2026-07-08&timezone=America%2FNew_York&granularity=daily&metrics=sent%2Cdelivered%2Copen_rate&dimensions=period%2Cemail&filter%5Bemail_id%5D=4dd369bc-aa82-4ff3-97de-514ae3000ee0',
+        'https://api.resend.com/emails/metrics?start_date=2026-07-01&end_date=2026-07-08&timezone=America%2FNew_York&granularity=daily&metrics=sent%2Cdelivered%2Copen_rate&dimensions=period%2Cemail&email_id=4dd369bc-aa82-4ff3-97de-514ae3000ee0',
       );
     });
 

--- a/src/emails/emails.ts
+++ b/src/emails/emails.ts
@@ -124,8 +124,8 @@ function buildMetricsQuery(options: GetEmailsMetricsOptions) {
     granularity: options.granularity,
     metrics: options.metrics?.join(','),
     dimensions: options.dimensions?.join(','),
-    'filter[domain_id]': options.filter?.domainId?.join(','),
-    'filter[email_id]': options.filter?.emailId?.join(','),
+    domain_id: options.filter?.domainId?.join(','),
+    email_id: options.filter?.emailId?.join(','),
     sort_by: options.sortBy,
     sort_order: options.sortOrder,
   };


### PR DESCRIPTION
## Summary
- The public-api's `/emails/metrics` endpoint now accepts `domain_id`/`email_id` as flat query params instead of `filter[domain_id]`/`filter[email_id]` (resend/resend-monorepo#7974).
- Updates `buildMetricsQuery` in `src/emails/emails.ts` to send the flat params. The public SDK option shape (`filter: { domainId, emailId }`) is unchanged — only the wire format sent to the API changed.

## Test plan
- [x] Updated `emails.spec.ts` expected request URLs to the flat param format
- [x] `vitest run src/emails/emails.spec.ts` — 33 passing
- [x] `biome check` — clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Flattened `/emails/metrics` query params to use `domain_id` and `email_id` instead of `filter[domain_id]` and `filter[email_id]`, matching the public API contract. Updated `buildMetricsQuery` to send the flat params; the SDK option shape (`filter: { domainId, emailId }`) remains unchanged.

<sup>Written for commit 2c23260b87b07c5d2be9dedf34add1768cfdcbc2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

