### PR TITLE
feat: buildPaginationUrl helper to simplify code

### DIFF
--- a/src/api-keys/api-keys.ts
+++ b/src/api-keys/api-keys.ts
@@ -1,4 +1,4 @@
-import { buildPaginationQuery } from '../common/utils/build-pagination-query';
+import { buildPaginationUrl } from '../common/utils/build-pagination-query';
 import type { Resend } from '../resend';
 import type {
   CreateApiKeyOptions,
@@ -33,8 +33,7 @@ export class ApiKeys {
   }
 
   async list(options: ListApiKeysOptions = {}): Promise<ListApiKeysResponse> {
-    const queryString = buildPaginationQuery(options);
-    const url = queryString ? `/api-keys?${queryString}` : '/api-keys';
+    const url = buildPaginationUrl('/api-keys', options);
 
     const data = await this.resend.get<ListApiKeysResponseSuccess>(url);
     return data;

--- a/src/broadcasts/broadcasts.ts
+++ b/src/broadcasts/broadcasts.ts
@@ -1,7 +1,4 @@
-import {
-  buildPaginationQuery,
-  buildPaginationUrl,
-} from '../common/utils/build-pagination-query';
+import { buildPaginationUrl } from '../common/utils/build-pagination-query';
 import { render } from '../render';
 import type { Resend } from '../resend';
 import type {

--- a/src/broadcasts/broadcasts.ts
+++ b/src/broadcasts/broadcasts.ts
@@ -1,4 +1,7 @@
-import { buildPaginationQuery } from '../common/utils/build-pagination-query';
+import {
+  buildPaginationQuery,
+  buildPaginationUrl,
+} from '../common/utils/build-pagination-query';
 import { render } from '../render';
 import type { Resend } from '../resend';
 import type {
@@ -75,8 +78,7 @@ export class Broadcasts {
   async list(
     options: ListBroadcastsOptions = {},
   ): Promise<ListBroadcastsResponse> {
-    const queryString = buildPaginationQuery(options);
-    const url = queryString ? `/broadcasts?${queryString}` : '/broadcasts';
+    const url = buildPaginationUrl('/broadcasts', options);
 
     const data = await this.resend.get<ListBroadcastsResponseSuccess>(url);
     return data;

--- a/src/common/utils/build-pagination-query.ts
+++ b/src/common/utils/build-pagination-query.ts
@@ -1,5 +1,14 @@
 import type { PaginationOptions } from '../interfaces/pagination-options.interface';
 
+export function buildPaginationUrl(
+  base: string,
+  options: PaginationOptions,
+): string {
+  const queryString = buildPaginationQuery(options);
+
+  return queryString ? `${base}?${queryString}` : base;
+}
+
 /**
  * Builds a query string from pagination options
  * @param options - Pagination options containing limit and either after or before (but not both)

--- a/src/contact-properties/contact-properties.ts
+++ b/src/contact-properties/contact-properties.ts
@@ -1,4 +1,4 @@
-import { buildPaginationQuery } from '../common/utils/build-pagination-query';
+import { buildPaginationUrl } from '../common/utils/build-pagination-query';
 import {
   parseContactPropertyFromApi,
   parseContactPropertyToApiOptions,
@@ -45,10 +45,7 @@ export class ContactProperties {
   async list(
     options: ListContactPropertiesOptions = {},
   ): Promise<ListContactPropertiesResponse> {
-    const queryString = buildPaginationQuery(options);
-    const url = queryString
-      ? `/contact-properties?${queryString}`
-      : '/contact-properties';
+    const url = buildPaginationUrl('/contact-properties', options);
 
     const response =
       await this.resend.get<ListContactPropertiesResponseSuccess>(url);

--- a/src/contacts/contacts.ts
+++ b/src/contacts/contacts.ts
@@ -1,4 +1,4 @@
-import { buildPaginationQuery } from '../common/utils/build-pagination-query';
+import { buildPaginationUrl } from '../common/utils/build-pagination-query';
 import type { Resend } from '../resend';
 import { ContactImports } from './imports/contact-imports';
 import type {
@@ -104,16 +104,12 @@ export class Contacts {
   async list(options: ListContactsOptions = {}): Promise<ListContactsResponse> {
     const segmentId = options.segmentId ?? options.audienceId;
     if (!segmentId) {
-      const queryString = buildPaginationQuery(options);
-      const url = queryString ? `/contacts?${queryString}` : '/contacts';
+      const url = buildPaginationUrl('/contacts', options);
       const data = await this.resend.get<ListContactsResponseSuccess>(url);
       return data;
     }
 
-    const queryString = buildPaginationQuery(options);
-    const url = queryString
-      ? `/segments/${segmentId}/contacts?${queryString}`
-      : `/segments/${segmentId}/contacts`;
+    const url = buildPaginationUrl(`/segments/${segmentId}/contacts`, options);
     const data = await this.resend.get<ListContactsResponseSuccess>(url);
     return data;
   }

--- a/src/contacts/segments/contact-segments.ts
+++ b/src/contacts/segments/contact-segments.ts
@@ -1,4 +1,4 @@
-import { buildPaginationQuery } from '../../common/utils/build-pagination-query';
+import { buildPaginationUrl } from '../../common/utils/build-pagination-query';
 import type { Resend } from '../../resend';
 import type {
   AddContactSegmentOptions,
@@ -35,10 +35,7 @@ export class ContactSegments {
     }
 
     const identifier = options.email ? options.email : options.contactId;
-    const queryString = buildPaginationQuery(options);
-    const url = queryString
-      ? `/contacts/${identifier}/segments?${queryString}`
-      : `/contacts/${identifier}/segments`;
+    const url = buildPaginationUrl(`/contacts/${identifier}/segments`, options);
 
     const data = await this.resend.get<ListContactSegmentsResponseSuccess>(url);
     return data;

--- a/src/contacts/topics/contact-topics.ts
+++ b/src/contacts/topics/contact-topics.ts
@@ -1,4 +1,4 @@
-import { buildPaginationQuery } from '../../common/utils/build-pagination-query';
+import { buildPaginationUrl } from '../../common/utils/build-pagination-query';
 import type { Resend } from '../../resend';
 import type {
   ListContactTopicsOptions,
@@ -52,10 +52,7 @@ export class ContactTopics {
     }
 
     const identifier = options.email ? options.email : options.id;
-    const queryString = buildPaginationQuery(options);
-    const url = queryString
-      ? `/contacts/${identifier}/topics?${queryString}`
-      : `/contacts/${identifier}/topics`;
+    const url = buildPaginationUrl(`/contacts/${identifier}/topics`, options);
 
     return this.resend.get<ListContactTopicsResponseSuccess>(url);
   }

--- a/src/domains/domains.ts
+++ b/src/domains/domains.ts
@@ -1,4 +1,4 @@
-import { buildPaginationQuery } from '../common/utils/build-pagination-query';
+import { buildPaginationUrl } from '../common/utils/build-pagination-query';
 import { parseDomainToApiOptions } from '../common/utils/parse-domain-to-api-options';
 import type { Resend } from '../resend';
 import { DomainClaims } from './claims/domain-claims';
@@ -51,8 +51,7 @@ export class Domains {
   }
 
   async list(options: ListDomainsOptions = {}): Promise<ListDomainsResponse> {
-    const queryString = buildPaginationQuery(options);
-    const url = queryString ? `/domains?${queryString}` : '/domains';
+    const url = buildPaginationUrl('/domains', options);
 
     const data = await this.resend.get<ListDomainsResponseSuccess>(url);
     return data;

--- a/src/emails/attachments/attachments.ts
+++ b/src/emails/attachments/attachments.ts
@@ -1,4 +1,4 @@
-import { buildPaginationQuery } from '../../common/utils/build-pagination-query';
+import { buildPaginationUrl } from '../../common/utils/build-pagination-query';
 import type { Resend } from '../../resend';
 import type {
   GetAttachmentOptions,
@@ -27,10 +27,7 @@ export class Attachments {
   ): Promise<ListAttachmentsResponse> {
     const { emailId } = options;
 
-    const queryString = buildPaginationQuery(options);
-    const url = queryString
-      ? `/emails/${emailId}/attachments?${queryString}`
-      : `/emails/${emailId}/attachments`;
+    const url = buildPaginationUrl(`/emails/${emailId}/attachments`, options);
 
     const data = await this.resend.get<ListAttachmentsResponseSuccess>(url);
 

--- a/src/emails/emails.ts
+++ b/src/emails/emails.ts
@@ -1,4 +1,4 @@
-import { buildPaginationQuery } from '../common/utils/build-pagination-query';
+import { buildPaginationUrl } from '../common/utils/build-pagination-query';
 import { parseEmailToApiOptions } from '../common/utils/parse-email-to-api-options';
 import { render } from '../render';
 import type { Resend } from '../resend';
@@ -73,8 +73,7 @@ export class Emails {
   }
 
   async list(options: ListEmailsOptions = {}): Promise<ListEmailsResponse> {
-    const queryString = buildPaginationQuery(options);
-    const url = queryString ? `/emails?${queryString}` : '/emails';
+    const url = buildPaginationUrl('/emails', options);
 
     const data = await this.resend.get<ListEmailsResponseSuccess>(url);
 

--- a/src/emails/receiving/attachments/attachments.ts
+++ b/src/emails/receiving/attachments/attachments.ts
@@ -1,4 +1,4 @@
-import { buildPaginationQuery } from '../../../common/utils/build-pagination-query';
+import { buildPaginationUrl } from '../../../common/utils/build-pagination-query';
 import type { Resend } from '../../../resend';
 import type {
   GetAttachmentOptions,
@@ -27,10 +27,10 @@ export class Attachments {
   ): Promise<ListAttachmentsResponse> {
     const { emailId } = options;
 
-    const queryString = buildPaginationQuery(options);
-    const url = queryString
-      ? `/emails/receiving/${emailId}/attachments?${queryString}`
-      : `/emails/receiving/${emailId}/attachments`;
+    const url = buildPaginationUrl(
+      `/emails/receiving/${emailId}/attachments`,
+      options,
+    );
 
     const data = await this.resend.get<ListAttachmentsResponseSuccess>(url);
 

--- a/src/emails/receiving/receiving.ts
+++ b/src/emails/receiving/receiving.ts
@@ -1,5 +1,5 @@
 import PostalMime from 'postal-mime';
-import { buildPaginationQuery } from '../../common/utils/build-pagination-query';
+import { buildPaginationUrl } from '../../common/utils/build-pagination-query';
 import type { Resend } from '../../resend';
 import { Attachments } from './attachments/attachments';
 import type {
@@ -49,10 +49,7 @@ export class Receiving {
   async list(
     options: ListReceivingEmailsOptions = {},
   ): Promise<ListReceivingEmailsResponse> {
-    const queryString = buildPaginationQuery(options);
-    const url = queryString
-      ? `/emails/receiving?${queryString}`
-      : '/emails/receiving';
+    const url = buildPaginationUrl('/emails/receiving', options);
 
     const data = await this.resend.get<ListReceivingEmailsResponseSuccess>(url);
 

--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -1,4 +1,7 @@
-import { buildPaginationQuery } from '../common/utils/build-pagination-query';
+import {
+  buildPaginationQuery,
+  buildPaginationUrl,
+} from '../common/utils/build-pagination-query';
 import { parseEventToApiOptions } from '../common/utils/parse-automation-to-api-options';
 import type { Resend } from '../resend';
 import type {
@@ -59,9 +62,7 @@ export class Events {
   }
 
   async list(options: ListEventsOptions = {}): Promise<ListEventsResponse> {
-    const queryString = buildPaginationQuery(options);
-    const url = queryString ? `/events?${queryString}` : '/events';
-
+    const url = buildPaginationUrl('/events', options);
     const data = await this.resend.get<ListEventsResponseSuccess>(url);
     return data;
   }

--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -1,7 +1,4 @@
-import {
-  buildPaginationQuery,
-  buildPaginationUrl,
-} from '../common/utils/build-pagination-query';
+import { buildPaginationUrl } from '../common/utils/build-pagination-query';
 import { parseEventToApiOptions } from '../common/utils/parse-automation-to-api-options';
 import type { Resend } from '../resend';
 import type {

--- a/src/logs/logs.ts
+++ b/src/logs/logs.ts
@@ -1,4 +1,4 @@
-import { buildPaginationQuery } from '../common/utils/build-pagination-query';
+import { buildPaginationUrl } from '../common/utils/build-pagination-query';
 import type { Resend } from '../resend';
 import type {
   GetLogResponse,
@@ -14,8 +14,7 @@ export class Logs {
   constructor(private readonly resend: Resend) {}
 
   async list(options: ListLogsOptions = {}): Promise<ListLogsResponse> {
-    const queryString = buildPaginationQuery(options);
-    const url = queryString ? `/logs?${queryString}` : '/logs';
+    const url = buildPaginationUrl('/logs', options);
     const data = await this.resend.get<ListLogsResponseSuccess>(url);
     return data;
   }

--- a/src/oauth-grants/oauth-grants.ts
+++ b/src/oauth-grants/oauth-grants.ts
@@ -1,4 +1,4 @@
-import { buildPaginationQuery } from '../common/utils/build-pagination-query';
+import { buildPaginationUrl } from '../common/utils/build-pagination-query';
 import type { Resend } from '../resend';
 import type {
   ListOAuthGrantsOptions,
@@ -16,8 +16,7 @@ export class OAuthGrants {
   async list(
     options: ListOAuthGrantsOptions = {},
   ): Promise<ListOAuthGrantsResponse> {
-    const queryString = buildPaginationQuery(options);
-    const url = queryString ? `/oauth/grants?${queryString}` : '/oauth/grants';
+    const url = buildPaginationUrl('/oauth/grants', options);
 
     const data = await this.resend.get<ListOAuthGrantsResponseSuccess>(url);
     return data;

--- a/src/segments/segments.ts
+++ b/src/segments/segments.ts
@@ -1,4 +1,4 @@
-import { buildPaginationQuery } from '../common/utils/build-pagination-query';
+import { buildPaginationUrl } from '../common/utils/build-pagination-query';
 import type { Resend } from '../resend';
 import type {
   CreateSegmentOptions,
@@ -36,8 +36,7 @@ export class Segments {
   }
 
   async list(options: ListSegmentsOptions = {}): Promise<ListSegmentsResponse> {
-    const queryString = buildPaginationQuery(options);
-    const url = queryString ? `/segments?${queryString}` : '/segments';
+    const url = buildPaginationUrl('/segments', options);
 
     const data = await this.resend.get<ListSegmentsResponseSuccess>(url);
     return data;

--- a/src/webhooks/webhooks.ts
+++ b/src/webhooks/webhooks.ts
@@ -1,5 +1,5 @@
 import { Webhook } from 'standardwebhooks';
-import { buildPaginationQuery } from '../common/utils/build-pagination-query';
+import { buildPaginationUrl } from '../common/utils/build-pagination-query';
 import type { Resend } from '../resend';
 import type {
   CreateWebhookOptions,
@@ -63,8 +63,7 @@ export class Webhooks {
   }
 
   async list(options: ListWebhooksOptions = {}): Promise<ListWebhooksResponse> {
-    const queryString = buildPaginationQuery(options);
-    const url = queryString ? `/webhooks?${queryString}` : '/webhooks';
+    const url = buildPaginationUrl('/webhooks', options);
 
     const data = await this.resend.get<ListWebhooksResponseSuccess>(url);
     return data;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Introduces `buildPaginationUrl` to build paginated URLs and updates list methods to use it. Removes duplicate query logic and fixes minor type issues without changing behavior.

- **Refactors**
  - Added `buildPaginationUrl(base, options)` in `src/common/utils/build-pagination-query.ts` (wraps `buildPaginationQuery`).
  - Updated list endpoints in `api-keys`, `broadcasts`, `contact-properties`, `contacts` (incl. `segments` and `topics`), `domains`, `emails` (incl. `receiving/attachments`), `events`, `logs`, `oauth-grants`, `segments`, and `webhooks` to use the helper, and aligned typings with `PaginationOptions`.

<sup>Written for commit 8fe9d407db5bfcd6e8cd4401bd9be33cae57697e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

