### PR TITLE
feat: add clicked-links support

### DIFF
--- a/src/broadcasts/broadcasts.spec.ts
+++ b/src/broadcasts/broadcasts.spec.ts
@@ -9,6 +9,7 @@ import type {
 } from './interfaces/create-broadcast-options.interface';
 import type { GetBroadcastResponseSuccess } from './interfaces/get-broadcast.interface';
 import type { GetBroadcastsMetricsResponseSuccess } from './interfaces/get-metrics.interface';
+import type { ListBroadcastClickedLinksResponseSuccess } from './interfaces/list-broadcast-clicked-links.interface';
 import type { ListBroadcastRecipientsResponseSuccess } from './interfaces/list-broadcast-recipients.interface';
 import type { ListBroadcastsResponseSuccess } from './interfaces/list-broadcasts.interface';
 import type { RemoveBroadcastResponseSuccess } from './interfaces/remove-broadcast.interface';
@@ -964,6 +965,139 @@ describe('Broadcasts', () => {
           headers: expect.any(Headers),
         }),
       );
+    });
+  });
+
+  describe('clickedLinks', () => {
+    const response: ListBroadcastClickedLinksResponseSuccess = {
+      object: 'list',
+      has_more: false,
+      data: [
+        {
+          id: 'b2Zmc2V0OjA',
+          url: 'https://resend.com/pricing',
+          clicks: 42,
+          unique_clicks: 30,
+        },
+        {
+          id: 'b2Zmc2V0OjE',
+          url: 'https://resend.com/docs',
+          clicks: 17,
+          unique_clicks: 15,
+        },
+      ],
+    };
+
+    describe('when no pagination options are provided', () => {
+      it('lists clicked links', async () => {
+        mockSuccessResponse(response, {
+          headers: {},
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+        const result = await resend.broadcasts.clickedLinks(
+          '559ac32e-9ef5-46fb-82a1-b76b840c0f7b',
+        );
+        expect(result).toEqual({
+          data: response,
+          error: null,
+          headers: {
+            'content-type': 'application/json',
+          },
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://api.resend.com/broadcasts/559ac32e-9ef5-46fb-82a1-b76b840c0f7b/clicked-links',
+          expect.objectContaining({
+            method: 'GET',
+            headers: expect.any(Headers),
+          }),
+        );
+      });
+    });
+
+    describe('when pagination options are provided', () => {
+      it('passes limit param and returns a response', async () => {
+        mockSuccessResponse(response, {
+          headers: {},
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+        const result = await resend.broadcasts.clickedLinks(
+          '559ac32e-9ef5-46fb-82a1-b76b840c0f7b',
+          { limit: 1 },
+        );
+        expect(result).toEqual({
+          data: response,
+          error: null,
+          headers: {
+            'content-type': 'application/json',
+          },
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://api.resend.com/broadcasts/559ac32e-9ef5-46fb-82a1-b76b840c0f7b/clicked-links?limit=1',
+          expect.objectContaining({
+            method: 'GET',
+            headers: expect.any(Headers),
+          }),
+        );
+      });
+
+      it('passes after param and returns a response', async () => {
+        mockSuccessResponse(response, {
+          headers: {},
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+        const result = await resend.broadcasts.clickedLinks(
+          '559ac32e-9ef5-46fb-82a1-b76b840c0f7b',
+          { limit: 1, after: 'cursor-value' },
+        );
+        expect(result).toEqual({
+          data: response,
+          error: null,
+          headers: {
+            'content-type': 'application/json',
+          },
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://api.resend.com/broadcasts/559ac32e-9ef5-46fb-82a1-b76b840c0f7b/clicked-links?limit=1&after=cursor-value',
+          expect.objectContaining({
+            method: 'GET',
+            headers: expect.any(Headers),
+          }),
+        );
+      });
+
+      it('passes before param and returns a response', async () => {
+        mockSuccessResponse(response, {
+          headers: {},
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+        const result = await resend.broadcasts.clickedLinks(
+          '559ac32e-9ef5-46fb-82a1-b76b840c0f7b',
+          { limit: 1, before: 'cursor-value' },
+        );
+        expect(result).toEqual({
+          data: response,
+          error: null,
+          headers: {
+            'content-type': 'application/json',
+          },
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://api.resend.com/broadcasts/559ac32e-9ef5-46fb-82a1-b76b840c0f7b/clicked-links?limit=1&before=cursor-value',
+          expect.objectContaining({
+            method: 'GET',
+            headers: expect.any(Headers),
+          }),
+        );
+      });
     });
   });
 

--- a/src/broadcasts/broadcasts.ts
+++ b/src/broadcasts/broadcasts.ts
@@ -22,6 +22,11 @@ import type {
   GetBroadcastsMetricsResponseSuccess,
 } from './interfaces/get-metrics.interface';
 import type {
+  ListBroadcastClickedLinksOptions,
+  ListBroadcastClickedLinksResponse,
+  ListBroadcastClickedLinksResponseSuccess,
+} from './interfaces/list-broadcast-clicked-links.interface';
+import type {
   BroadcastRecipientEventType,
   ListBroadcastRecipientsOptions,
   ListBroadcastRecipientsResponse,
@@ -130,6 +135,17 @@ export class Broadcasts {
 
     const data =
       await this.resend.get<ListBroadcastRecipientsResponseSuccess<T>>(url);
+    return data;
+  }
+
+  async clickedLinks(
+    id: string,
+    options: ListBroadcastClickedLinksOptions = {},
+  ): Promise<ListBroadcastClickedLinksResponse> {
+    const url = buildPaginationUrl(`/broadcasts/${id}/clicked-links`, options);
+
+    const data =
+      await this.resend.get<ListBroadcastClickedLinksResponseSuccess>(url);
     return data;
   }
 

--- a/src/broadcasts/interfaces/index.ts
+++ b/src/broadcasts/interfaces/index.ts
@@ -3,6 +3,7 @@ export * from './cancel-broadcast.interface';
 export * from './create-broadcast-options.interface';
 export * from './get-broadcast.interface';
 export * from './get-metrics.interface';
+export * from './list-broadcast-clicked-links.interface';
 export * from './list-broadcast-recipients.interface';
 export * from './list-broadcasts.interface';
 export * from './remove-broadcast.interface';

--- a/src/broadcasts/interfaces/list-broadcast-clicked-links.interface.ts
+++ b/src/broadcasts/interfaces/list-broadcast-clicked-links.interface.ts
@@ -1,0 +1,25 @@
+import type {
+  PaginatedData,
+  PaginationOptions,
+} from '../../common/interfaces/pagination-options.interface';
+import type { Response } from '../../interfaces';
+
+export type ListBroadcastClickedLinksOptions = PaginationOptions;
+
+export type BroadcastClickedLink = {
+  /**
+   * An opaque cursor for this row, used only for pagination. It does not
+   * identify any entity in Resend.
+   */
+  id: string;
+  url: string;
+  clicks: number;
+  unique_clicks: number;
+};
+
+export type ListBroadcastClickedLinksResponseSuccess = PaginatedData<
+  BroadcastClickedLink[]
+>;
+
+export type ListBroadcastClickedLinksResponse =
+  Response<ListBroadcastClickedLinksResponseSuccess>;


### PR DESCRIPTION
## Summary
- Adds `broadcasts.clickedLinks(id, options?)` for `GET /broadcasts/:id/clicked-links`, cursor-paginated (`limit`/`after`/`before`), matching the existing `list()`/`recipients()` pagination pattern
- Bumps version to `6.19.0-preview-headless-dashboard.7`

## Test plan
- [x] `broadcasts.spec.ts` covers no-options, `limit`, `after`, and `before`
- [x] `tsc --noEmit` and `biome check` pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds broadcasts.clickedLinks(id, options?) to fetch clicked links for a broadcast. Previously the SDK could not fetch clicked links; now it returns a cursor-paginated list of link URLs with total and unique click counts, with no breaking changes.

- Mirrors GET /broadcasts/:id/clicked-links; options `limit`, `after`, `before` match `list()` and `recipients()`.
- Returns PaginatedData items: id (opaque cursor), url, clicks, unique_clicks.
- Exposes types in `src/broadcasts/interfaces/index.ts`.
- Tests cover default usage and each pagination parameter.

<sup>Written for commit 9f32dfc5ec6a249175af159f3149b20615e21f52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1069?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

