### PR TITLE
chore: bump version to 6.22.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.22.0",
+  "version": "6.22.1",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
Releases [#1073](https://github.com/resend/resend-node/pull/1073) — `ContactEventData.first_name` / `last_name` are now `string | null` on webhook events ([DEV-1625](https://linear.app/resend/issue/DEV-1625/allow-nullable-contact-first-and-last-names-in-openapi)).

Patch: type-only correction, no API surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `resend` to 6.22.1 to release a type-only correction: in webhook `ContactEventData`, `first_name` and `last_name` are now `string | null` (were `string`) to match actual payloads and OpenAPI (DEV-1625).

- Migration: TypeScript consumers must handle `null` for contact first/last names (add null checks or defaults). No runtime or wire-format changes.

<sup>Written for commit 335b9a11995851191596d7efc146a0d18be0dd7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

