### PR TITLE
feat: add broadcasts.cancel() method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.18.1",
+  "version": "6.19.0",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/src/broadcasts/broadcasts.spec.ts
+++ b/src/broadcasts/broadcasts.spec.ts
@@ -2,6 +2,7 @@ import createFetchMock from 'vitest-fetch-mock';
 import type { ErrorResponse } from '../interfaces';
 import { Resend } from '../resend';
 import { mockSuccessResponse } from '../test-utils/mock-fetch';
+import type { CancelBroadcastResponseSuccess } from './interfaces/cancel-broadcast.interface';
 import type {
   CreateBroadcastOptions,
   CreateBroadcastResponseSuccess,
@@ -626,6 +627,76 @@ describe('Broadcasts', () => {
           },
         }
       `);
+    });
+  });
+
+  describe('cancel', () => {
+    it('cancels a broadcast', async () => {
+      const id = 'b01e0de9-7c27-4a53-bf38-2e3f98389a65';
+      const response: CancelBroadcastResponseSuccess = {
+        object: 'broadcast',
+        id,
+      };
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      await expect(
+        resend.broadcasts.cancel(id),
+      ).resolves.toMatchInlineSnapshot(`
+        {
+          "data": {
+            "id": "b01e0de9-7c27-4a53-bf38-2e3f98389a65",
+            "object": "broadcast",
+          },
+          "error": null,
+          "headers": {
+            "content-type": "application/json",
+          },
+        }
+      `);
+    });
+
+    describe('when broadcast is not cancelable', () => {
+      it('returns error', async () => {
+        const response: ErrorResponse = {
+          name: 'validation_error',
+          statusCode: 403,
+          message: 'Only queued or scheduled broadcasts can be canceled',
+        };
+
+        fetchMock.mockOnce(JSON.stringify(response), {
+          status: 403,
+          headers: {
+            'content-type': 'application/json',
+          },
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+        const result = resend.broadcasts.cancel(
+          '559ac32e-9ef5-46fb-82a1-b76b840c0f7b',
+        );
+
+        await expect(result).resolves.toMatchInlineSnapshot(`
+          {
+            "data": null,
+            "error": {
+              "message": "Only queued or scheduled broadcasts can be canceled",
+              "name": "validation_error",
+              "statusCode": 403,
+            },
+            "headers": {
+              "content-type": "application/json",
+            },
+          }
+        `);
+      });
     });
   });
 

--- a/src/broadcasts/broadcasts.ts
+++ b/src/broadcasts/broadcasts.ts
@@ -2,6 +2,10 @@ import { buildPaginationQuery } from '../common/utils/build-pagination-query';
 import { render } from '../render';
 import type { Resend } from '../resend';
 import type {
+  CancelBroadcastResponse,
+  CancelBroadcastResponseSuccess,
+} from './interfaces/cancel-broadcast.interface';
+import type {
   CreateBroadcastOptions,
   CreateBroadcastRequestOptions,
 } from './interfaces/create-broadcast-options.interface';
@@ -92,6 +96,13 @@ export class Broadcasts {
   async remove(id: string): Promise<RemoveBroadcastResponse> {
     const data = await this.resend.delete<RemoveBroadcastResponseSuccess>(
       `/broadcasts/${id}`,
+    );
+    return data;
+  }
+
+  async cancel(id: string): Promise<CancelBroadcastResponse> {
+    const data = await this.resend.post<CancelBroadcastResponseSuccess>(
+      `/broadcasts/${id}/cancel`,
     );
     return data;
   }

--- a/src/broadcasts/interfaces/cancel-broadcast.interface.ts
+++ b/src/broadcasts/interfaces/cancel-broadcast.interface.ts
@@ -1,0 +1,8 @@
+import type { Response } from '../../interfaces';
+import type { Broadcast } from './broadcast';
+
+export interface CancelBroadcastResponseSuccess extends Pick<Broadcast, 'id'> {
+  object: 'broadcast';
+}
+
+export type CancelBroadcastResponse = Response<CancelBroadcastResponseSuccess>;

--- a/src/broadcasts/interfaces/index.ts
+++ b/src/broadcasts/interfaces/index.ts
@@ -1,4 +1,5 @@
 export * from './broadcast';
+export * from './cancel-broadcast.interface';
 export * from './create-broadcast-options.interface';
 export * from './get-broadcast.interface';
 export * from './list-broadcasts.interface';


### PR DESCRIPTION
## Summary
- Cherry-picks `broadcasts.cancel()` (#1059, 33273b2) from `preview-headless-dashboard` onto `main`.
- Cancel is shipping straight to GA (no beta banner, no feature-flag gate — see resend/resend-monorepo#8126 and resend/resend-docs#1722), so it doesn't belong stuck behind the `preview-headless-dashboard` prerelease line with metrics/recipients. This gets it into the next stable release instead.
- Adds `broadcasts.cancel(id)`, calling `POST /broadcasts/:id/cancel`, no body. Mirrors `emails.cancel()`.
- Bumps version to `6.19.0` (minor, additive method).

Part of the broadcast cancel rollout: resend/resend-monorepo#8126, resend/resend-openapi#85, resend/resend-docs#1722, resend/resend-go#144, resend/resend-java#122, resend/resend-php#135, resend/resend-python#250, resend/resend-ruby#216, resend/resend-rust#91, resend/resend-dotnet#136.

## Test plan
- [x] Clean cherry-pick from `preview-headless-dashboard`, diff identical to the original 4-file change
- [x] `vitest run src/broadcasts/broadcasts.spec.ts` — 21/21 passing
- [x] `biome check src/broadcasts` — clean
- [x] `tsc --noEmit` — pre-existing `node10 moduleResolution` deprecation warning on `main` unrelated to this change (verified via a clean `origin/main` worktree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)