### PR TITLE
feat: add broadcasts.recipients() method

### DIFF
--- a/src/broadcasts/broadcasts.spec.ts
+++ b/src/broadcasts/broadcasts.spec.ts
@@ -8,6 +8,7 @@ import type {
   CreateBroadcastResponseSuccess,
 } from './interfaces/create-broadcast-options.interface';
 import type { GetBroadcastResponseSuccess } from './interfaces/get-broadcast.interface';
+import type { ListBroadcastRecipientsResponseSuccess } from './interfaces/list-broadcast-recipients.interface';
 import type { ListBroadcastsResponseSuccess } from './interfaces/list-broadcasts.interface';
 import type { RemoveBroadcastResponseSuccess } from './interfaces/remove-broadcast.interface';
 import type { UpdateBroadcastResponseSuccess } from './interfaces/update-broadcast.interface';
@@ -592,6 +593,211 @@ describe('Broadcasts', () => {
           },
         }
       `);
+    });
+  });
+
+  describe('recipients', () => {
+    describe('when broadcast not found', () => {
+      it('returns error', async () => {
+        const response: ErrorResponse = {
+          name: 'not_found',
+          statusCode: 404,
+          message: 'Broadcast not found',
+        };
+
+        fetchMock.mockOnce(JSON.stringify(response), {
+          status: 404,
+          headers: {
+            'content-type': 'application/json',
+          },
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+        const result = resend.broadcasts.recipients(
+          '559ac32e-9ef5-46fb-82a1-b76b840c0f7b',
+          { type: 'clicked' },
+        );
+
+        await expect(result).resolves.toMatchInlineSnapshot(`
+          {
+            "data": null,
+            "error": {
+              "message": "Broadcast not found",
+              "name": "not_found",
+              "statusCode": 404,
+            },
+            "headers": {
+              "content-type": "application/json",
+            },
+          }
+        `);
+      });
+    });
+
+    it('lists broadcast recipients filtered by type', async () => {
+      const response: ListBroadcastRecipientsResponseSuccess<'clicked'> = {
+        object: 'list',
+        has_more: true,
+        data: [
+          {
+            id: 'b2Zmc2V0OjA',
+            contact_id: 'e169aa45-1ecf-4183-9955-b1499d5701d3',
+            email: 'carter@example.com',
+            count: 3,
+            clicked_links: [
+              { url: 'https://resend.com/pricing', clicks: 2 },
+              { url: 'https://resend.com/docs', clicks: 1 },
+            ],
+          },
+          {
+            id: 'b2Zmc2V0OjE',
+            contact_id: null,
+            email: 'dana@example.com',
+            count: 1,
+            clicked_links: [{ url: 'https://resend.com/pricing', clicks: 1 }],
+          },
+        ],
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      const result = await resend.broadcasts.recipients(
+        '559ac32e-9ef5-46fb-82a1-b76b840c0f7b',
+        { type: 'clicked', limit: 20 },
+      );
+
+      expect(result).toEqual({
+        data: response,
+        error: null,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://api.resend.com/broadcasts/559ac32e-9ef5-46fb-82a1-b76b840c0f7b/recipients?limit=20&type=clicked',
+        expect.objectContaining({
+          method: 'GET',
+          headers: expect.any(Headers),
+        }),
+      );
+    });
+
+    it('passes email and bounceType filters', async () => {
+      const response: ListBroadcastRecipientsResponseSuccess<'bounced'> = {
+        object: 'list',
+        has_more: false,
+        data: [
+          {
+            id: 'b2Zmc2V0OjA',
+            contact_id: null,
+            email: 'bounced@example.com',
+            bounce_type: 'permanent',
+          },
+        ],
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      const result = await resend.broadcasts.recipients(
+        '559ac32e-9ef5-46fb-82a1-b76b840c0f7b',
+        {
+          type: 'bounced',
+          email: 'bounced@example.com',
+          bounceType: 'permanent',
+        },
+      );
+
+      expect(result).toEqual({
+        data: response,
+        error: null,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://api.resend.com/broadcasts/559ac32e-9ef5-46fb-82a1-b76b840c0f7b/recipients?type=bounced&email=bounced%40example.com&bounce_type=permanent',
+        expect.objectContaining({
+          method: 'GET',
+          headers: expect.any(Headers),
+        }),
+      );
+    });
+
+    it('passes after cursor for pagination', async () => {
+      const response: ListBroadcastRecipientsResponseSuccess = {
+        object: 'list',
+        has_more: false,
+        data: [],
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      await resend.broadcasts.recipients(
+        '559ac32e-9ef5-46fb-82a1-b76b840c0f7b',
+        { type: 'opened', limit: 10, after: 'cursor-value' },
+      );
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://api.resend.com/broadcasts/559ac32e-9ef5-46fb-82a1-b76b840c0f7b/recipients?limit=10&after=cursor-value&type=opened',
+        expect.objectContaining({
+          method: 'GET',
+          headers: expect.any(Headers),
+        }),
+      );
+    });
+
+    it('passes before cursor for pagination', async () => {
+      const response: ListBroadcastRecipientsResponseSuccess = {
+        object: 'list',
+        has_more: false,
+        data: [],
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      await resend.broadcasts.recipients(
+        '559ac32e-9ef5-46fb-82a1-b76b840c0f7b',
+        { type: 'opened', limit: 10, before: 'cursor-value' },
+      );
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://api.resend.com/broadcasts/559ac32e-9ef5-46fb-82a1-b76b840c0f7b/recipients?limit=10&before=cursor-value&type=opened',
+        expect.objectContaining({
+          method: 'GET',
+          headers: expect.any(Headers),
+        }),
+      );
     });
   });
 

--- a/src/broadcasts/broadcasts.ts
+++ b/src/broadcasts/broadcasts.ts
@@ -1,4 +1,7 @@
-import { buildPaginationUrl } from '../common/utils/build-pagination-query';
+import {
+  buildPaginationQuery,
+  buildPaginationUrl,
+} from '../common/utils/build-pagination-query';
 import { render } from '../render';
 import type { Resend } from '../resend';
 import type {
@@ -13,6 +16,12 @@ import type {
   GetBroadcastResponse,
   GetBroadcastResponseSuccess,
 } from './interfaces/get-broadcast.interface';
+import type {
+  BroadcastRecipientEventType,
+  ListBroadcastRecipientsOptions,
+  ListBroadcastRecipientsResponse,
+  ListBroadcastRecipientsResponseSuccess,
+} from './interfaces/list-broadcast-recipients.interface';
 import type {
   ListBroadcastsOptions,
   ListBroadcastsResponse,
@@ -92,6 +101,20 @@ export class Broadcasts {
     return data;
   }
 
+  async recipients<T extends BroadcastRecipientEventType>(
+    id: string,
+    options: ListBroadcastRecipientsOptions<T>,
+  ): Promise<ListBroadcastRecipientsResponse<T>> {
+    const queryString = buildRecipientsQuery(
+      options as ListBroadcastRecipientsOptions,
+    );
+    const url = `/broadcasts/${id}/recipients?${queryString}`;
+
+    const data =
+      await this.resend.get<ListBroadcastRecipientsResponseSuccess<T>>(url);
+    return data;
+  }
+
   async remove(id: string): Promise<RemoveBroadcastResponse> {
     const data = await this.resend.delete<RemoveBroadcastResponseSuccess>(
       `/broadcasts/${id}`,
@@ -129,4 +152,21 @@ export class Broadcasts {
     );
     return data;
   }
+}
+
+function buildRecipientsQuery(options: ListBroadcastRecipientsOptions) {
+  const { type, email, bounceType, ...pagination } = options;
+  const searchParams = new URLSearchParams(buildPaginationQuery(pagination));
+
+  searchParams.set('type', type);
+
+  if (email !== undefined) {
+    searchParams.set('email', email);
+  }
+
+  if (bounceType !== undefined) {
+    searchParams.set('bounce_type', bounceType);
+  }
+
+  return searchParams.toString();
 }

--- a/src/broadcasts/interfaces/index.ts
+++ b/src/broadcasts/interfaces/index.ts
@@ -2,6 +2,7 @@ export * from './broadcast';
 export * from './cancel-broadcast.interface';
 export * from './create-broadcast-options.interface';
 export * from './get-broadcast.interface';
+export * from './list-broadcast-recipients.interface';
 export * from './list-broadcasts.interface';
 export * from './remove-broadcast.interface';
 export * from './send-broadcast-options.interface';

--- a/src/broadcasts/interfaces/list-broadcast-recipients.interface.ts
+++ b/src/broadcasts/interfaces/list-broadcast-recipients.interface.ts
@@ -1,0 +1,75 @@
+import type {
+  PaginatedData,
+  PaginationOptions,
+} from '../../common/interfaces/pagination-options.interface';
+import type { Response } from '../../interfaces';
+
+export type BroadcastRecipientEventType =
+  | 'sent'
+  | 'delivered'
+  | 'opened'
+  | 'clicked'
+  | 'bounced'
+  | 'complained'
+  | 'unsubscribed'
+  | 'suppressed';
+
+export type BroadcastRecipientBounceType =
+  | 'permanent'
+  | 'transient'
+  | 'undetermined';
+
+export type ListBroadcastRecipientsOptions<
+  T extends BroadcastRecipientEventType = BroadcastRecipientEventType,
+> = PaginationOptions & {
+  type: T;
+  email?: string;
+  bounceType?: T extends 'bounced' ? BroadcastRecipientBounceType : never;
+};
+
+export interface BroadcastRecipientClickedLink {
+  url: string;
+  clicks: number;
+}
+
+type BroadcastRecipientBase = {
+  id: string;
+  contact_id: string | null;
+  email: string;
+};
+
+type BroadcastRecipientLoose = BroadcastRecipientBase & {
+  count?: number;
+  clicked_links?: BroadcastRecipientClickedLink[];
+  bounce_type?: BroadcastRecipientBounceType;
+};
+
+// True for a union of 2+ members (including the full default union), false
+// for a single literal. https://github.com/microsoft/TypeScript/issues/27024
+type IsUnion<T, B = T> = T extends B ? ([B] extends [T] ? false : true) : never;
+
+type BroadcastRecipientFieldsByType = {
+  sent: unknown;
+  delivered: unknown;
+  opened: { count: number };
+  clicked: { count: number; clicked_links: BroadcastRecipientClickedLink[] };
+  bounced: { bounce_type: BroadcastRecipientBounceType };
+  complained: unknown;
+  unsubscribed: unknown;
+  suppressed: unknown;
+};
+
+export type BroadcastRecipient<
+  T extends BroadcastRecipientEventType = BroadcastRecipientEventType,
+> =
+  IsUnion<T> extends true
+    ? BroadcastRecipientLoose
+    : BroadcastRecipientBase & BroadcastRecipientFieldsByType[T];
+
+export type ListBroadcastRecipientsResponseSuccess<
+  T extends BroadcastRecipientEventType = BroadcastRecipientEventType,
+> = PaginatedData<BroadcastRecipient<T>[]>;
+
+export type ListBroadcastRecipientsResponse<
+  T extends BroadcastRecipientEventType = BroadcastRecipientEventType,
+> = Response<ListBroadcastRecipientsResponseSuccess<T>>;


### PR DESCRIPTION
## Summary
- Adds `broadcasts.recipients(id, options)` to list a broadcast's recipients, filterable by event type (`sent`/`delivered`/`opened`/`clicked`/`bounced`/`complained`/`unsubscribed`/`suppressed`), `email`, and `bounce_type` (bounced only)
- Split out of #1037, which bundled this with a `broadcasts.metrics()` method for a per-broadcast metrics endpoint that has since been removed from public-api (#8178 on resend-monorepo) — that half is dropped here
- Fixes a latent bug from #1037: `buildRecipientsQuery()` calls `buildPaginationQuery` without importing it; it only worked on the preview branch because an unrelated later commit happened to add that import

Tracked by [DEV-1871](https://linear.app/resend/issue/DEV-1871).

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` — 400 passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new broadcasts.recipients(id, options) method to list a broadcast’s recipients with filtering and pagination. Previously the SDK had no per-broadcast recipients listing; this enables delivery and engagement inspection per broadcast.

- Filters: requires a type (sent/delivered/opened/clicked/bounced/complained/unsubscribed/suppressed); supports email; supports bounce_type only when type=bounced.
- Pagination: supports limit, before, after; fixes a missing import in buildRecipientsQuery that previously could break query construction.
- Types: response shape is narrowed by the provided type (e.g., opened includes count; clicked includes count and clicked_links; bounced includes bounce_type); mixed types return a loose shape.
- Tests cover 404 handling, filter/pagination query construction, and typed responses; new interfaces are exported via broadcasts/interfaces/index.ts.
- Fulfills Linear DEV-1871. No migration required.

<sup>Written for commit 0ed80c73d1524cdd0985f50747fe9d36073b9847. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

