### PR TITLE
chore: bump version to 6.21.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.20.0",
+  "version": "6.21.0",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## Summary
- Bump `package.json` version from 6.20.0 to 6.21.0 for release, covering the feature work merged since the last bump (emails.share(), api-keys.update()).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `resend` from 6.20.0 to 6.21.0 to cut a new release that includes features merged since the last bump. No runtime or build changes beyond the version update.

- Ships `emails.share()` and `api-keys.update()` introduced since 6.20.0.
- Rollout: publish to npm; consumers upgrade to `6.21.0` to use these APIs.

<sup>Written for commit f6d616d17a9a044abc729f48ab0edfd9fa0b0e0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1076?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

