### PR TITLE
feat(broadcasts): add duplicate()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.27.0",
+  "version": "6.28.0",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/src/broadcasts/broadcasts.spec.ts
+++ b/src/broadcasts/broadcasts.spec.ts
@@ -7,6 +7,7 @@ import type {
   CreateBroadcastOptions,
   CreateBroadcastResponseSuccess,
 } from './interfaces/create-broadcast-options.interface';
+import type { DuplicateBroadcastResponseSuccess } from './interfaces/duplicate-broadcast.interface';
 import type { GetBroadcastResponseSuccess } from './interfaces/get-broadcast.interface';
 import type { ListBroadcastClickedLinksResponseSuccess } from './interfaces/list-broadcast-clicked-links.interface';
 import type { ListBroadcastRecipientsResponseSuccess } from './interfaces/list-broadcast-recipients.interface';
@@ -1037,6 +1038,41 @@ describe('Broadcasts', () => {
           }
         `);
       });
+    });
+  });
+
+  describe('duplicate', () => {
+    it('duplicates a broadcast', async () => {
+      const response: DuplicateBroadcastResponseSuccess = {
+        object: 'broadcast',
+        id: '1f85ae38-f5b9-4c1f-8766-667a53970fea',
+      };
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 201,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      await expect(
+        resend.broadcasts.duplicate('e6bd3843-3cc7-4c0d-b7fd-e01cbb514a16'),
+      ).resolves.toMatchInlineSnapshot(`
+        {
+          "data": {
+            "id": "1f85ae38-f5b9-4c1f-8766-667a53970fea",
+            "object": "broadcast",
+          },
+          "error": null,
+          "headers": {
+            "content-type": "application/json",
+          },
+        }
+      `);
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://api.resend.com/broadcasts/e6bd3843-3cc7-4c0d-b7fd-e01cbb514a16/duplicate',
+        expect.objectContaining({ method: 'POST' }),
+      );
     });
   });
 

--- a/src/broadcasts/broadcasts.ts
+++ b/src/broadcasts/broadcasts.ts
@@ -13,6 +13,10 @@ import type {
   CreateBroadcastRequestOptions,
 } from './interfaces/create-broadcast-options.interface';
 import type {
+  DuplicateBroadcastResponse,
+  DuplicateBroadcastResponseSuccess,
+} from './interfaces/duplicate-broadcast.interface';
+import type {
   GetBroadcastResponse,
   GetBroadcastResponseSuccess,
 } from './interfaces/get-broadcast.interface';
@@ -141,6 +145,13 @@ export class Broadcasts {
   async cancel(id: string): Promise<CancelBroadcastResponse> {
     const data = await this.resend.post<CancelBroadcastResponseSuccess>(
       `/broadcasts/${id}/cancel`,
+    );
+    return data;
+  }
+
+  async duplicate(id: string): Promise<DuplicateBroadcastResponse> {
+    const data = await this.resend.post<DuplicateBroadcastResponseSuccess>(
+      `/broadcasts/${id}/duplicate`,
     );
     return data;
   }

--- a/src/broadcasts/interfaces/duplicate-broadcast.interface.ts
+++ b/src/broadcasts/interfaces/duplicate-broadcast.interface.ts
@@ -1,0 +1,10 @@
+import type { Response } from '../../interfaces';
+import type { Broadcast } from './broadcast';
+
+export interface DuplicateBroadcastResponseSuccess
+  extends Pick<Broadcast, 'id'> {
+  object: 'broadcast';
+}
+
+export type DuplicateBroadcastResponse =
+  Response<DuplicateBroadcastResponseSuccess>;

--- a/src/broadcasts/interfaces/index.ts
+++ b/src/broadcasts/interfaces/index.ts
@@ -1,6 +1,7 @@
 export * from './broadcast';
 export * from './cancel-broadcast.interface';
 export * from './create-broadcast-options.interface';
+export * from './duplicate-broadcast.interface';
 export * from './get-broadcast.interface';
 export * from './list-broadcast-clicked-links.interface';
 export * from './list-broadcast-recipients.interface';


### PR DESCRIPTION
Adds `resend.broadcasts.duplicate(id)`, a POST to `/broadcasts/{id}/duplicate` that returns the new draft's `{ object: 'broadcast', id }`, the contract in resend/resend-openapi#115. Production already serves the route (resend/resend-monorepo#9608 merged on 2026-09-02). This release is 6.28.0; the CLI, OSS MCP, and remote MCP PRs in DEV-2089 pin it.

Claude ran the built dist against staging (duplicated a draft, read the copy back, removed it), then probed production with an unknown id and an unknown path to show the route is live there.

<details>
<summary>dup-node.mjs</summary>

```js
import { Resend } from './dist/index.mjs';
const resend = new Resend(process.env.RESEND_API_KEY);
const source = 'e6bd3843-3cc7-4c0d-b7fd-e01cbb514a16';
const dup = await resend.broadcasts.duplicate(source);
console.log('duplicate:', JSON.stringify(dup.data), dup.error);
const copy = await resend.broadcasts.get(dup.data.id);
console.log('copy:', JSON.stringify({ id: copy.data.id, name: copy.data.name, status: copy.data.status }));
const removed = await resend.broadcasts.remove(dup.data.id);
console.log('removed:', JSON.stringify(removed.data));
```

</details>

```
duplicate: {"object":"broadcast","id":"b1a06415-1e88-428c-a64f-bc7f6f5ed0df"} null
copy: {"id":"b1a06415-1e88-428c-a64f-bc7f6f5ed0df","name":"Untitled (copy)","status":"draft"}
removed: {"object":"broadcast","id":"b1a06415-1e88-428c-a64f-bc7f6f5ed0df","deleted":true}
```

```
$ http POST https://api.resend.com/broadcasts/00000000-0000-0000-0000-000000000000/duplicate "Authorization: Bearer <redacted>"
{"statusCode":404,"message":"Broadcast not found","name":"not_found"}
$ http POST https://api.resend.com/broadcasts/00000000-0000-0000-0000-000000000000/does-not-exist "Authorization: Bearer <redacted>"
{"statusCode":405,"message":"Method POST is not allowed for the requested path.","name":"method_not_allowed"}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `resend.broadcasts.duplicate(id)`, calling POST `/broadcasts/{id}/duplicate` and returning the new draft's `{ object, id }`. The production route already exists, so this only ships the Node SDK method and bumps the package to 6.28.0 for the CLI and MCP releases that depend on it.

- Adds the `DuplicateBroadcastResponse` interface and exports it.
- Covers the new method with a unit test asserting the request URL, method, and response shape.

<sup>Written for commit ec2e703fbc36cb0884e409cffce24d6c6f86f585. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/1094?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

