### PR TITLE
feat(segments): add segments.update()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.22.1",
+  "version": "6.23.0",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/src/segments/interfaces/index.ts
+++ b/src/segments/interfaces/index.ts
@@ -3,3 +3,4 @@ export * from './get-segment.interface';
 export * from './list-segments.interface';
 export * from './remove-segment.interface';
 export * from './segment';
+export * from './update-segment.interface';

--- a/src/segments/interfaces/update-segment.interface.ts
+++ b/src/segments/interfaces/update-segment.interface.ts
@@ -5,8 +5,7 @@ export interface UpdateSegmentOptions {
   name: string;
 }
 
-export interface UpdateSegmentResponseSuccess
-  extends Pick<Segment, 'id' | 'name'> {
+export interface UpdateSegmentResponseSuccess extends Pick<Segment, 'id'> {
   object: 'segment';
 }
 

--- a/src/segments/interfaces/update-segment.interface.ts
+++ b/src/segments/interfaces/update-segment.interface.ts
@@ -1,0 +1,13 @@
+import type { Response } from '../../interfaces';
+import type { Segment } from './segment';
+
+export interface UpdateSegmentOptions {
+  name: string;
+}
+
+export interface UpdateSegmentResponseSuccess
+  extends Pick<Segment, 'id' | 'name'> {
+  object: 'segment';
+}
+
+export type UpdateSegmentResponse = Response<UpdateSegmentResponseSuccess>;

--- a/src/segments/segments.spec.ts
+++ b/src/segments/segments.spec.ts
@@ -323,6 +323,15 @@ describe('Segments', () => {
           },
         }
       `);
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        `https://api.resend.com/segments/${id}`,
+        expect.objectContaining({
+          method: 'PATCH',
+          body: JSON.stringify(payload),
+          headers: expect.any(Headers),
+        }),
+      );
     });
 
     it('throws error when segment not found', async () => {

--- a/src/segments/segments.spec.ts
+++ b/src/segments/segments.spec.ts
@@ -296,7 +296,6 @@ describe('Segments', () => {
       const response: UpdateSegmentResponseSuccess = {
         object: 'segment',
         id,
-        name: 'Updated Segment',
       };
 
       fetchMock.mockOnce(JSON.stringify(response), {
@@ -314,7 +313,6 @@ describe('Segments', () => {
         {
           "data": {
             "id": "5262504e-8ed7-4fac-bd16-0d4be94bc9f2",
-            "name": "Updated Segment",
             "object": "segment",
           },
           "error": null,

--- a/src/segments/segments.spec.ts
+++ b/src/segments/segments.spec.ts
@@ -9,6 +9,10 @@ import type {
 import type { GetSegmentResponseSuccess } from './interfaces/get-segment.interface';
 import type { ListSegmentsResponseSuccess } from './interfaces/list-segments.interface';
 import type { RemoveSegmentResponseSuccess } from './interfaces/remove-segment.interface';
+import type {
+  UpdateSegmentOptions,
+  UpdateSegmentResponseSuccess,
+} from './interfaces/update-segment.interface';
 
 const fetchMocker = createFetchMock(vi);
 fetchMocker.enableMocks();
@@ -274,6 +278,82 @@ describe('Segments', () => {
             "object": "segment",
           },
           "error": null,
+          "headers": {
+            "content-type": "application/json",
+          },
+        }
+      `);
+    });
+  });
+
+  describe('update', () => {
+    const id = '5262504e-8ed7-4fac-bd16-0d4be94bc9f2';
+
+    it('updates a segment name', async () => {
+      const payload: UpdateSegmentOptions = {
+        name: 'Updated Segment',
+      };
+      const response: UpdateSegmentResponseSuccess = {
+        object: 'segment',
+        id,
+        name: 'Updated Segment',
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      await expect(
+        resend.segments.update(id, payload),
+      ).resolves.toMatchInlineSnapshot(`
+        {
+          "data": {
+            "id": "5262504e-8ed7-4fac-bd16-0d4be94bc9f2",
+            "name": "Updated Segment",
+            "object": "segment",
+          },
+          "error": null,
+          "headers": {
+            "content-type": "application/json",
+          },
+        }
+      `);
+    });
+
+    it('throws error when segment not found', async () => {
+      const payload: UpdateSegmentOptions = {
+        name: 'Updated Segment',
+      };
+      const response: ErrorResponse = {
+        name: 'not_found',
+        message: 'Audience not found',
+        statusCode: 404,
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 404,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      const result = resend.segments.update(id, payload);
+
+      await expect(result).resolves.toMatchInlineSnapshot(`
+        {
+          "data": null,
+          "error": {
+            "message": "Audience not found",
+            "name": "not_found",
+            "statusCode": 404,
+          },
           "headers": {
             "content-type": "application/json",
           },

--- a/src/segments/segments.ts
+++ b/src/segments/segments.ts
@@ -19,6 +19,11 @@ import type {
   RemoveSegmentResponse,
   RemoveSegmentResponseSuccess,
 } from './interfaces/remove-segment.interface';
+import type {
+  UpdateSegmentOptions,
+  UpdateSegmentResponse,
+  UpdateSegmentResponseSuccess,
+} from './interfaces/update-segment.interface';
 
 export class Segments {
   constructor(private readonly resend: Resend) {}
@@ -45,6 +50,17 @@ export class Segments {
   async get(id: string): Promise<GetSegmentResponse> {
     const data = await this.resend.get<GetSegmentResponseSuccess>(
       `/segments/${id}`,
+    );
+    return data;
+  }
+
+  async update(
+    id: string,
+    payload: UpdateSegmentOptions,
+  ): Promise<UpdateSegmentResponse> {
+    const data = await this.resend.patch<UpdateSegmentResponseSuccess>(
+      `/segments/${id}`,
+      payload,
     );
     return data;
   }


### PR DESCRIPTION
## Usage

```ts
await resend.segments.update(id, { name: 'Active Users' });
```

Params:
- `id` (string, required)
- `name` (string, required)

Response: `{ object: "segment", id, name }`

Rollout: [DEV-1941](https://linear.app/resend/issue/DEV-1941/api-change-rollout-rename-segments-through-the-api)