### PR TITLE
chore: migrate biome config from deprecated recommended field to preset

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -22,7 +22,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "style": {
         "noParameterAssign": "error",
         "useAsConstAssertion": "error",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Running `biome check` printed a deprecation warning:

> The use of the recommended field has been deprecated, and will removed in the next major version of Biome. Use preset instead.

This applies the official migration (`biome migrate --write`), which replaces `"recommended": true` with `"preset": "recommended"` in `biome.jsonc`.

## Verification

- `pnpm run lint` now checks all 238 files cleanly with no deprecation warning and no rule changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://resend.slack.com/archives/C0AG3A0TP7W/p1786128549012549?thread_ts=1786128549.012549&cid=C0AG3A0TP7W)

<div><a href="https://cursor.com/agents/bc-5ad09e81-0fc9-5347-b8ad-ffd81e72e62e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ad09e81-0fc9-5347-b8ad-ffd81e72e62e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated `biome.jsonc` to use `preset: "recommended"` instead of the deprecated `recommended: true`. This removes the `biome check` deprecation warning with no rule changes; `pnpm run lint` passes clean.

<sup>Written for commit b0c3e5d2fe6a637fef746d9bd06981d5b2b48bb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

