### PR TITLE
feat: allow CNAME type on domain SPF records

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.24.0",
+  "version": "6.25.0",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/src/domains/interfaces/domain.ts
+++ b/src/domains/interfaces/domain.ts
@@ -47,7 +47,7 @@ export interface DomainSpfRecord {
   record: 'SPF';
   name: string;
   value: string;
-  type: 'MX' | 'TXT';
+  type: 'MX' | 'TXT' | 'CNAME';
   ttl: string;
   status: DomainRecordStatus;
   routing_policy?: string;


### PR DESCRIPTION
`DomainSpfRecord.type` was typed `'MX' | 'TXT'`, but the API can return an SPF record with `type: 'CNAME'` for domains on Resend's internal MTA (the return-path is a managed CNAME instead of the classic MX+TXT pair). This widens the type to include `'CNAME'` so those records type-check correctly.

Note: this is a type widening on an output union, so consumers doing exhaustive `switch`/`assertNever` on an SPF record's `type` will get a compile nudge to handle the `CNAME` case — which is the intended outcome, since the API can already return it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Widens `DomainSpfRecord.type` to include `'CNAME'` because the API returns that value for domains on Resend's internal MTA (the return-path is a managed CNAME instead of the classic MX+TXT pair), and bumps the package version to 6.25.0. This is a type widening on an output union, so consumers doing exhaustive `switch`/`assertNever` on an SPF record's `type` will get a compile nudge to handle the `CNAME` case — which is the intended outcome.

<sup>Written for commit 2c2e31509838b8c66ededa24508844bfdc70ee60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1085?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

