### PR TITLE
chore: bump version to 6.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.21.0",
+  "version": "6.22.0",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
Bump `package.json` version from 6.21.0 to 6.22.0 for release, covering the feature work merged since the last bump:
- `broadcasts.clickedLinks()` (#1077)
- `broadcasts.recipients()` (#1078)
- `emails.metrics()` (#1079)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes `resend` 6.22.0 so clients can use new broadcast and email metrics methods. 6.21.0 did not export these; 6.22.0 exports them with no other changes.

- Exposes `broadcasts.clickedLinks()`, `broadcasts.recipients()`, and `emails.metrics()`.
- Upgrade: update your dependency to `resend@6.22.0` to access the new methods.

<sup>Written for commit 12bffcbde8ea2c3dcc3fbde0f8e6dcca7b822139. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

