### PR TITLE
fix(segments): flatten metrics filter query params

### DIFF
--- a/src/segments/segments.spec.ts
+++ b/src/segments/segments.spec.ts
@@ -286,7 +286,7 @@ describe('Segments', () => {
       );
     });
 
-    it('calls endpoint passing metrics, dimensions and filter[segment_id]', async () => {
+    it('calls endpoint passing metrics, dimensions and segment_id', async () => {
       const response: GetSegmentsMetricsResponseSuccess = {
         object: 'segments_metrics',
         metrics: ['all_contacts'],
@@ -325,7 +325,7 @@ describe('Segments', () => {
       });
 
       expect(fetchMock).toHaveBeenCalledWith(
-        'https://api.resend.com/segments/metrics?metrics=all_contacts&dimensions=segment&filter%5Bsegment_id%5D=78261eea-8f8b-4381-83c6-79fa7120f1cf',
+        'https://api.resend.com/segments/metrics?metrics=all_contacts&dimensions=segment&segment_id=78261eea-8f8b-4381-83c6-79fa7120f1cf',
         expect.objectContaining({
           method: 'GET',
           headers: expect.any(Headers),

--- a/src/segments/segments.ts
+++ b/src/segments/segments.ts
@@ -79,7 +79,7 @@ function buildMetricsQuery(options: GetSegmentsMetricsOptions) {
   const params: Record<string, string | undefined> = {
     metrics: options.metrics?.join(','),
     dimensions: options.dimensions?.join(','),
-    'filter[segment_id]': options.filter?.segmentId?.join(','),
+    segment_id: options.filter?.segmentId?.join(','),
     sort_by: options.sortBy,
     sort_order: options.sortOrder,
   };


### PR DESCRIPTION
## Summary
- The public-api's `/segments/metrics` endpoint now accepts `segment_id` as a flat query param instead of `filter[segment_id]` (resend/resend-monorepo#7974).
- Updates `buildMetricsQuery` in `src/segments/segments.ts` to send the flat param. The public SDK option shape (`filter: { segmentId }`) is unchanged — only the wire format sent to the API changed.

## Test plan
- [x] Updated `segments.spec.ts` expected request URL to the flat param format
- [x] `vitest run src/segments/segments.spec.ts` — 15 passing
- [x] `biome check` — clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Flattened the `segment_id` query param for `/segments/metrics`, replacing `filter[segment_id]`, to match the public API. SDK option shape stays the same; only the wire format changes.

- **Bug Fixes**
  - Updated `buildMetricsQuery` to send `segment_id`.
  - Adjusted `segments.spec.ts` to expect the flat param.

<sup>Written for commit 702c971f5ff960864478779e14efcc11c409de45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1053?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

