### PR TITLE
feat: add broadcasts.cancel() method (#1064)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.18.1",
+  "version": "6.19.0",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/src/broadcasts/broadcasts.spec.ts
+++ b/src/broadcasts/broadcasts.spec.ts
@@ -2,6 +2,7 @@ import createFetchMock from 'vitest-fetch-mock';
 import type { ErrorResponse } from '../interfaces';
 import { Resend } from '../resend';
 import { mockSuccessResponse } from '../test-utils/mock-fetch';
+import type { CancelBroadcastResponseSuccess } from './interfaces/cancel-broadcast.interface';
 import type {
   CreateBroadcastOptions,
   CreateBroadcastResponseSuccess,
@@ -626,6 +627,76 @@ describe('Broadcasts', () => {
           },
         }
       `);
+    });
+  });
+
+  describe('cancel', () => {
+    it('cancels a broadcast', async () => {
+      const id = 'b01e0de9-7c27-4a53-bf38-2e3f98389a65';
+      const response: CancelBroadcastResponseSuccess = {
+        object: 'broadcast',
+        id,
+      };
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      await expect(
+        resend.broadcasts.cancel(id),
+      ).resolves.toMatchInlineSnapshot(`
+        {
+          "data": {
+            "id": "b01e0de9-7c27-4a53-bf38-2e3f98389a65",
+            "object": "broadcast",
+          },
+          "error": null,
+          "headers": {
+            "content-type": "application/json",
+          },
+        }
+      `);
+    });
+
+    describe('when broadcast is not cancelable', () => {
+      it('returns error', async () => {
+        const response: ErrorResponse = {
+          name: 'validation_error',
+          statusCode: 403,
+          message: 'Only queued or scheduled broadcasts can be canceled',
+        };
+
+        fetchMock.mockOnce(JSON.stringify(response), {
+          status: 403,
+          headers: {
+            'content-type': 'application/json',
+          },
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+        const result = resend.broadcasts.cancel(
+          '559ac32e-9ef5-46fb-82a1-b76b840c0f7b',
+        );
+
+        await expect(result).resolves.toMatchInlineSnapshot(`
+          {
+            "data": null,
+            "error": {
+              "message": "Only queued or scheduled broadcasts can be canceled",
+              "name": "validation_error",
+              "statusCode": 403,
+            },
+            "headers": {
+              "content-type": "application/json",
+            },
+          }
+        `);
+      });
     });
   });
 

--- a/src/broadcasts/broadcasts.ts
+++ b/src/broadcasts/broadcasts.ts
@@ -2,6 +2,10 @@ import { buildPaginationUrl } from '../common/utils/build-pagination-query';
 import { render } from '../render';
 import type { Resend } from '../resend';
 import type {
+  CancelBroadcastResponse,
+  CancelBroadcastResponseSuccess,
+} from './interfaces/cancel-broadcast.interface';
+import type {
   CreateBroadcastOptions,
   CreateBroadcastRequestOptions,
 } from './interfaces/create-broadcast-options.interface';
@@ -91,6 +95,13 @@ export class Broadcasts {
   async remove(id: string): Promise<RemoveBroadcastResponse> {
     const data = await this.resend.delete<RemoveBroadcastResponseSuccess>(
       `/broadcasts/${id}`,
+    );
+    return data;
+  }
+
+  async cancel(id: string): Promise<CancelBroadcastResponse> {
+    const data = await this.resend.post<CancelBroadcastResponseSuccess>(
+      `/broadcasts/${id}/cancel`,
     );
     return data;
   }

--- a/src/broadcasts/interfaces/cancel-broadcast.interface.ts
+++ b/src/broadcasts/interfaces/cancel-broadcast.interface.ts
@@ -1,0 +1,8 @@
+import type { Response } from '../../interfaces';
+import type { Broadcast } from './broadcast';
+
+export interface CancelBroadcastResponseSuccess extends Pick<Broadcast, 'id'> {
+  object: 'broadcast';
+}
+
+export type CancelBroadcastResponse = Response<CancelBroadcastResponseSuccess>;

--- a/src/broadcasts/interfaces/index.ts
+++ b/src/broadcasts/interfaces/index.ts
@@ -1,4 +1,5 @@
 export * from './broadcast';
+export * from './cancel-broadcast.interface';
 export * from './create-broadcast-options.interface';
 export * from './get-broadcast.interface';
 export * from './list-broadcasts.interface';


### PR DESCRIPTION
## Summary
- Cherry-picks `ade6ecc` (#1064) from `main` into `canary` — it was accidentally merged to `main` instead of `canary`.
- Adds `broadcasts.cancel()` method, its interface, and tests.

## Test plan
- [x] `npx vitest run src/broadcasts` — 21 passed
- [x] `npx tsc --noEmit` — clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `broadcasts.cancel(id)` to the `resend` SDK to cancel queued or scheduled broadcasts. Includes response types and tests; bumps version to 6.19.0.

- **New Features**
  - Added `broadcasts.cancel(id)` (POST `/broadcasts/{id}/cancel`).
  - Exported `CancelBroadcastResponse` types; tests cover success and 403 when not cancelable.

<sup>Written for commit 683dce54cd82f1ef1000d37efe8e77a27f734eab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1065?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

