### PR TITLE
fix: allow null contact first_name and last_name on webhook events

### DIFF
--- a/src/webhooks/interfaces/webhook-event.interface.ts
+++ b/src/webhooks/interfaces/webhook-event.interface.ts
@@ -81,8 +81,8 @@ interface ContactEventData {
   created_at: string;
   updated_at: string;
   email: string;
-  first_name?: string;
-  last_name?: string;
+  first_name?: string | null;
+  last_name?: string | null;
   unsubscribed: boolean;
 }
 


### PR DESCRIPTION
The response types are already right. `Contact` in `contacts/interfaces/contact.ts` uses `string | null`, fixed in #757. Only the webhook payload lagged, where `ContactEventData` had:

```ts
first_name?: string;
last_name?: string;
```

`?` is the wrong axis on its own. It says the key may be absent, while still promising a `string` whenever the key is there. The API sends `null`, which is the case that type rules out, so `event.data.first_name` narrows to `string` after a truthiness check but can hold `null` at runtime.

Changed to `first_name?: string | null`, keeping both halves, because for this payload both are real:

- **Absent:** the `contact.created` fixture in resend-dotnet has a `data` object with only `id`, `created_at`, `updated_at`, `email`, and `unsubscribed`. The OpenAPI `required` list agrees.
- **Null:** the API returns `null` for a contact with no name. This repo's own `__recordings__` carry `"first_name":null` in 12 HAR fixtures, though those are the REST endpoints rather than webhook deliveries.

`string | null` is already used for nullable fields in this same file, on `filename`, `content_disposition`, `content_id`, and `source_id`.

## Verification

`tsc --noEmit` is clean and the 80 tests across `src/webhooks` and `src/contacts` pass.

## Related

Spec fix in resend/resend-openapi#91, which makes `ContactEventData.first_name` nullable there too.

Ref DEV-1625

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow webhook contact fields first_name and last_name to be nullable to match the API (DEV-1625) and prevent unsafe string narrowing. Previously they were optional but non-nullable; now both can be absent or null. No runtime behavior change.

- Set `first_name?: string | null` and `last_name?: string | null` in `ContactEventData` (`src/webhooks/interfaces/webhook-event.interface.ts`).
- Migration: TypeScript consumers must handle `null` when reading these fields.

<sup>Written for commit e8b190b4ca51ca8d987d7f46660eed667f826d3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1073?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Version bump

Includes a patch bump to `6.20.1` in `package.json`. This repo normally bumps in a separate `chore:` PR, so drop that commit if you would rather keep the split.
