### PR TITLE
feat: add broadcasts.cancel() method

### DIFF
--- a/src/broadcasts/broadcasts.spec.ts
+++ b/src/broadcasts/broadcasts.spec.ts
@@ -2,6 +2,7 @@ import createFetchMock from 'vitest-fetch-mock';
 import type { ErrorResponse } from '../interfaces';
 import { Resend } from '../resend';
 import { mockSuccessResponse } from '../test-utils/mock-fetch';
+import type { CancelBroadcastResponseSuccess } from './interfaces/cancel-broadcast.interface';
 import type {
   CreateBroadcastOptions,
   CreateBroadcastResponseSuccess,
@@ -980,6 +981,76 @@ describe('Broadcasts', () => {
           },
         }
       `);
+    });
+  });
+
+  describe('cancel', () => {
+    it('cancels a broadcast', async () => {
+      const id = 'b01e0de9-7c27-4a53-bf38-2e3f98389a65';
+      const response: CancelBroadcastResponseSuccess = {
+        object: 'broadcast',
+        id,
+      };
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      await expect(
+        resend.broadcasts.cancel(id),
+      ).resolves.toMatchInlineSnapshot(`
+        {
+          "data": {
+            "id": "b01e0de9-7c27-4a53-bf38-2e3f98389a65",
+            "object": "broadcast",
+          },
+          "error": null,
+          "headers": {
+            "content-type": "application/json",
+          },
+        }
+      `);
+    });
+
+    describe('when broadcast is not cancelable', () => {
+      it('returns error', async () => {
+        const response: ErrorResponse = {
+          name: 'validation_error',
+          statusCode: 403,
+          message: 'Only queued or scheduled broadcasts can be canceled',
+        };
+
+        fetchMock.mockOnce(JSON.stringify(response), {
+          status: 403,
+          headers: {
+            'content-type': 'application/json',
+          },
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+        const result = resend.broadcasts.cancel(
+          '559ac32e-9ef5-46fb-82a1-b76b840c0f7b',
+        );
+
+        await expect(result).resolves.toMatchInlineSnapshot(`
+          {
+            "data": null,
+            "error": {
+              "message": "Only queued or scheduled broadcasts can be canceled",
+              "name": "validation_error",
+              "statusCode": 403,
+            },
+            "headers": {
+              "content-type": "application/json",
+            },
+          }
+        `);
+      });
     });
   });
 

--- a/src/broadcasts/broadcasts.ts
+++ b/src/broadcasts/broadcasts.ts
@@ -5,6 +5,10 @@ import {
 import { render } from '../render';
 import type { Resend } from '../resend';
 import type {
+  CancelBroadcastResponse,
+  CancelBroadcastResponseSuccess,
+} from './interfaces/cancel-broadcast.interface';
+import type {
   CreateBroadcastOptions,
   CreateBroadcastRequestOptions,
 } from './interfaces/create-broadcast-options.interface';
@@ -125,6 +129,13 @@ export class Broadcasts {
   async remove(id: string): Promise<RemoveBroadcastResponse> {
     const data = await this.resend.delete<RemoveBroadcastResponseSuccess>(
       `/broadcasts/${id}`,
+    );
+    return data;
+  }
+
+  async cancel(id: string): Promise<CancelBroadcastResponse> {
+    const data = await this.resend.post<CancelBroadcastResponseSuccess>(
+      `/broadcasts/${id}/cancel`,
     );
     return data;
   }

--- a/src/broadcasts/interfaces/cancel-broadcast.interface.ts
+++ b/src/broadcasts/interfaces/cancel-broadcast.interface.ts
@@ -1,0 +1,8 @@
+import type { Response } from '../../interfaces';
+import type { Broadcast } from './broadcast';
+
+export interface CancelBroadcastResponseSuccess extends Pick<Broadcast, 'id'> {
+  object: 'broadcast';
+}
+
+export type CancelBroadcastResponse = Response<CancelBroadcastResponseSuccess>;

--- a/src/broadcasts/interfaces/index.ts
+++ b/src/broadcasts/interfaces/index.ts
@@ -1,4 +1,5 @@
 export * from './broadcast';
+export * from './cancel-broadcast.interface';
 export * from './create-broadcast-options.interface';
 export * from './get-broadcast.interface';
 export * from './get-broadcast-metrics.interface';


### PR DESCRIPTION
## Summary
- Adds `broadcasts.cancel(id)`, calling `POST /broadcasts/:id/cancel` to cancel a queued or scheduled broadcast.
- Returns a `validation_error`/403 if the broadcast is `draft`, `sent`, or `failed`.
- Mirrors `emails.cancel()`'s shape exactly (no body, no options param) since the underlying endpoint is the same kind of simple id-only action.

Companion API docs: resend/resend-docs#(branch `broadcasts-cancel`, based on `main`).

## Test plan
- [x] `pnpm typecheck` — clean
- [x] lint (scoped to touched files — the full repo-wide lint script chokes on committed `.next` build artifacts under `e2e/`, unrelated to this change)
- [x] `pnpm test` — 28/28 passing in `broadcasts.spec.ts` (26 existing + 2 new: success case, 403 not-cancelable case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `broadcasts.cancel(id)` to cancel queued or scheduled broadcasts via `POST /broadcasts/:id/cancel`, matching `emails.cancel()`.

- **New Features**
  - Cancels by ID with no body/options; returns `validation_error` (403) if the broadcast is `draft`, `sent`, or `failed`.
  - Adds `CancelBroadcastResponse` types and exports under `src/broadcasts/interfaces`.

<sup>Written for commit 04700012fa75cd91adface1e7b05016d1d70bc27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1059?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

