### PR TITLE
feat(api-keys): add update() method to rename an api key

### DIFF
--- a/src/api-keys/api-keys.spec.ts
+++ b/src/api-keys/api-keys.spec.ts
@@ -8,6 +8,10 @@ import type {
 } from './interfaces/create-api-key-options.interface';
 import type { ListApiKeysResponseSuccess } from './interfaces/list-api-keys.interface';
 import type { RemoveApiKeyResponseSuccess } from './interfaces/remove-api-keys.interface';
+import type {
+  UpdateApiKeyOptions,
+  UpdateApiKeyResponseSuccess,
+} from './interfaces/update-api-key-options.interface';
 
 const fetchMocker = createFetchMock(vi);
 fetchMocker.enableMocks();
@@ -397,6 +401,116 @@ describe('API Keys', () => {
           }),
         );
       });
+    });
+  });
+
+  describe('update', () => {
+    const id = '5262504e-8ed7-4fac-bd16-0d4be94bc9f2';
+
+    it('updates an api key name', async () => {
+      const payload: UpdateApiKeyOptions = {
+        name: 'New name',
+      };
+      const response: UpdateApiKeyResponseSuccess = {
+        object: 'api_key',
+        id,
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      await expect(
+        resend.apiKeys.update(id, payload),
+      ).resolves.toMatchInlineSnapshot(`
+        {
+          "data": {
+            "id": "5262504e-8ed7-4fac-bd16-0d4be94bc9f2",
+            "object": "api_key",
+          },
+          "error": null,
+          "headers": {
+            "content-type": "application/json",
+          },
+        }
+      `);
+    });
+
+    it('throws error when missing name', async () => {
+      const payload: UpdateApiKeyOptions = {
+        name: '',
+      };
+      const response: ErrorResponse = {
+        message: 'String must contain at least 1 character(s)',
+        name: 'validation_error',
+        statusCode: 422,
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 422,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      const result = resend.apiKeys.update(id, payload);
+
+      await expect(result).resolves.toMatchInlineSnapshot(`
+        {
+          "data": null,
+          "error": {
+            "message": "String must contain at least 1 character(s)",
+            "name": "validation_error",
+            "statusCode": 422,
+          },
+          "headers": {
+            "content-type": "application/json",
+          },
+        }
+      `);
+    });
+
+    it('throws error when wrong id', async () => {
+      const response: ErrorResponse = {
+        name: 'not_found',
+        message: 'API key not found',
+        statusCode: 404,
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 404,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      const result = resend.apiKeys.update(
+        '34bd250e-615a-400c-be11-5912572ee15b',
+        { name: 'New name' },
+      );
+
+      await expect(result).resolves.toMatchInlineSnapshot(`
+        {
+          "data": null,
+          "error": {
+            "message": "API key not found",
+            "name": "not_found",
+            "statusCode": 404,
+          },
+          "headers": {
+            "content-type": "application/json",
+          },
+        }
+      `);
     });
   });
 

--- a/src/api-keys/api-keys.ts
+++ b/src/api-keys/api-keys.ts
@@ -15,6 +15,11 @@ import type {
   RemoveApiKeyResponse,
   RemoveApiKeyResponseSuccess,
 } from './interfaces/remove-api-keys.interface';
+import type {
+  UpdateApiKeyOptions,
+  UpdateApiKeyResponse,
+  UpdateApiKeyResponseSuccess,
+} from './interfaces/update-api-key-options.interface';
 
 export class ApiKeys {
   constructor(private readonly resend: Resend) {}
@@ -36,6 +41,17 @@ export class ApiKeys {
     const url = buildPaginationUrl('/api-keys', options);
 
     const data = await this.resend.get<ListApiKeysResponseSuccess>(url);
+    return data;
+  }
+
+  async update(
+    id: string,
+    payload: UpdateApiKeyOptions,
+  ): Promise<UpdateApiKeyResponse> {
+    const data = await this.resend.patch<UpdateApiKeyResponseSuccess>(
+      `/api-keys/${id}`,
+      payload,
+    );
     return data;
   }
 

--- a/src/api-keys/interfaces/index.ts
+++ b/src/api-keys/interfaces/index.ts
@@ -2,3 +2,4 @@ export * from './api-key';
 export * from './create-api-key-options.interface';
 export * from './list-api-keys.interface';
 export * from './remove-api-keys.interface';
+export * from './update-api-key-options.interface';

--- a/src/api-keys/interfaces/update-api-key-options.interface.ts
+++ b/src/api-keys/interfaces/update-api-key-options.interface.ts
@@ -1,0 +1,12 @@
+import type { Response } from '../../interfaces';
+
+export interface UpdateApiKeyOptions {
+  name: string;
+}
+
+export interface UpdateApiKeyResponseSuccess {
+  object: 'api_key';
+  id: string;
+}
+
+export type UpdateApiKeyResponse = Response<UpdateApiKeyResponseSuccess>;


### PR DESCRIPTION
## Summary
- Adds `apiKeys.update(id, { name })`, mirroring `webhooks.update`'s pattern, for the new `PATCH /api-keys/:id` endpoint — see https://resend.com/docs/api-reference/api-keys/update-api-key.
- Only `name` is patchable. `permission`/`domain_id` are deliberately not exposed on `UpdateApiKeyOptions` — the endpoint doesn't accept them (prevents a leaked management key from silently widening another key's scope).
- No client-side length validation on `name`, matching `create`'s existing (lack of) validation — the server doesn't enforce the documented "Maximum 50 characters" either.

Draft because the SDK rollout is still in progress. Tracked in Linear as DEV-1219.

## Test plan
- [x] `pnpm build` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 391 passed (3 new: rename success, empty-name validation, not-found)
- [x] `pnpm lint` — clean