### PR TITLE
chore: bump version to 6.19.0-preview-headless-dashboard.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.19.0-preview-headless-dashboard.1",
+  "version": "6.19.0-preview-headless-dashboard.2",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## Summary
- Bump version to `6.19.0-preview-headless-dashboard.2`
