### PR TITLE
chore: bump version to 6.19.0-preview-headless-dashboard.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.19.0-preview-headless-dashboard.2",
+  "version": "6.19.0-preview-headless-dashboard.3",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## Summary
- Bump version to `6.19.0-preview-headless-dashboard.3`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `package.json` version from `6.19.0-preview-headless-dashboard.2` to `6.19.0-preview-headless-dashboard.3` to publish the next headless dashboard preview.

<sup>Written for commit 6a853192287076ccd6f0e2a7e6ad2850a5346be9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

