### PR TITLE
chore: bump to 6.19.0-preview-headless-dashboard.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.19.0-preview-headless-dashboard.4",
+  "version": "6.19.0-preview-headless-dashboard.5",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## Summary
- Bumps the prerelease version now that #1059 (`broadcasts.cancel()`) is merged into `preview-headless-dashboard`, following the same pattern as #1058.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump prerelease to 6.19.0-preview-headless-dashboard.5 so the preview-headless-dashboard channel includes broadcast cancellation (broadcasts.cancel()).
No code changes—only the version in package.json.

<sup>Written for commit 2aec91926e439b8d0daa2c6a044678e4ee21f4b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

