### PR TITLE
feat(webhooks): add rotateSigningSecret()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.26.0",
+  "version": "6.27.0",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/src/webhooks/interfaces/index.ts
+++ b/src/webhooks/interfaces/index.ts
@@ -42,6 +42,10 @@ export type {
   ReplayWebhookEventResponseSuccess,
 } from './replay-webhook-event.interface';
 export type {
+  RotateWebhookSigningSecretResponse,
+  RotateWebhookSigningSecretResponseSuccess,
+} from './rotate-webhook-signing-secret.interface';
+export type {
   UpdateWebhookOptions,
   UpdateWebhookResponse,
   UpdateWebhookResponseSuccess,

--- a/src/webhooks/interfaces/rotate-webhook-signing-secret.interface.ts
+++ b/src/webhooks/interfaces/rotate-webhook-signing-secret.interface.ts
@@ -1,0 +1,10 @@
+import type { Response } from '../../interfaces';
+
+export interface RotateWebhookSigningSecretResponseSuccess {
+  object: 'webhook';
+  id: string;
+  signing_secret: string;
+}
+
+export type RotateWebhookSigningSecretResponse =
+  Response<RotateWebhookSigningSecretResponseSuccess>;

--- a/src/webhooks/webhooks.spec.ts
+++ b/src/webhooks/webhooks.spec.ts
@@ -15,6 +15,7 @@ import type { ListWebhookEventsResponseSuccess } from './interfaces/list-webhook
 import type { ListWebhooksResponseSuccess } from './interfaces/list-webhooks.interface';
 import type { RemoveWebhookResponseSuccess } from './interfaces/remove-webhook.interface';
 import type { ReplayWebhookEventResponseSuccess } from './interfaces/replay-webhook-event.interface';
+import type { RotateWebhookSigningSecretResponseSuccess } from './interfaces/rotate-webhook-signing-secret.interface';
 import type {
   UpdateWebhookOptions,
   UpdateWebhookResponseSuccess,
@@ -836,6 +837,77 @@ describe('Webhooks', () => {
             },
           }
         `);
+      });
+    });
+  });
+
+  describe('rotateSigningSecret', () => {
+    const id = '430eed87-632a-4ea6-90db-0aace67ec228';
+
+    it('rotates the signing secret', async () => {
+      const response: RotateWebhookSigningSecretResponseSuccess = {
+        object: 'webhook',
+        id,
+        signing_secret: 'whsec_MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw',
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      const result = await resend.webhooks.rotateSigningSecret(id);
+      expect(result).toEqual({
+        data: response,
+        error: null,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        `https://api.resend.com/webhooks/${id}/signing-secret/rotate`,
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.any(Headers),
+        }),
+      );
+    });
+
+    describe('when webhook not found', () => {
+      it('returns error', async () => {
+        const response: ErrorResponse = {
+          name: 'not_found',
+          message: 'Webhook not found',
+          statusCode: 404,
+        };
+
+        fetchMock.mockOnce(JSON.stringify(response), {
+          status: 404,
+          headers: {
+            'content-type': 'application/json',
+          },
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+        const result = resend.webhooks.rotateSigningSecret(id);
+
+        await expect(result).resolves.toEqual({
+          data: null,
+          error: {
+            message: 'Webhook not found',
+            name: 'not_found',
+            statusCode: 404,
+          },
+          headers: {
+            'content-type': 'application/json',
+          },
+        });
       });
     });
   });

--- a/src/webhooks/webhooks.ts
+++ b/src/webhooks/webhooks.ts
@@ -22,6 +22,10 @@ import type {
   RemoveWebhookResponseSuccess,
 } from './interfaces/remove-webhook.interface';
 import type {
+  RotateWebhookSigningSecretResponse,
+  RotateWebhookSigningSecretResponseSuccess,
+} from './interfaces/rotate-webhook-signing-secret.interface';
+import type {
   UpdateWebhookOptions,
   UpdateWebhookResponse,
   UpdateWebhookResponseSuccess,
@@ -89,6 +93,16 @@ export class Webhooks {
     const data = await this.resend.delete<RemoveWebhookResponseSuccess>(
       `/webhooks/${id}`,
     );
+    return data;
+  }
+
+  async rotateSigningSecret(
+    id: string,
+  ): Promise<RotateWebhookSigningSecretResponse> {
+    const data =
+      await this.resend.post<RotateWebhookSigningSecretResponseSuccess>(
+        `/webhooks/${id}/signing-secret/rotate`,
+      );
     return data;
   }
 


### PR DESCRIPTION
Adds `resend.webhooks.rotateSigningSecret(id)` for `POST /webhooks/{webhook_id}/signing-secret/rotate`. The response is the create webhook shape (`object`, `id`, `signing_secret`), so the new interface file copies that. Follows `webhooks.events.replay()` from #1087 for layout, exports, test, and the minor version bump. Spec: https://github.com/resend/resend-openapi/pull/113. Tracking: https://linear.app/resend/issue/DEV-2071.

Claude wrote a script against staging from `dist/` that creates a webhook, rotates its secret, removes it, then rotates again to hit the 404.

<details>
<summary>live-rotate.mjs</summary>

```js
import { Resend } from './dist/index.mjs';
const resend = new Resend(process.env.KEY);
const created = await resend.webhooks.create({ endpoint: 'https://example.com/rotate-test', events: ['email.sent'] });
console.log('create', JSON.stringify({ ...created.data, signing_secret: created.data?.signing_secret?.slice(0, 10) + '...' }), created.error);
const rotated = await resend.webhooks.rotateSigningSecret(created.data.id);
console.log('rotate', JSON.stringify({ ...rotated.data, signing_secret: rotated.data?.signing_secret?.slice(0, 10) + '...' }), rotated.error);
console.log('secret changed:', created.data.signing_secret !== rotated.data?.signing_secret);
const removed = await resend.webhooks.remove(created.data.id);
console.log('remove', JSON.stringify(removed.data), removed.error);
const missing = await resend.webhooks.rotateSigningSecret(created.data.id);
console.log('rotate deleted', missing.data, JSON.stringify(missing.error));
```

</details>

```
create {"object":"webhook","id":"ecfdedd6-997f-4ed0-a018-bfa06cf1ddea","signing_secret":"whsec_TO33..."} null
rotate {"object":"webhook","id":"ecfdedd6-997f-4ed0-a018-bfa06cf1ddea","signing_secret":"whsec_wRiK..."} null
secret changed: true
remove {"object":"webhook","id":"ecfdedd6-997f-4ed0-a018-bfa06cf1ddea","deleted":true} null
rotate deleted null {"statusCode":404,"message":"Webhook endpoint not found","name":"not_found"}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `resend.webhooks.rotateSigningSecret(id)` so users can rotate a webhook's signing secret through the SDK, which previously had no method for this endpoint.

**New Features**
- Calls `POST /webhooks/{webhook_id}/signing-secret/rotate`.
- Returns the webhook with the new `signing_secret`, matching the create webhook response shape.
- Rotating a deleted or missing webhook returns a 404 error.

<sup>Written for commit 3f2146ee5e997290120cb1c7275e0faade556e67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

