### PR TITLE
feat: add emails.metrics() for account-level email metrics

### DIFF
--- a/src/emails/emails.spec.ts
+++ b/src/emails/emails.spec.ts
@@ -1071,7 +1071,7 @@ describe('Emails', () => {
         granularity: 'daily',
         metrics: ['sent', 'delivered', 'open_rate'],
         dimensions: ['period', 'domain'],
-        filter: { domainId: ['d91cd9bd-1176-4f47-2a4b-fce2d5399cbf'] },
+        domainId: ['d91cd9bd-1176-4f47-2a4b-fce2d5399cbf'],
       });
 
       expect(result).toEqual({
@@ -1119,7 +1119,7 @@ describe('Emails', () => {
         granularity: 'daily',
         metrics: ['sent', 'delivered', 'open_rate'],
         dimensions: ['period', 'email'],
-        filter: { emailId: ['4dd369bc-aa82-4ff3-97de-514ae3000ee0'] },
+        emailId: ['4dd369bc-aa82-4ff3-97de-514ae3000ee0'],
       });
 
       expect(result).toEqual({
@@ -1168,7 +1168,7 @@ describe('Emails', () => {
         granularity: 'daily',
         metrics: ['sent', 'delivered', 'open_rate'],
         dimensions: ['period', 'broadcast'],
-        filter: { broadcastId: ['5a5a3b1e-3b1a-4b1a-8b1a-3b1a4b1a8b1a'] },
+        broadcastId: ['5a5a3b1e-3b1a-4b1a-8b1a-3b1a4b1a8b1a'],
       });
 
       expect(result).toEqual({

--- a/src/emails/emails.spec.ts
+++ b/src/emails/emails.spec.ts
@@ -7,6 +7,7 @@ import type {
   CreateEmailResponseSuccess,
 } from './interfaces/create-email-options.interface';
 import type { GetEmailResponseSuccess } from './interfaces/get-email-options.interface';
+import type { GetEmailsMetricsResponseSuccess } from './interfaces/get-metrics.interface';
 import type { ListEmailsResponseSuccess } from './interfaces/list-emails-options.interface';
 import type { ShareEmailResponseSuccess } from './interfaces/share-email-options.interface';
 
@@ -1001,6 +1002,216 @@ describe('Emails', () => {
           }
         `);
       });
+    });
+  });
+
+  describe('metrics', () => {
+    it('calls endpoint with no options and returns the response', async () => {
+      const response: GetEmailsMetricsResponseSuccess = {
+        object: 'metrics',
+        start_date: '2026-07-01T00:00:00.000Z',
+        end_date: '2026-07-08T00:00:00.000Z',
+        metrics: ['sent', 'delivered', 'open_rate'],
+        dimensions: [],
+        granularity: 'daily',
+        totals: {
+          sent: 1204,
+          delivered: 1180,
+          open_rate: 50.0,
+        },
+      };
+
+      mockSuccessResponse(response);
+
+      const result = await resend.emails.metrics();
+
+      expect(result).toEqual({
+        data: response,
+        error: null,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'https://api.resend.com/emails/metrics',
+      );
+    });
+
+    it('calls endpoint passing date range, metrics, dimensions and domain_id', async () => {
+      const response: GetEmailsMetricsResponseSuccess = {
+        object: 'metrics',
+        start_date: '2026-07-01T00:00:00.000Z',
+        end_date: '2026-07-08T00:00:00.000Z',
+        metrics: ['sent', 'delivered', 'open_rate'],
+        dimensions: ['period', 'domain'],
+        granularity: 'daily',
+        totals: {
+          sent: 1204,
+          delivered: 1180,
+          open_rate: 50.0,
+        },
+        data: [
+          {
+            period: '2026-07-01',
+            domain_id: 'd91cd9bd-1176-4f47-2a4b-fce2d5399cbf',
+            domain_name: 'example.com',
+            sent: 172,
+            delivered: 169,
+            open_rate: 49.7,
+          },
+        ],
+      };
+
+      mockSuccessResponse(response);
+
+      const result = await resend.emails.metrics({
+        startDate: '2026-07-01',
+        endDate: '2026-07-08',
+        timezone: 'America/New_York',
+        granularity: 'daily',
+        metrics: ['sent', 'delivered', 'open_rate'],
+        dimensions: ['period', 'domain'],
+        filter: { domainId: ['d91cd9bd-1176-4f47-2a4b-fce2d5399cbf'] },
+      });
+
+      expect(result).toEqual({
+        data: response,
+        error: null,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'https://api.resend.com/emails/metrics?start_date=2026-07-01&end_date=2026-07-08&timezone=America%2FNew_York&granularity=daily&metrics=sent%2Cdelivered%2Copen_rate&dimensions=period%2Cdomain&domain_id=d91cd9bd-1176-4f47-2a4b-fce2d5399cbf',
+      );
+    });
+
+    it('calls endpoint passing the email dimension and email_id', async () => {
+      const response: GetEmailsMetricsResponseSuccess = {
+        object: 'metrics',
+        start_date: '2026-07-01T00:00:00.000Z',
+        end_date: '2026-07-08T00:00:00.000Z',
+        metrics: ['sent', 'delivered', 'open_rate'],
+        dimensions: ['period', 'email'],
+        granularity: 'daily',
+        totals: {
+          sent: 1204,
+          delivered: 1180,
+          open_rate: 50.0,
+        },
+        data: [
+          {
+            period: '2026-07-01',
+            email_id: '4dd369bc-aa82-4ff3-97de-514ae3000ee0',
+            sent: 172,
+            delivered: 169,
+            open_rate: 49.7,
+          },
+        ],
+      };
+
+      mockSuccessResponse(response);
+
+      const result = await resend.emails.metrics({
+        startDate: '2026-07-01',
+        endDate: '2026-07-08',
+        timezone: 'America/New_York',
+        granularity: 'daily',
+        metrics: ['sent', 'delivered', 'open_rate'],
+        dimensions: ['period', 'email'],
+        filter: { emailId: ['4dd369bc-aa82-4ff3-97de-514ae3000ee0'] },
+      });
+
+      expect(result).toEqual({
+        data: response,
+        error: null,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'https://api.resend.com/emails/metrics?start_date=2026-07-01&end_date=2026-07-08&timezone=America%2FNew_York&granularity=daily&metrics=sent%2Cdelivered%2Copen_rate&dimensions=period%2Cemail&email_id=4dd369bc-aa82-4ff3-97de-514ae3000ee0',
+      );
+    });
+
+    it('calls endpoint passing the broadcast dimension and broadcast_id', async () => {
+      const response: GetEmailsMetricsResponseSuccess = {
+        object: 'metrics',
+        start_date: '2026-07-01T00:00:00.000Z',
+        end_date: '2026-07-08T00:00:00.000Z',
+        metrics: ['sent', 'delivered', 'open_rate'],
+        dimensions: ['period', 'broadcast'],
+        granularity: 'daily',
+        totals: {
+          sent: 1204,
+          delivered: 1180,
+          open_rate: 50.0,
+        },
+        data: [
+          {
+            period: '2026-07-01',
+            broadcast_id: '5a5a3b1e-3b1a-4b1a-8b1a-3b1a4b1a8b1a',
+            broadcast_name: 'July Newsletter',
+            sent: 172,
+            delivered: 169,
+            open_rate: 49.7,
+          },
+        ],
+      };
+
+      mockSuccessResponse(response);
+
+      const result = await resend.emails.metrics({
+        startDate: '2026-07-01',
+        endDate: '2026-07-08',
+        timezone: 'America/New_York',
+        granularity: 'daily',
+        metrics: ['sent', 'delivered', 'open_rate'],
+        dimensions: ['period', 'broadcast'],
+        filter: { broadcastId: ['5a5a3b1e-3b1a-4b1a-8b1a-3b1a4b1a8b1a'] },
+      });
+
+      expect(result).toEqual({
+        data: response,
+        error: null,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'https://api.resend.com/emails/metrics?start_date=2026-07-01&end_date=2026-07-08&timezone=America%2FNew_York&granularity=daily&metrics=sent%2Cdelivered%2Copen_rate&dimensions=period%2Cbroadcast&broadcast_id=5a5a3b1e-3b1a-4b1a-8b1a-3b1a4b1a8b1a',
+      );
+    });
+
+    it('returns error when request fails', async () => {
+      const response: ErrorResponse = {
+        name: 'validation_error',
+        message: 'Invalid `start_date`.',
+        statusCode: 422,
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 422,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      const result = await resend.emails.metrics({ startDate: 'not-a-date' });
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "data": null,
+          "error": {
+            "message": "Invalid \`start_date\`.",
+            "name": "validation_error",
+            "statusCode": 422,
+          },
+          "headers": {
+            "content-type": "application/json",
+          },
+        }
+      `);
     });
   });
 });

