### PR TITLE
feat(webhooks): add events.replay()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.25.0",
+  "version": "6.26.0",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/src/webhooks/events/events.ts
+++ b/src/webhooks/events/events.ts
@@ -10,6 +10,11 @@ import type {
   ListWebhookEventsResponse,
   ListWebhookEventsResponseSuccess,
 } from '../interfaces/list-webhook-events.interface';
+import type {
+  ReplayWebhookEventOptions,
+  ReplayWebhookEventResponse,
+  ReplayWebhookEventResponseSuccess,
+} from '../interfaces/replay-webhook-event.interface';
 import { Attempts } from './attempts/attempts';
 
 export class Events {
@@ -35,6 +40,17 @@ export class Events {
 
     const data = await this.resend.get<GetWebhookEventResponseSuccess>(
       `/webhooks/${webhookId}/events/${eventId}`,
+    );
+    return data;
+  }
+
+  async replay(
+    options: ReplayWebhookEventOptions,
+  ): Promise<ReplayWebhookEventResponse> {
+    const { webhookId, eventId } = options;
+
+    const data = await this.resend.post<ReplayWebhookEventResponseSuccess>(
+      `/webhooks/${webhookId}/events/${eventId}/replay`,
     );
     return data;
   }

--- a/src/webhooks/interfaces/index.ts
+++ b/src/webhooks/interfaces/index.ts
@@ -37,6 +37,11 @@ export type {
   RemoveWebhookResponseSuccess,
 } from './remove-webhook.interface';
 export type {
+  ReplayWebhookEventOptions,
+  ReplayWebhookEventResponse,
+  ReplayWebhookEventResponseSuccess,
+} from './replay-webhook-event.interface';
+export type {
   UpdateWebhookOptions,
   UpdateWebhookResponse,
   UpdateWebhookResponseSuccess,

--- a/src/webhooks/interfaces/replay-webhook-event.interface.ts
+++ b/src/webhooks/interfaces/replay-webhook-event.interface.ts
@@ -1,0 +1,14 @@
+import type { Response } from '../../interfaces';
+
+export interface ReplayWebhookEventOptions {
+  webhookId: string;
+  eventId: string;
+}
+
+export interface ReplayWebhookEventResponseSuccess {
+  object: 'webhook_event';
+  id: string;
+}
+
+export type ReplayWebhookEventResponse =
+  Response<ReplayWebhookEventResponseSuccess>;

--- a/src/webhooks/webhooks.spec.ts
+++ b/src/webhooks/webhooks.spec.ts
@@ -14,6 +14,7 @@ import type { ListWebhookEventAttemptsResponseSuccess } from './interfaces/list-
 import type { ListWebhookEventsResponseSuccess } from './interfaces/list-webhook-events.interface';
 import type { ListWebhooksResponseSuccess } from './interfaces/list-webhooks.interface';
 import type { RemoveWebhookResponseSuccess } from './interfaces/remove-webhook.interface';
+import type { ReplayWebhookEventResponseSuccess } from './interfaces/replay-webhook-event.interface';
 import type {
   UpdateWebhookOptions,
   UpdateWebhookResponseSuccess,
@@ -363,6 +364,80 @@ describe('Webhooks', () => {
         const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
 
         const result = resend.webhooks.events.get({ webhookId, eventId });
+
+        await expect(result).resolves.toEqual({
+          data: null,
+          error: {
+            message: 'Webhook event not found',
+            name: 'not_found',
+            statusCode: 404,
+          },
+          headers: {
+            'content-type': 'application/json',
+          },
+        });
+      });
+    });
+  });
+
+  describe('events.replay', () => {
+    const webhookId = '430eed87-632a-4ea6-90db-0aace67ec228';
+    const eventId = 'msg_1srOrx2ZWZBpBUvZwXKQmoEYga2';
+
+    it('replays an event', async () => {
+      const response: ReplayWebhookEventResponseSuccess = {
+        object: 'webhook_event',
+        id: eventId,
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      const result = await resend.webhooks.events.replay({
+        webhookId,
+        eventId,
+      });
+      expect(result).toEqual({
+        data: response,
+        error: null,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        `https://api.resend.com/webhooks/${webhookId}/events/${eventId}/replay`,
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.any(Headers),
+        }),
+      );
+    });
+
+    describe('when event not found', () => {
+      it('returns error', async () => {
+        const response: ErrorResponse = {
+          name: 'not_found',
+          message: 'Webhook event not found',
+          statusCode: 404,
+        };
+
+        fetchMock.mockOnce(JSON.stringify(response), {
+          status: 404,
+          headers: {
+            'content-type': 'application/json',
+          },
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+        const result = resend.webhooks.events.replay({ webhookId, eventId });
 
         await expect(result).resolves.toEqual({
           data: null,


### PR DESCRIPTION
Adds `POST /webhooks/{webhook_id}/events/{event_id}/replay` as `resend.webhooks.events.replay()`, next to the existing `events.get()`. Replaying queues one more delivery of the event to the webhook, same as the dashboard's Replay button; manual replays do not schedule automatic retries.

```ts
replay(options: ReplayWebhookEventOptions): Promise<ReplayWebhookEventResponse>
```

```ts
const { data, error } = await resend.webhooks.events.replay({
  webhookId: '4dd369bc-aa82-4ff3-97de-514ae3000ee0',
  eventId: 'msg_1srOrx2ZWZBpBUvZwXKQmoEYga2',
});
// data: { object: 'webhook_event', id: 'msg_1srOrx2ZWZBpBUvZwXKQmoEYga2' }
```

Also bumps the package version from 6.25.0 to 6.26.0 (same as #1083 did for the event endpoints).

- Spec: https://github.com/resend/resend-openapi/pull/112
- API: https://github.com/resend/resend-monorepo/pull/9535
- Docs: https://resend.com/docs/api-reference/webhooks/replay-event

Checks:
- `pnpm install --frozen-lockfile` ok
- `pnpm lint` ok
- `pnpm typecheck` ok
- `pnpm test` ok (36 files, 419 passed)
- `pnpm build` ok

Not done: no live API call (write endpoint, no key configured). No CHANGELOG entry, following #1083.

Part of DEV-2005.

Linear: https://linear.app/resend/issue/DEV-2008

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `resend.webhooks.events.replay()` to queue one more delivery of a webhook event, matching the dashboard's Replay button. Manual replays do not schedule automatic retries. Bumps the package version to 6.26.0.

<sup>Written for commit aae172be414fb832b6036047235d797689e7192f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

