### PR TITLE
feat: add broadcasts.clickedLinks() method

### DIFF
--- a/src/broadcasts/broadcasts.spec.ts
+++ b/src/broadcasts/broadcasts.spec.ts
@@ -8,6 +8,7 @@ import type {
   CreateBroadcastResponseSuccess,
 } from './interfaces/create-broadcast-options.interface';
 import type { GetBroadcastResponseSuccess } from './interfaces/get-broadcast.interface';
+import type { ListBroadcastClickedLinksResponseSuccess } from './interfaces/list-broadcast-clicked-links.interface';
 import type { ListBroadcastRecipientsResponseSuccess } from './interfaces/list-broadcast-recipients.interface';
 import type { ListBroadcastsResponseSuccess } from './interfaces/list-broadcasts.interface';
 import type { RemoveBroadcastResponseSuccess } from './interfaces/remove-broadcast.interface';
@@ -798,6 +799,139 @@ describe('Broadcasts', () => {
           headers: expect.any(Headers),
         }),
       );
+    });
+  });
+
+  describe('clickedLinks', () => {
+    const response: ListBroadcastClickedLinksResponseSuccess = {
+      object: 'list',
+      has_more: false,
+      data: [
+        {
+          id: 'b2Zmc2V0OjA',
+          url: 'https://resend.com/pricing',
+          clicks: 42,
+          unique_clicks: 30,
+        },
+        {
+          id: 'b2Zmc2V0OjE',
+          url: 'https://resend.com/docs',
+          clicks: 17,
+          unique_clicks: 15,
+        },
+      ],
+    };
+
+    describe('when no pagination options are provided', () => {
+      it('lists clicked links', async () => {
+        mockSuccessResponse(response, {
+          headers: {},
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+        const result = await resend.broadcasts.clickedLinks(
+          '559ac32e-9ef5-46fb-82a1-b76b840c0f7b',
+        );
+        expect(result).toEqual({
+          data: response,
+          error: null,
+          headers: {
+            'content-type': 'application/json',
+          },
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://api.resend.com/broadcasts/559ac32e-9ef5-46fb-82a1-b76b840c0f7b/clicked-links',
+          expect.objectContaining({
+            method: 'GET',
+            headers: expect.any(Headers),
+          }),
+        );
+      });
+    });
+
+    describe('when pagination options are provided', () => {
+      it('passes limit param and returns a response', async () => {
+        mockSuccessResponse(response, {
+          headers: {},
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+        const result = await resend.broadcasts.clickedLinks(
+          '559ac32e-9ef5-46fb-82a1-b76b840c0f7b',
+          { limit: 1 },
+        );
+        expect(result).toEqual({
+          data: response,
+          error: null,
+          headers: {
+            'content-type': 'application/json',
+          },
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://api.resend.com/broadcasts/559ac32e-9ef5-46fb-82a1-b76b840c0f7b/clicked-links?limit=1',
+          expect.objectContaining({
+            method: 'GET',
+            headers: expect.any(Headers),
+          }),
+        );
+      });
+
+      it('passes after param and returns a response', async () => {
+        mockSuccessResponse(response, {
+          headers: {},
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+        const result = await resend.broadcasts.clickedLinks(
+          '559ac32e-9ef5-46fb-82a1-b76b840c0f7b',
+          { limit: 1, after: 'cursor-value' },
+        );
+        expect(result).toEqual({
+          data: response,
+          error: null,
+          headers: {
+            'content-type': 'application/json',
+          },
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://api.resend.com/broadcasts/559ac32e-9ef5-46fb-82a1-b76b840c0f7b/clicked-links?limit=1&after=cursor-value',
+          expect.objectContaining({
+            method: 'GET',
+            headers: expect.any(Headers),
+          }),
+        );
+      });
+
+      it('passes before param and returns a response', async () => {
+        mockSuccessResponse(response, {
+          headers: {},
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+        const result = await resend.broadcasts.clickedLinks(
+          '559ac32e-9ef5-46fb-82a1-b76b840c0f7b',
+          { limit: 1, before: 'cursor-value' },
+        );
+        expect(result).toEqual({
+          data: response,
+          error: null,
+          headers: {
+            'content-type': 'application/json',
+          },
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://api.resend.com/broadcasts/559ac32e-9ef5-46fb-82a1-b76b840c0f7b/clicked-links?limit=1&before=cursor-value',
+          expect.objectContaining({
+            method: 'GET',
+            headers: expect.any(Headers),
+          }),
+        );
+      });
     });
   });
 

--- a/src/broadcasts/broadcasts.ts
+++ b/src/broadcasts/broadcasts.ts
@@ -17,6 +17,11 @@ import type {
   GetBroadcastResponseSuccess,
 } from './interfaces/get-broadcast.interface';
 import type {
+  ListBroadcastClickedLinksOptions,
+  ListBroadcastClickedLinksResponse,
+  ListBroadcastClickedLinksResponseSuccess,
+} from './interfaces/list-broadcast-clicked-links.interface';
+import type {
   BroadcastRecipientEventType,
   ListBroadcastRecipientsOptions,
   ListBroadcastRecipientsResponse,
@@ -112,6 +117,17 @@ export class Broadcasts {
 
     const data =
       await this.resend.get<ListBroadcastRecipientsResponseSuccess<T>>(url);
+    return data;
+  }
+
+  async clickedLinks(
+    id: string,
+    options: ListBroadcastClickedLinksOptions = {},
+  ): Promise<ListBroadcastClickedLinksResponse> {
+    const url = buildPaginationUrl(`/broadcasts/${id}/clicked-links`, options);
+
+    const data =
+      await this.resend.get<ListBroadcastClickedLinksResponseSuccess>(url);
     return data;
   }
 

--- a/src/broadcasts/interfaces/index.ts
+++ b/src/broadcasts/interfaces/index.ts
@@ -2,6 +2,7 @@ export * from './broadcast';
 export * from './cancel-broadcast.interface';
 export * from './create-broadcast-options.interface';
 export * from './get-broadcast.interface';
+export * from './list-broadcast-clicked-links.interface';
 export * from './list-broadcast-recipients.interface';
 export * from './list-broadcasts.interface';
 export * from './remove-broadcast.interface';

--- a/src/broadcasts/interfaces/list-broadcast-clicked-links.interface.ts
+++ b/src/broadcasts/interfaces/list-broadcast-clicked-links.interface.ts
@@ -1,0 +1,25 @@
+import type {
+  PaginatedData,
+  PaginationOptions,
+} from '../../common/interfaces/pagination-options.interface';
+import type { Response } from '../../interfaces';
+
+export type ListBroadcastClickedLinksOptions = PaginationOptions;
+
+export type BroadcastClickedLink = {
+  /**
+   * An opaque cursor for this row, used only for pagination. It does not
+   * identify any entity in Resend.
+   */
+  id: string;
+  url: string;
+  clicks: number;
+  unique_clicks: number;
+};
+
+export type ListBroadcastClickedLinksResponseSuccess = PaginatedData<
+  BroadcastClickedLink[]
+>;
+
+export type ListBroadcastClickedLinksResponse =
+  Response<ListBroadcastClickedLinksResponseSuccess>;

--- a/src/broadcasts/interfaces/list-broadcast-clicked-links.interface.ts
+++ b/src/broadcasts/interfaces/list-broadcast-clicked-links.interface.ts
@@ -8,8 +8,8 @@ export type ListBroadcastClickedLinksOptions = PaginationOptions;
 
 export type BroadcastClickedLink = {
   /**
-   * An opaque cursor for this row, used only for pagination. It does not
-   * identify any entity in Resend.
+   * `id` is an opaque cursor for this row, used only for pagination.
+   * It does not identify any entity in Resend.
    */
   id: string;
   url: string;


### PR DESCRIPTION
## Summary
- Adds `broadcasts.clickedLinks(id, options)` — cursor-paginated list of a broadcast's clicked links (`url`, `clicks`, `unique_clicks`), matching the existing `list()`/`recipients()` pagination pattern
- Cherry-picked from the `preview-headless-dashboard` branch (originally #1069), re-resolved against `main` since that branch is ahead with unrelated sibling endpoints (recipients, metrics) — no functional changes to the clicked-links code itself

Public-api: resend/resend-monorepo#8176
OpenAPI spec: resend/resend-openapi#95
Linear: DEV-1887

## Test plan
- [x] `pnpm exec vitest run src/broadcasts` — 25 passed
- [x] `pnpm exec biome check src/broadcasts` — clean
- [x] `pnpm exec tsc --noEmit` — clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `broadcasts.clickedLinks(id, options)` to list a broadcast’s clicked links with cursor pagination. Enables per-link analytics (`url`, `clicks`, `unique_clicks`) and follows existing `list()`/`recipients()` patterns. Addresses Linear DEV-1887.

- Calls GET `/broadcasts/{id}/clicked-links`; supports `limit`, `after`, `before` via `buildPaginationUrl`; returns `Response<PaginatedData<BroadcastClickedLink[]>>` with `has_more`.
- Exports `ListBroadcastClickedLinksOptions`, `BroadcastClickedLink`, and `ListBroadcastClickedLinksResponse*`; JSDoc clarifies `BroadcastClickedLink.id` is an opaque pagination cursor only.
- Tests cover default and paginated requests; no breaking changes.

<sup>Written for commit 7ebf72e913ad90c96bc4b6cdede640e77fb70be6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