--- a/src/emails/emails.ts
+++ b/src/emails/emails.ts
@@ -139,9 +139,9 @@ function buildMetricsQuery(options: GetEmailsMetricsOptions) {
     granularity: options.granularity,
     metrics: options.metrics?.join(','),
     dimensions: options.dimensions?.join(','),
-    domain_id: options.filter?.domainId?.join(','),
-    email_id: options.filter?.emailId?.join(','),
-    broadcast_id: options.filter?.broadcastId?.join(','),
+    domain_id: options.domainId?.join(','),
+    email_id: options.emailId?.join(','),
+    broadcast_id: options.broadcastId?.join(','),
   };
 
   const searchParams = new URLSearchParams();

--- a/src/emails/emails.ts
+++ b/src/emails/emails.ts
@@ -18,6 +18,11 @@ import type {
   GetEmailResponseSuccess,
 } from './interfaces/get-email-options.interface';
 import type {
+  GetEmailsMetricsOptions,
+  GetEmailsMetricsResponse,
+  GetEmailsMetricsResponseSuccess,
+} from './interfaces/get-metrics.interface';
+import type {
   ListEmailsOptions,
   ListEmailsResponse,
   ListEmailsResponseSuccess,
@@ -112,4 +117,39 @@ export class Emails {
     );
     return data;
   }
