### PR TITLE
feat(automations): endpoint to duplicate

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.19.0",
+  "version": "6.20.0",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/src/automations/automations.spec.ts
+++ b/src/automations/automations.spec.ts
@@ -9,6 +9,7 @@ import type {
 import type { GetAutomationResponseSuccess } from './interfaces/get-automation.interface';
 import type { ListAutomationsResponseSuccess } from './interfaces/list-automation.interface';
 import type { RemoveAutomationResponseSuccess } from './interfaces/remove-automation.interface';
+import type { DuplicateAutomationResponseSuccess } from './interfaces/duplicate-automation.interface';
 import type { StopAutomationResponseSuccess } from './interfaces/stop-automation.interface';
 import type { UpdateAutomationResponseSuccess } from './interfaces/update-automation.interface';
 
@@ -524,6 +525,45 @@ describe('update', () => {
         method: 'PATCH',
         headers: expect.any(Headers),
         body: JSON.stringify({ name: 'Updated Flow' }),
+      }),
+    );
+  });
+});
+
+describe('duplicate', () => {
+  it('duplicates an automation', async () => {
+    const id = '71cdfe68-cf79-473a-a9d7-21f91db6a526';
+    const response: DuplicateAutomationResponseSuccess = {
+      object: 'automation',
+      id: 'e169aa45-1ecf-4183-9955-b1499d5701d3',
+    };
+
+    fetchMock.mockOnce(JSON.stringify(response), {
+      status: 200,
+      headers: {
+        'content-type': 'application/json',
+      },
+    });
+
+    const data = await resend.automations.duplicate(id);
+    expect(data).toMatchInlineSnapshot(`
+        {
+          "data": {
+            "id": "e169aa45-1ecf-4183-9955-b1499d5701d3",
+            "object": "automation",
+          },
+          "error": null,
+          "headers": {
+            "content-type": "application/json",
+          },
+        }
+      `);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `https://api.resend.com/automations/${id}/duplicate`,
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.any(Headers),
       }),
     );
   });

--- a/src/automations/automations.spec.ts
+++ b/src/automations/automations.spec.ts
@@ -6,10 +6,10 @@ import type {
   CreateAutomationOptions,
   CreateAutomationResponseSuccess,
 } from './interfaces/create-automation-options.interface';
+import type { DuplicateAutomationResponseSuccess } from './interfaces/duplicate-automation.interface';
 import type { GetAutomationResponseSuccess } from './interfaces/get-automation.interface';
 import type { ListAutomationsResponseSuccess } from './interfaces/list-automation.interface';
 import type { RemoveAutomationResponseSuccess } from './interfaces/remove-automation.interface';
-import type { DuplicateAutomationResponseSuccess } from './interfaces/duplicate-automation.interface';
 import type { StopAutomationResponseSuccess } from './interfaces/stop-automation.interface';
 import type { UpdateAutomationResponseSuccess } from './interfaces/update-automation.interface';
 

--- a/src/automations/automations.ts
+++ b/src/automations/automations.ts
@@ -12,6 +12,10 @@ import type {
   CreateAutomationResponseSuccess,
 } from './interfaces/create-automation-options.interface';
 import type {
+  DuplicateAutomationResponse,
+  DuplicateAutomationResponseSuccess,
+} from './interfaces/duplicate-automation.interface';
+import type {
   GetAutomationResponse,
   GetAutomationResponseSuccess,
 } from './interfaces/get-automation.interface';
@@ -105,6 +109,13 @@ export class Automations {
     const data = await this.resend.patch<UpdateAutomationResponseSuccess>(
       `/automations/${id}`,
       apiPayload,
+    );
+    return data;
+  }
+
+  async duplicate(id: string): Promise<DuplicateAutomationResponse> {
+    const data = await this.resend.post<DuplicateAutomationResponseSuccess>(
+      `/automations/${id}/duplicate`,
     );
     return data;
   }

--- a/src/automations/interfaces/duplicate-automation.interface.ts
+++ b/src/automations/interfaces/duplicate-automation.interface.ts
@@ -1,0 +1,10 @@
+import type { Response } from '../../interfaces';
+import type { Automation } from './automation';
+
+export interface DuplicateAutomationResponseSuccess
+  extends Pick<Automation, 'id'> {
+  object: 'automation';
+}
+
+export type DuplicateAutomationResponse =
+  Response<DuplicateAutomationResponseSuccess>;

--- a/src/automations/interfaces/index.ts
+++ b/src/automations/interfaces/index.ts
@@ -1,6 +1,7 @@
 export * from './automation';
 export * from './automation-step.interface';
 export * from './create-automation-options.interface';
+export * from './duplicate-automation.interface';
 export * from './get-automation.interface';
 export * from './list-automation.interface';
 export * from './remove-automation.interface';


### PR DESCRIPTION
Signed-off-by: Gabriel Miranda <gabriel@resend.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds automations.duplicate(id) to the `resend` Node SDK so users can copy an automation. Previously duplication was not supported; now POST /automations/:id/duplicate returns { object: 'automation', id }.

- Implements Automations.duplicate(), typed as `DuplicateAutomationResponse` (no version_id) and exported via the interfaces barrel.
- Adds a success spec asserting a POST to /automations/{id}/duplicate and response shape.
- Bumps package version to 6.20.0.
- Aligns with Linear DEV-1704 (Headless Dashboard rollout).

<sup>Written for commit e23bd5e52b69acd91ed6e2ce57ce0b71213442f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1071?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

