### PR TITLE
feat: add emails.share() method

### DIFF
--- a/src/emails/emails.spec.ts
+++ b/src/emails/emails.spec.ts
@@ -8,6 +8,7 @@ import type {
 } from './interfaces/create-email-options.interface';
 import type { GetEmailResponseSuccess } from './interfaces/get-email-options.interface';
 import type { ListEmailsResponseSuccess } from './interfaces/list-emails-options.interface';
+import type { ShareEmailResponseSuccess } from './interfaces/share-email-options.interface';
 
 const fetchMocker = createFetchMock(vi);
 fetchMocker.enableMocks();
@@ -869,6 +870,136 @@ describe('Emails', () => {
         expect(fetchMock.mock.calls[0][0]).toBe(
           'https://api.resend.com/emails?before=cursor123',
         );
+      });
+    });
+  });
+
+  describe('share', () => {
+    it('creates a share link with the default expiration', async () => {
+      const id = '67d9bcdb-5a02-42d7-8da9-0d6feea18cff';
+      const response: ShareEmailResponseSuccess = {
+        object: 'email',
+        id,
+        url: 'https://resend.com/share/abc123',
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      await expect(resend.emails.share(id)).resolves.toMatchInlineSnapshot(`
+        {
+          "data": {
+            "id": "67d9bcdb-5a02-42d7-8da9-0d6feea18cff",
+            "object": "email",
+            "url": "https://resend.com/share/abc123",
+          },
+          "error": null,
+          "headers": {
+            "content-type": "application/json",
+          },
+        }
+      `);
+
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        `https://api.resend.com/emails/${id}/share`,
+      );
+      expect(fetchMock.mock.calls[0][1]?.body).toBe('{}');
+    });
+
+    it('creates a share link with a custom expiration', async () => {
+      const id = '67d9bcdb-5a02-42d7-8da9-0d6feea18cff';
+      const response: ShareEmailResponseSuccess = {
+        object: 'email',
+        id,
+        url: 'https://resend.com/share/abc123',
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      await resend.emails.share(id, { expiresIn: '10m' });
+
+      expect(fetchMock.mock.calls[0][1]?.body).toBe(
+        JSON.stringify({ expires_in: '10m' }),
+      );
+    });
+
+    describe('when expiresIn is malformed or exceeds 48 hours', () => {
+      it('returns a validation error', async () => {
+        const response: ErrorResponse = {
+          name: 'validation_error',
+          statusCode: 422,
+          message: 'expires_in must not exceed 48 hours',
+        };
+
+        fetchMock.mockOnce(JSON.stringify(response), {
+          status: 422,
+          headers: {
+            'content-type': 'application/json',
+          },
+        });
+
+        const result = resend.emails.share(
+          '67d9bcdb-5a02-42d7-8da9-0d6feea18cff',
+          { expiresIn: '72h' },
+        );
+
+        await expect(result).resolves.toMatchInlineSnapshot(`
+          {
+            "data": null,
+            "error": {
+              "message": "expires_in must not exceed 48 hours",
+              "name": "validation_error",
+              "statusCode": 422,
+            },
+            "headers": {
+              "content-type": "application/json",
+            },
+          }
+        `);
+      });
+    });
+
+    describe('when email is not found', () => {
+      it('returns error', async () => {
+        const response: ErrorResponse = {
+          name: 'not_found',
+          statusCode: 404,
+          message: 'Email not found',
+        };
+
+        fetchMock.mockOnce(JSON.stringify(response), {
+          status: 404,
+          headers: {
+            'content-type': 'application/json',
+          },
+        });
+
+        const result = resend.emails.share(
+          '61cda979-919d-4b9d-9638-c148b93ff410',
+        );
+
+        await expect(result).resolves.toMatchInlineSnapshot(`
+          {
+            "data": null,
+            "error": {
+              "message": "Email not found",
+              "name": "not_found",
+              "statusCode": 404,
+            },
+            "headers": {
+              "content-type": "application/json",
+            },
+          }
+        `);
       });
     });
   });

--- a/src/emails/emails.ts
+++ b/src/emails/emails.ts
@@ -23,6 +23,11 @@ import type {
   ListEmailsResponseSuccess,
 } from './interfaces/list-emails-options.interface';
 import type {
+  ShareEmailOptions,
+  ShareEmailResponse,
+  ShareEmailResponseSuccess,
+} from './interfaces/share-email-options.interface';
+import type {
   UpdateEmailOptions,
   UpdateEmailResponse,
   UpdateEmailResponseSuccess,
@@ -93,6 +98,17 @@ export class Emails {
   async cancel(id: string): Promise<CancelEmailResponse> {
     const data = await this.resend.post<CancelEmailResponseSuccess>(
       `/emails/${id}/cancel`,
+    );
+    return data;
+  }
+
+  async share(
+    id: string,
+    payload?: ShareEmailOptions,
+  ): Promise<ShareEmailResponse> {
+    const data = await this.resend.post<ShareEmailResponseSuccess>(
+      `/emails/${id}/share`,
+      { expires_in: payload?.expiresIn },
     );
     return data;
   }

--- a/src/emails/interfaces/index.ts
+++ b/src/emails/interfaces/index.ts
@@ -2,4 +2,5 @@ export * from './cancel-email-options.interface';
 export * from './create-email-options.interface';
 export * from './get-email-options.interface';
 export * from './list-emails-options.interface';
+export * from './share-email-options.interface';
 export * from './update-email-options.interface';

--- a/src/emails/interfaces/share-email-options.interface.ts
+++ b/src/emails/interfaces/share-email-options.interface.ts
@@ -1,0 +1,13 @@
+import type { Response } from '../../interfaces';
+
+export interface ShareEmailOptions {
+  expiresIn?: string;
+}
+
+export interface ShareEmailResponseSuccess {
+  object: 'email';
+  id: string;
+  url: string;
+}
+
+export type ShareEmailResponse = Response<ShareEmailResponseSuccess>;


### PR DESCRIPTION
Adds `emails.share(id, options?)`, calling the new `POST /emails/{id}/share` endpoint that creates a shareable link for a sent or received email. See the spec PR resend/resend-openapi#92.

`options.expiresIn` is an optional human-readable duration (e.g. `10m`, `2 hours`, `1 day`; server defaults to `48h`, capped at 48h).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `emails.share(id, options?)` to generate a shareable link for a sent or received email. Previously there was no SDK method; now clients can create a link with an optional expiration (server defaults to 48h, capped at 48h).

- Maps `options.expiresIn` (e.g., "10m", "2 hours", "1 day") to `{ expires_in }` in `POST /emails/{id}/share`. Returns 422 for malformed or >48h durations, and 404 when the email is not found.
- Introduces `ShareEmailOptions`/`ShareEmailResponse` types and re-exports them. Adds tests for default/custom expiration and error cases.

<sup>Written for commit efabbe7c50df6811491c11075471632665b4b802. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1074?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