+
+  async metrics(
+    options: GetEmailsMetricsOptions = {},
+  ): Promise<GetEmailsMetricsResponse> {
+    const queryString = buildMetricsQuery(options);
+    const url = queryString
+      ? `/emails/metrics?${queryString}`
+      : '/emails/metrics';
+
+    const data = await this.resend.get<GetEmailsMetricsResponseSuccess>(url);
+    return data;
+  }
+}
+
+function buildMetricsQuery(options: GetEmailsMetricsOptions) {
+  const params: Record<string, string | undefined> = {
+    start_date: options.startDate,
+    end_date: options.endDate,
+    timezone: options.timezone,
+    granularity: options.granularity,
+    metrics: options.metrics?.join(','),
+    dimensions: options.dimensions?.join(','),
+    domain_id: options.filter?.domainId?.join(','),
+    email_id: options.filter?.emailId?.join(','),
+    broadcast_id: options.filter?.broadcastId?.join(','),
+  };
+
+  const searchParams = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== '') {
+      searchParams.set(key, value);
+    }
+  }
+
+  return searchParams.toString();
 }

--- a/src/emails/interfaces/get-metrics.interface.ts
+++ b/src/emails/interfaces/get-metrics.interface.ts
@@ -28,7 +28,7 @@ export type EmailMetricsDimension = 'period' | 'domain' | 'email' | 'broadcast';
 
 export type EmailMetricsGranularity = 'hourly' | 'daily' | 'weekly' | 'monthly';
 
