### PR TITLE
chore: bump to 6.19.0-preview-headless-dashboard.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.19.0-preview-headless-dashboard.5",
+  "version": "6.19.0-preview-headless-dashboard.6",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
Version bump following #1067 (broadcasts.metrics() for account-level broadcast metrics).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes `resend` 6.19.0-preview-headless-dashboard.6 to expose the account-level broadcast metrics added in #1067 via broadcasts.metrics(). No runtime code changes; upgrade to `resend@6.19.0-preview-headless-dashboard.6` to use broadcasts.metrics().

<sup>Written for commit 12be2a8b2f924bda1e89b02d827ec9517c96e2eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

