### PR TITLE
chore: bump to 6.19.0-preview-headless-dashboard.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.19.0-preview-headless-dashboard.3",
+  "version": "6.19.0-preview-headless-dashboard.4",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumped the `resend` package version to 6.19.0-preview-headless-dashboard.4 to publish the next headless-dashboard preview. No code changes; version update only.

<sup>Written for commit f5212b2224afaeb49d8aa23092eeff5880d3e8ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

