### PR TITLE
chore: bump to 6.19.0-preview-headless-dashboard.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.19.0-preview-headless-dashboard.6",
+  "version": "6.19.0-preview-headless-dashboard.7",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
Version bump following #1069 (broadcasts.clickedLinks() for broadcast clicked links).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes `resend` 6.19.0-preview-headless-dashboard.7 to ship the preview release that includes `broadcasts.clickedLinks()` support added in #1069. This PR only bumps the package version; runtime behavior is unchanged.

**Rollout**
- No code changes; review is trivial.
- Install with `npm i resend@6.19.0-preview-headless-dashboard.7` to access `broadcasts.clickedLinks()` in preview.
- No migration required.

<sup>Written for commit 12e3755315fda193d724ba25db5e0773e8847268. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