-export type GetEmailsMetricsOptions = {
+type EmailMetricsCommonOptions = {
   /**
    * The start of the date range, as an ISO 8601 date or datetime.
    * Defaults to 6 days before `endDate`.
@@ -63,30 +63,44 @@ export type GetEmailsMetricsOptions = {
   metrics?: EmailMetric[];
 
   /**
-   * The dimensions to break the response down by. Defaults to `[]`, which
-   * returns a single `totals` row for the whole range, with no `data`.
+   * Restrict the response to these sending domain IDs.
    */
-  dimensions?: EmailMetricsDimension[];
-
-  filter?: {
-    /**
-     * Restrict the response to these sending domain IDs.
-     */
-    domainId?: string[];
-
-    /**
-     * Restrict the response to these email IDs. Cannot be combined with the
-     * `broadcast` dimension.
-     */
-    emailId?: string[];
-
-    /**
-     * Restrict the response to these broadcast IDs. Cannot be combined with
-     * the `email` dimension.
-     */
-    broadcastId?: string[];
-  };
+  domainId?: string[];
 };
+
+export type GetEmailsMetricsOptions = EmailMetricsCommonOptions &
+  (
+    | {
+        /**
+         * The dimensions to break the response down by. Defaults to `[]`,
+         * which returns a single `totals` row for the whole range, with no
+         * `data`. Cannot combine `broadcast` with `email`/`emailId`.
+         */
+        dimensions?: Exclude<EmailMetricsDimension, 'broadcast'>[];
+
+        /**
+         * Restrict the response to these email IDs. Cannot be combined with
+         * the `broadcast` dimension or `broadcastId`.
+         */
+        emailId?: string[];
+        broadcastId?: never;
+      }
+    | {
+        /**
+         * The dimensions to break the response down by. Defaults to `[]`,
+         * which returns a single `totals` row for the whole range, with no
+         * `data`. Cannot combine `email` with `broadcast`/`broadcastId`.
+         */
+        dimensions?: Exclude<EmailMetricsDimension, 'email'>[];
+
+        emailId?: never;
+        /**
+         * Restrict the response to these broadcast IDs. Cannot be combined
+         * with the `email` dimension or `emailId`.
+         */
+        broadcastId?: string[];
+      }
+  );
 
 export type EmailMetricsTotals = Partial<Record<EmailMetric, number>>;
 

--- a/src/emails/interfaces/get-metrics.interface.ts
+++ b/src/emails/interfaces/get-metrics.interface.ts
@@ -1,0 +1,114 @@
+import type { Response } from '../../interfaces';
+
+export type EmailMetric =
+  | 'received'
+  | 'delivered'
+  | 'complained'
+  | 'suppressed'
+  | 'bounced'
+  | 'bounced_transient'
+  | 'bounced_permanent'
+  | 'bounced_undetermined'
+  | 'opened'
+  | 'clicked'
+  | 'unsubscribed'
+  | 'delivery_delayed'
+  | 'failed'
+  | 'sent'
+  | 'unique_opened'
+  | 'unique_clicked'
+  | 'delivery_rate'
+  | 'open_rate'
+  | 'click_rate'
+  | 'bounce_rate'
+  | 'complaint_rate'
+  | 'unsubscribe_rate';
+
+export type EmailMetricsDimension = 'period' | 'domain' | 'email' | 'broadcast';
+
+export type EmailMetricsGranularity = 'hourly' | 'daily' | 'weekly' | 'monthly';
+
+export type GetEmailsMetricsOptions = {
+  /**
+   * The start of the date range, as an ISO 8601 date or datetime.
+   * Defaults to 6 days before `endDate`.
+   *
+   * @link https://resend.com/docs/api-reference/emails/get-metrics#query-parameters
+   */
+  startDate?: string;
+
+  /**
+   * The end of the date range, as an ISO 8601 date or datetime.
+   * Defaults to now.
+   *
+   * @link https://resend.com/docs/api-reference/emails/get-metrics#query-parameters
+   */
+  endDate?: string;
+
+  /**
+   * The IANA timezone used to bucket periods when `period` is in `dimensions`.
+   * Defaults to `UTC`.
+   */
+  timezone?: string;
+
+  /**
+   * The bucket size used when `period` is in `dimensions`.
+   * Defaults to `daily`.
+   */
+  granularity?: EmailMetricsGranularity;
+
+  /**
+   * The metrics to include in the response. Defaults to all metrics.
+   */
+  metrics?: EmailMetric[];
+
+  /**
+   * The dimensions to break the response down by. Defaults to `[]`, which
+   * returns a single `totals` row for the whole range, with no `data`.
+   */
+  dimensions?: EmailMetricsDimension[];
+
+  filter?: {
+    /**
+     * Restrict the response to these sending domain IDs.
+     */
+    domainId?: string[];
+
+    /**
+     * Restrict the response to these email IDs. Cannot be combined with the
+     * `broadcast` dimension.
+     */
+    emailId?: string[];
+
+    /**
+     * Restrict the response to these broadcast IDs. Cannot be combined with
+     * the `email` dimension.
+     */
+    broadcastId?: string[];
+  };
+};
+
+export type EmailMetricsTotals = Partial<Record<EmailMetric, number>>;
+
+export type EmailMetricsDataRow = EmailMetricsTotals & {
+  period?: string;
+  domain_id?: string;
+  domain_name?: string;
+  email_id?: string;
+  broadcast_id?: string;
+  broadcast_name?: string;
+};
+
+export interface GetEmailsMetricsResponseSuccess {
+  object: 'metrics';
+  start_date: string;
+  end_date: string;
+  metrics: EmailMetric[];
+  dimensions: EmailMetricsDimension[];
+  granularity: EmailMetricsGranularity;
+  totals: EmailMetricsTotals;
+  data?: EmailMetricsDataRow[];
+}
+
+export type GetEmailsMetricsResponse =
+  Response<GetEmailsMetricsResponseSuccess>;

--- a/src/emails/interfaces/index.ts
+++ b/src/emails/interfaces/index.ts
@@ -1,6 +1,7 @@
 export * from './cancel-email-options.interface';
 export * from './create-email-options.interface';
 export * from './get-email-options.interface';
+export * from './get-metrics.interface';
 export * from './list-emails-options.interface';
 export * from './share-email-options.interface';
 export * from './update-email-options.interface';


### PR DESCRIPTION
Adds `Emails#metrics()` for the beta `GET /emails/metrics` endpoint.

- `period` / `domain` / `email` / `broadcast` dimensions
- `domain_id` / `email_id` / `broadcast_id` filters (`broadcast` and `email` are mutually exclusive)
- `hourly` / `daily` / `weekly` / `monthly` granularity

Pulled out of the `preview-headless-dashboard` branch (#1042, #1050, #1052, plus the broadcast-dimension addition) onto a clean branch off `main`, since this feature is ready to ship independently of the rest of that stack. Also drops `sort_by`/`sort_order`, which existed transiently in an earlier iteration of the public-api implementation and were removed before ship (resend/resend-monorepo#9f2428848f) — the option/response fields for it were never actually live in production, so they're left out here.

Mirrors resend/resend-openapi#96. Part of the emails/metrics rollout tracked in DEV-1771.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `Emails#metrics()` to fetch account-level email metrics from the beta `GET /emails/metrics` endpoint. Previously there was no metrics API; now clients can query totals and breakdowns by period, domain, email, or broadcast.

- Supports `startDate`, `endDate`, `timezone`, and `granularity` (`hourly` | `daily` | `weekly` | `monthly`), plus selecting `metrics` and `dimensions` (`period` | `domain` | `email` | `broadcast`).
- Flat filters: `domainId`, `emailId`, `broadcastId`. `email` and `broadcast` are mutually exclusive and enforced at the type level via a discriminated union.
- Builds the query with `URLSearchParams`, omitting unset fields and encoding comma-separated lists; returns `totals` and optional `data` rows keyed by selected dimensions.
- Adds and exports types in `src/emails/interfaces/get-metrics.interface.ts`; tests cover default, domain/email/broadcast flows, and 422 error handling.
- No breaking changes; part of DEV-1771 emails/metrics rollout.

<sup>Written for commit b5157d65750c56606f294d1154c704bb713271c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

